### PR TITLE
fix: use external URL for Gitea repo links

### DIFF
--- a/src/components/dashboard/RepositoryList.tsx
+++ b/src/components/dashboard/RepositoryList.tsx
@@ -4,6 +4,7 @@ import { GitFork } from "lucide-react";
 import { SiGithub, SiGitea } from "react-icons/si";
 import type { Repository } from "@/lib/db/schema";
 import { getStatusColor } from "@/lib/utils";
+import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
 
 interface RepositoryListProps {
@@ -15,11 +16,6 @@ export function RepositoryList({ repositories }: RepositoryListProps) {
 
   // Helper function to construct Gitea repository URL
   const getGiteaRepoUrl = (repository: Repository): string | null => {
-    const rawBaseUrl = giteaConfig?.externalUrl || giteaConfig?.url;
-    if (!rawBaseUrl) {
-      return null;
-    }
-
     // Only provide Gitea links for repositories that have been or are being mirrored
     const validStatuses = ['mirroring', 'mirrored', 'syncing', 'synced'];
     if (!validStatuses.includes(repository.status)) {
@@ -38,12 +34,7 @@ export function RepositoryList({ repositories }: RepositoryListProps) {
       repoPath = `${owner}/${repository.name}`;
     }
 
-    // Ensure the base URL doesn't have a trailing slash
-    const baseUrl = rawBaseUrl.endsWith("/")
-      ? rawBaseUrl.slice(0, -1)
-      : rawBaseUrl;
-
-    return `${baseUrl}/${repoPath}`;
+    return buildGiteaWebUrl(giteaConfig, repoPath);
   };
 
   return (

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -9,6 +9,7 @@ import type { FilterParams } from "@/types/filter";
 import Fuse from "fuse.js";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import { MirrorDestinationEditor } from "./MirrorDestinationEditor";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
 import {
@@ -67,11 +68,6 @@ export function OrganizationList({
 
   // Helper function to construct Gitea organization URL
   const getGiteaOrgUrl = (organization: Organization): string | null => {
-    const rawBaseUrl = giteaConfig?.externalUrl || giteaConfig?.url;
-    if (!rawBaseUrl) {
-      return null;
-    }
-
     // Only provide Gitea links for organizations that have been mirrored
     const validStatuses = ['mirroring', 'mirrored'];
     if (!validStatuses.includes(organization.status || '')) {
@@ -84,12 +80,7 @@ export function OrganizationList({
       return null;
     }
 
-    // Ensure the base URL doesn't have a trailing slash
-    const baseUrl = rawBaseUrl.endsWith("/")
-      ? rawBaseUrl.slice(0, -1)
-      : rawBaseUrl;
-
-    return `${baseUrl}/${orgName}`;
+    return buildGiteaWebUrl(giteaConfig, orgName);
   };
 
   const handleUpdateDestination = async (orgId: string, newDestination: string | null) => {

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -14,6 +14,7 @@ import { SiGithub, SiGitea } from "react-icons/si";
 import type { Repository } from "@/lib/db/schema";
 import { Button } from "@/components/ui/button";
 import { formatLastSyncTime } from "@/lib/utils";
+import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import type { FilterParams } from "@/types/filter";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
@@ -124,10 +125,6 @@ export default function RepositoryTable({
 
   // Helper function to construct Gitea repository URL
   const getGiteaRepoUrl = (repository: Repository): string | null => {
-    if (!giteaConfig?.url) {
-      return null;
-    }
-
     // Only provide Gitea links for repositories that have been or are being mirrored
     const validStatuses = ['mirroring', 'mirrored', 'syncing', 'synced', 'archived'];
     if (!validStatuses.includes(repository.status)) {
@@ -144,12 +141,7 @@ export default function RepositoryTable({
       repoPath = `${owner}/${repository.name}`;
     }
 
-    // Ensure the base URL doesn't have a trailing slash
-    const baseUrl = giteaConfig.url.endsWith('/')
-      ? giteaConfig.url.slice(0, -1)
-      : giteaConfig.url;
-
-    return `${baseUrl}/${repoPath}`;
+    return buildGiteaWebUrl(giteaConfig, repoPath);
   };
 
   const hasAnyFilter = [

--- a/src/lib/gitea-url.test.ts
+++ b/src/lib/gitea-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { buildGiteaWebUrl, getGiteaWebBaseUrl } from "@/lib/gitea-url";
+
+describe("getGiteaWebBaseUrl", () => {
+  it("prefers externalUrl when both urls are present", () => {
+    const baseUrl = getGiteaWebBaseUrl({
+      url: "http://gitea:3000",
+      externalUrl: "https://git.example.com",
+    });
+
+    expect(baseUrl).toBe("https://git.example.com");
+  });
+
+  it("falls back to url when externalUrl is missing", () => {
+    const baseUrl = getGiteaWebBaseUrl({
+      url: "http://gitea:3000",
+    });
+
+    expect(baseUrl).toBe("http://gitea:3000");
+  });
+
+  it("trims a trailing slash", () => {
+    const baseUrl = getGiteaWebBaseUrl({
+      externalUrl: "https://git.example.com/",
+    });
+
+    expect(baseUrl).toBe("https://git.example.com");
+  });
+});
+
+describe("buildGiteaWebUrl", () => {
+  it("builds a full repository url and removes leading path slashes", () => {
+    const url = buildGiteaWebUrl(
+      { externalUrl: "https://git.example.com/" },
+      "/org/repo"
+    );
+
+    expect(url).toBe("https://git.example.com/org/repo");
+  });
+
+  it("returns null when no gitea url is configured", () => {
+    const url = buildGiteaWebUrl({}, "org/repo");
+    expect(url).toBeNull();
+  });
+});

--- a/src/lib/gitea-url.ts
+++ b/src/lib/gitea-url.ts
@@ -1,0 +1,28 @@
+interface GiteaUrlConfig {
+  url?: string | null;
+  externalUrl?: string | null;
+}
+
+export function getGiteaWebBaseUrl(
+  config?: GiteaUrlConfig | null
+): string | null {
+  const rawBaseUrl = config?.externalUrl || config?.url;
+  if (!rawBaseUrl) {
+    return null;
+  }
+
+  return rawBaseUrl.endsWith("/") ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+}
+
+export function buildGiteaWebUrl(
+  config: GiteaUrlConfig | null | undefined,
+  path: string
+): string | null {
+  const baseUrl = getGiteaWebBaseUrl(config);
+  if (!baseUrl) {
+    return null;
+  }
+
+  const normalizedPath = path.replace(/^\/+/, "");
+  return normalizedPath ? `${baseUrl}/${normalizedPath}` : baseUrl;
+}


### PR DESCRIPTION
## Summary
- fix repository links on the repositories page to use `giteaConfig.externalUrl` when configured
- add a shared Gitea web URL helper used by repository table, dashboard repository list, and organizations list
- add regression tests for external URL precedence and URL normalization

## Rationale
When `GITEA_URL` points to an internal service (for example `http://gitea:3000`) and `GITEA_EXTERNAL_URL` is configured, repo links should point to the external/public URL. This patch aligns repository links with existing organization-link behavior and prevents regressions.

## Testing
- `bun test src/lib/gitea-url.test.ts`

Closes #232
