### PR TITLE
fix website install guide command

### DIFF
--- a/www/src/components/Installation.tsx
+++ b/www/src/components/Installation.tsx
@@ -22,7 +22,7 @@ export function Installation() {
       steps: [
         {
           title: "Clone the repository",
-          command: "git clone https://github.com/RayLabsHQ/gitea-mirror.git\ncd gitea-mirror",
+          command: "git clone https://github.com/RayLabsHQ/gitea-mirror.git && cd gitea-mirror",
           id: "docker-clone"
         },
         {


### PR DESCRIPTION
`git clone https://github.com/RayLabsHQ/gitea-mirror.git cd gitea-mirror` isnt a valid command as `\n` isnt being recognised so I replaced it with `&&` instead