### PR TITLE
Add admin CLI password reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,20 @@ bun run build
 - Never stored in plaintext
 - Secure cookie-based session management
 
+### Admin Password Recovery (CLI)
+If email delivery is not configured, an admin with server access can reset a user password from the command line:
+
+```bash
+bun run reset-password -- --email=user@example.com --new-password='new-secure-password'
+```
+
+What this does:
+- Updates the credential password hash for the matching user
+- Creates a credential account if one does not already exist
+- Invalidates all active sessions for that user (forces re-login)
+
+Use this only from trusted server/admin environments.
+
 ## Authentication
 
 Gitea Mirror supports multiple authentication methods. **Email/password authentication is the default and always enabled.**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check-db": "bun scripts/manage-db.ts check",
     "fix-db": "bun scripts/manage-db.ts fix",
     "reset-users": "bun scripts/manage-db.ts reset-users",
+    "reset-password": "bun scripts/manage-db.ts reset-password",
     "db:generate": "bun drizzle-kit generate",
     "db:migrate": "bun drizzle-kit migrate",
     "db:push": "bun drizzle-kit push",


### PR DESCRIPTION
## Summary
- add a non-destructive `reset-password` command to `scripts/manage-db.ts`
- hash with Better Auth's own crypto helper and upsert credential account if missing
- invalidate existing sessions for the user after reset
- document CLI recovery flow in README and add `bun run reset-password` script

## Why
Fixes the admin lockout recovery gap raised in #172 and complements #164 without requiring email provider setup.

## Test
- bun test
