### PR TITLE
Support release limits above 100

### DIFF
--- a/src/components/config/GitHubMirrorSettings.tsx
+++ b/src/components/config/GitHubMirrorSettings.tsx
@@ -377,14 +377,13 @@ export function GitHubMirrorSettings({
                       id="release-limit"
                       type="number"
                       min="1"
-                      max="100"
                       value={mirrorOptions.releaseLimit || 10}
                       onChange={(e) => {
                         const value = parseInt(e.target.value) || 10;
-                        const clampedValue = Math.min(100, Math.max(1, value));
+                        const clampedValue = Math.max(1, value);
                         handleMirrorChange('releaseLimit', clampedValue);
                       }}
-                      className="w-16 px-2 py-1 text-xs border border-input rounded bg-background text-foreground"
+                      className="w-20 px-2 py-1 text-xs border border-input rounded bg-background text-foreground"
                     />
                     <span className="text-xs text-muted-foreground">releases</span>
                   </div>


### PR DESCRIPTION
## Summary - remove the UI hard cap of 100 releases in release limit input
- add paginated GitHub release fetching so configured limits above 100 are respected
- preserve existing behavior/order processing for release mirroring

## Why 
Issue #176 reported that release limit appears capped at 100. The previous implementation used a single API call and UI clamp, which prevented higher values from being effective.

Closes #176