### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,5 +1,8 @@
 name: Helm Chart CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/RayLabsHQ/gitea-mirror/security/code-scanning/33](https://github.com/RayLabsHQ/gitea-mirror/security/code-scanning/33)

To fix this issue, add a `permissions` block declaring the minimal necessary permissions. Since the jobs only perform read-only operations (checkout, setup, local lints, and rendering, without writing to repository or opening PRs), they should only need `contents: read`. The most robust solution is to add a single `permissions` block at the root of the workflow, so all jobs inherit these restrictions. This change should be made near the top of `.github/workflows/helm-test.yml`, typically after the `name:` and before or after `on:`. No further modifications or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
