### PR TITLE
ci: persist release tag version to main package.json

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,6 +45,7 @@ This workflow builds Docker images on pushes and pull requests, and pushes to Gi
 - Creates multiple tags for each image (latest, semver, sha)
 - Auto-syncs `package.json` version from `v*` tags during release builds
 - Validates release tags use semver format before building
+- After tag builds succeed, writes the same version back to `main/package.json`
 
 ### Docker Security Scan (`docker-scan.yml`)
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -258,3 +258,44 @@ jobs:
         continue-on-error: true
         with:
           sarif_file: scout-results.sarif
+
+  sync-version-main:
+    name: Sync package.json version back to main
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: docker
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update package.json version on main
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [[ ! "$TAG_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag '${TAG_VERSION}' is invalid. Expected semver tag format like v1.2.3 or v1.2.3-rc.1"
+            exit 1
+          fi
+
+          APP_VERSION="${TAG_VERSION#v}"
+          echo "Syncing ${TARGET_BRANCH}/package.json to ${APP_VERSION}"
+
+          jq --arg version "${APP_VERSION}" '.version = $version' package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          if git diff --quiet -- package.json; then
+            echo "package.json on ${TARGET_BRANCH} already at ${APP_VERSION}; nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: sync version to ${APP_VERSION}"
+          git push origin "HEAD:${TARGET_BRANCH}"

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -328,6 +328,7 @@ git push origin vX.Y.Z
 
 5. **CI version sync (automatic)**:
 - On `v*` tags, release CI updates `package.json` version in the build context from the tag (`vX.Y.Z` -> `X.Y.Z`), so Docker release images always report the correct app version.
+- After the release build succeeds, CI commits the same `package.json` version back to `main` automatically.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitea-mirror",
   "type": "module",
-  "version": "3.10.1",
+  "version": "3.12.1",
   "engines": {
     "bun": ">=1.2.9"
   },


### PR DESCRIPTION
## Summary
- add a post-release job in Docker workflow to sync `package.json` version back to `main` after `v*` tag builds
- keep semver validation on release tags
- update docs to state the write-back behavior
- align current `package.json` version to `3.12.1`

## Why
The previous change synced version only inside CI build context, so `main/package.json` stayed stale.

## Testing
- validated workflow YAML parsing locally (`ruby -ryaml`)
- inspected diff for tag-path behavior and main write-back logic

Follow-up to #209
