### PR TITLE
Improved repository label terminology (private -> personal)

### DIFF
--- a/src/components/config/GitHubMirrorSettings.tsx
+++ b/src/components/config/GitHubMirrorSettings.tsx
@@ -125,10 +125,10 @@ export function GitHubMirrorSettings({
                 className="text-sm font-normal cursor-pointer flex items-center gap-2"
               >
                 <Lock className="h-3.5 w-3.5" />
-                Include private repositories
+                Include personal repositories
               </Label>
               <p className="text-xs text-muted-foreground">
-                Mirror your private repositories
+                Mirror your personal repositories
               </p>
             </div>
           </div>


### PR DESCRIPTION
The current label "Include private repositories" is confusing because it can be misinterpreted as referring to repository **visibility** (public vs private repositories), when it actually refers to repository **ownership** (personal repositories owned by the user vs organization repositories).

Changed 'private repositories' to 'personal repositories' for better clarity in GitHub mirror settings.