### PR TITLE
fix: include organization_member in /user/repos affiliation

### DIFF
--- a/src/lib/github-affiliation.test.ts
+++ b/src/lib/github-affiliation.test.ts
@@ -39,37 +39,62 @@ function makeOctokit() {
 }
 
 describe("getGithubRepositories - affiliation", () => {
-  test("defaults to owner+collaborator when field is unset (backward compat)", async () => {
+  test("defaults to owner+collaborator+organization_member when field is unset (backward compat)", async () => {
     const { octokit, getCaptured } = makeOctokit();
     await getGithubRepositories({ octokit, config: { githubConfig: { owner: "octo" } as any } });
-    expect(getCaptured()?.affiliation).toBe("owner,collaborator");
+    expect(getCaptured()?.affiliation).toBe("owner,collaborator,organization_member");
   });
 
-  test("uses owner only when includeCollaboratorRepos is false", async () => {
+  test("uses owner+organization_member when includeCollaboratorRepos is false", async () => {
     const { octokit, getCaptured } = makeOctokit();
     await getGithubRepositories({
       octokit,
       config: { githubConfig: { owner: "octo", includeCollaboratorRepos: false } as any },
     });
-    expect(getCaptured()?.affiliation).toBe("owner");
+    expect(getCaptured()?.affiliation).toBe("owner,organization_member");
   });
 
-  test("uses owner+collaborator when includeCollaboratorRepos is true", async () => {
+  test("uses owner+collaborator+organization_member when includeCollaboratorRepos is true", async () => {
     const { octokit, getCaptured } = makeOctokit();
     await getGithubRepositories({
       octokit,
       config: { githubConfig: { owner: "octo", includeCollaboratorRepos: true } as any },
     });
-    expect(getCaptured()?.affiliation).toBe("owner,collaborator");
+    expect(getCaptured()?.affiliation).toBe("owner,collaborator,organization_member");
   });
 
-  test("override forces owner+collaborator regardless of config (used by cleanup)", async () => {
+  test("override forces owner+collaborator+organization_member regardless of config (used by cleanup)", async () => {
     const { octokit, getCaptured } = makeOctokit();
     await getGithubRepositories({
       octokit,
       config: { githubConfig: { owner: "octo", includeCollaboratorRepos: false } as any },
       includeCollaboratorReposOverride: true,
     });
-    expect(getCaptured()?.affiliation).toBe("owner,collaborator");
+    expect(getCaptured()?.affiliation).toBe("owner,collaborator,organization_member");
+  });
+
+  test("always includes organization_member (regression guard for org-repo invisibility)", async () => {
+    const cases: Array<{ includeCollab?: boolean; override?: boolean }> = [
+      {},
+      { includeCollab: true },
+      { includeCollab: false },
+      { override: true },
+      { includeCollab: false, override: true },
+    ];
+    for (const c of cases) {
+      const { octokit, getCaptured } = makeOctokit();
+      await getGithubRepositories({
+        octokit,
+        config: {
+          githubConfig: {
+            owner: "octo",
+            ...(c.includeCollab !== undefined && { includeCollaboratorRepos: c.includeCollab }),
+          } as any,
+        },
+        ...(c.override !== undefined && { includeCollaboratorReposOverride: c.override }),
+      });
+      const aff = String(getCaptured()?.affiliation ?? "");
+      expect(aff.split(",")).toContain("organization_member");
+    }
   });
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -249,7 +249,13 @@ export async function getGithubRepositories({
       includeCollaboratorReposOverride ??
       config.githubConfig?.includeCollaboratorRepos ??
       true;
-    const affiliation = includeCollab ? "owner,collaborator" : "owner";
+    // Always include organization_member so repos owned by orgs the user
+    // belongs to are returned. Omitting it caused org repos to be invisible
+    // to the main sync, the scheduler, and the cleanup service (which then
+    // archived them on restart as if they had been deleted on GitHub).
+    const affiliation = includeCollab
+      ? "owner,collaborator,organization_member"
+      : "owner,organization_member";
 
     const repos = await octokit.paginate(
       octokit.repos.listForAuthenticatedUser,


### PR DESCRIPTION
## Summary

`getGithubRepositories` (used by the main sync, the scheduler, and the repository cleanup service) calls `/user/repos` with an `affiliation` parameter that omits `organization_member`. As a result, repositories owned by organizations the authenticated user belongs to are never returned. This causes several visible symptoms:

- Organizations added via the UI appear empty in subsequent syncs — `listForOrg` populated the repos on first add, but no later call sees them.
- The scheduler never picks up org repos for periodic syncs.
- The cleanup service, on every restart, sees org repos in the DB but not in the GitHub list, and (with `CLEANUP_DELETE_IF_NOT_IN_GITHUB=true`) flags them all as orphaned.

## Root Cause

PR #283 (`feat: add option to exclude collaborator repos from import`) changed the affiliation to:

```ts
const affiliation = includeCollab ? "owner,collaborator" : "owner";
```

That commit's own message acknowledges the GitHub default:

> *"GitHub's `listForAuthenticatedUser` defaults to returning every repo the user has access to (owner + collaborator + organization_member)…"*

But the implementation only set two of the three values. `organization_member` was meant to remain part of the default and was inadvertently dropped.

Three callers are affected:

| Caller | File | Effect |
|---|---|---|
| Main sync | `src/pages/api/sync/index.ts` | org repos never imported |
| Scheduler | `src/lib/scheduler-service.ts` | org repos missing from periodic syncs |
| Cleanup service | `src/lib/repository-cleanup-service.ts` | even with `includeCollaboratorReposOverride: true`, org repos are invisible → flagged as orphaned |

## Fix

Always include `organization_member` in the affiliation, regardless of the `includeCollaboratorRepos` toggle. The toggle's original semantics from #279/#283 are preserved:

- `includeCollaboratorRepos: true` (default) → `owner,collaborator,organization_member`
- `includeCollaboratorRepos: false` → `owner,organization_member`

The collaborator-exclusion feature still works as intended; this change only restores the previously missing slot.

## Testing

`src/lib/github-affiliation.test.ts`:
- 4 existing assertions updated to require `organization_member`.
- New regression test `always includes organization_member` iterates 5 config combinations (default, includeCollab true/false, override true, override+toggle) to lock the invariant.

```
bun test src/lib/github-affiliation.test.ts
```

## Steps to Reproduce (pre-fix)

1. PAT with `repo` + `read:org` scope.
2. Add an organization in the UI — repos appear (this uses `listForOrg`, which works).
3. Restart the container or wait for the scheduler.
4. Org repos disappear from the dashboard; cleanup logs them as orphaned.

After the fix, repos remain consistent across restarts and scheduler runs.

## Related

The symptom is mentioned in passing in [#254](https://github.com/RayLabsHQ/gitea-mirror/issues/254#issuecomment-4141605448) (*"I have a private repo from my org which does not show up at all in gitea-mirror"*), but that issue was scoped to Forgejo auth and the side-mention was not addressed. This PR is the first formal report and fix for the org-repo invisibility itself.

Origin of the bug: #283.