### PR TITLE
fix: rename repo count in dashboard

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -306,7 +306,7 @@ export function Dashboard() {
           title="Repositories"
           value={repoCount}
           icon={<GitFork className="h-4 w-4" />}
-          description="Total in mirror queue"
+          description="Total imported repositories"
         />
         <StatusCard
           title="Mirrored"


### PR DESCRIPTION
The current dashboard has the total number of known repositories marked as "Total in mirror queue". This implies that there are X repositories waiting to be mirrored (which is not the case). This PR renames the dashboard metric to be "Total imported repositories" instead which better describes the metric

