### PR TITLE
fix(docker): add git and git-lfs to runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN bun install --production --omit=peer --frozen-lockfile
 FROM oven/bun:1.3.9-debian AS runner
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  wget sqlite3 openssl ca-certificates \
+  git git-lfs wget sqlite3 openssl ca-certificates \
+  && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=pruner /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary
- Adds `git` and `git-lfs` packages to the Docker runner stage, which were missing after the Alpine → Debian image migration
- The pre-sync backup feature (enabled by default) shells out to `git clone --mirror` and `git bundle create`, so `git` must be present in the final image

Closes #196

## Test plan
- [ ] Build the Docker image and verify `git` and `git-lfs` are available inside the container
- [ ] Run a mirror sync and confirm pre-sync backup succeeds without "Executable not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)