### PR TITLE
Add GITHUB_EXCLUDED_ORGS support for organization filtering

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,6 +70,7 @@ services:
       # GitHub/Gitea Mirror Config
       - GITHUB_USERNAME=${GITHUB_USERNAME:-your-github-username}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-your-github-token}
+      - GITHUB_EXCLUDED_ORGS=${GITHUB_EXCLUDED_ORGS:-}
       - SKIP_FORKS=${SKIP_FORKS:-false}
       - PRIVATE_REPOSITORIES=${PRIVATE_REPOSITORIES:-false}
       - MIRROR_ISSUES=${MIRROR_ISSUES:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       # GitHub/Gitea Mirror Config
       - GITHUB_USERNAME=${GITHUB_USERNAME:-}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      - GITHUB_EXCLUDED_ORGS=${GITHUB_EXCLUDED_ORGS:-}
       - SKIP_FORKS=${SKIP_FORKS:-false}
       - PRIVATE_REPOSITORIES=${PRIVATE_REPOSITORIES:-false}
       - MIRROR_ISSUES=${MIRROR_ISSUES:-false}

--- a/docs/BUILD_GUIDE.md
+++ b/docs/BUILD_GUIDE.md
@@ -92,6 +92,7 @@ JWT_SECRET=your-secret-here
 # GitHub Configuration
 GITHUB_TOKEN=ghp_...
 GITHUB_WEBHOOK_SECRET=...
+GITHUB_EXCLUDED_ORGS=org1,org2,org3  # Optional: Comma-separated list of organizations to exclude from sync
 
 # Gitea Configuration
 GITEA_URL=https://your-gitea.com


### PR DESCRIPTION
## Add GITHUB_EXCLUDED_ORGS Environment Variable for Organization Filtering

### Problem
Users deploying gitea-mirror in environments with IP restrictions (like Proxmox/LXC) encounter sync failures when GitHub organizations have IP allowlists enabled. The entire sync process would crash with a 403 Forbidden error.

### Solution
Added `GITHUB_EXCLUDED_ORGS` environment variable to proactively exclude specific organizations from the sync process.

### Changes
- **Environment Variable**: `GITHUB_EXCLUDED_ORGS` accepts a comma-separated list of organization names to exclude
- **Filtering Logic**: Organizations are filtered out before any GitHub API calls are made
- **Case Insensitive**: Matching works regardless of casing
- **Docker Support**: Added to both `docker-compose.yml` and `docker-compose.dev.yml`
- **Documentation**: Updated `docs/BUILD_GUIDE.md` with usage example

### Usage
```bash
# Exclude organizations with IP restrictions or that shouldn't be synced
GITHUB_EXCLUDED_ORGS=private-org,restricted-org,test-org
```

### Benefits
- ✅ Prevents sync failures due to IP allowlists
- ✅ Gives users control over which organizations to sync
- ✅ Maintains fast parallel processing for remaining organizations
- ✅ Zero impact when not used (optional feature)

Fixes issues with IP allowlist restrictions in enterprise/restricted environments. https://github.com/RayLabsHQ/gitea-mirror/issues/46