### PR TITLE
fix: reconcile metadata on every sync instead of once per repo

### DIFF
--- a/src/lib/gitea-enhanced.test.ts
+++ b/src/lib/gitea-enhanced.test.ts
@@ -848,12 +848,15 @@ describe("Enhanced Gitea Operations", () => {
         }
       );
 
-      // All metadata components were previously synced, so none should be called again
+      // Metadata reconciliation now runs on every sync (mirror* functions
+      // are idempotent and PATCH existing entries by marker/name/title).
+      // Releases are still skipped here because the flag is off in this config.
+      // Labels are still skipped because the issues path also handles labels.
       expect(mockMirrorGitHubReleasesToGitea).not.toHaveBeenCalled();
-      expect(mockMirrorGitRepoIssuesToGitea).not.toHaveBeenCalled();
-      expect(mockMirrorGitRepoPullRequestsToGitea).not.toHaveBeenCalled();
+      expect(mockMirrorGitRepoIssuesToGitea).toHaveBeenCalledTimes(1);
+      expect(mockMirrorGitRepoPullRequestsToGitea).toHaveBeenCalledTimes(1);
       expect(mockMirrorGitRepoLabelsToGitea).not.toHaveBeenCalled();
-      expect(mockMirrorGitRepoMilestonesToGitea).not.toHaveBeenCalled();
+      expect(mockMirrorGitRepoMilestonesToGitea).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -601,25 +601,23 @@ export async function syncGiteaRepoEnhanced({
         return metadataOctokit;
       };
 
+      // Reconcile metadata on every sync (matches the release path).
+      // The underlying mirror* functions are idempotent: issues/PRs are
+      // matched via [GH-ISSUE #N] / [GH-PR #N] markers and PATCHed in
+      // place, labels are deduped by name, milestones by title.
       const shouldMirrorReleases =
         !!config.giteaConfig?.mirrorReleases && !skipMetadataForStarred;
       const shouldMirrorIssuesThisRun =
-        !!config.giteaConfig?.mirrorIssues &&
-        !skipMetadataForStarred &&
-        !metadataState.components.issues;
+        !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
       const shouldMirrorPullRequests =
-        !!config.giteaConfig?.mirrorPullRequests &&
-        !skipMetadataForStarred &&
-        !metadataState.components.pullRequests;
+        !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
+      // Labels-only path; issues run already creates/reconciles labels.
       const shouldMirrorLabels =
         !!config.giteaConfig?.mirrorLabels &&
         !skipMetadataForStarred &&
-        !shouldMirrorIssuesThisRun &&
-        !metadataState.components.labels;
+        !shouldMirrorIssuesThisRun;
       const shouldMirrorMilestones =
-        !!config.giteaConfig?.mirrorMilestones &&
-        !skipMetadataForStarred &&
-        !metadataState.components.milestones;
+        !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
 
       if (shouldMirrorReleases) {
         const octokit = ensureOctokit();
@@ -684,13 +682,6 @@ export async function syncGiteaRepoEnhanced({
             );
           }
         }
-      } else if (
-        config.giteaConfig?.mirrorIssues &&
-        metadataState.components.issues
-      ) {
-        console.log(
-          `[Sync] Issues already mirrored for ${repository.name}; skipping to avoid duplicates`
-        );
       }
 
       if (shouldMirrorPullRequests) {
@@ -721,13 +712,6 @@ export async function syncGiteaRepoEnhanced({
             );
           }
         }
-      } else if (
-        config.giteaConfig?.mirrorPullRequests &&
-        metadataState.components.pullRequests
-      ) {
-        console.log(
-          `[Sync] Pull requests already mirrored for ${repository.name}; skipping`
-        );
       }
 
       if (shouldMirrorLabels) {
@@ -760,13 +744,6 @@ export async function syncGiteaRepoEnhanced({
             );
           }
         }
-      } else if (
-        config.giteaConfig?.mirrorLabels &&
-        metadataState.components.labels
-      ) {
-        console.log(
-          `[Sync] Labels already mirrored for ${repository.name}; skipping`
-        );
       }
 
       if (shouldMirrorMilestones) {
@@ -799,13 +776,6 @@ export async function syncGiteaRepoEnhanced({
             );
           }
         }
-      } else if (
-        config.giteaConfig?.mirrorMilestones &&
-        metadataState.components.milestones
-      ) {
-        console.log(
-          `[Sync] Milestones already mirrored for ${repository.name}; skipping`
-        );
       }
 
       if (metadataUpdated) {

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -898,14 +898,15 @@ export const mirrorGithubRepoToGitea = async ({
       }
     }
 
-    // Determine metadata operations to avoid duplicates
+    // Reconcile metadata on every sync (matches the release path above).
+    // The underlying mirror* functions are idempotent: issues/PRs are
+    // matched via [GH-ISSUE #N] / [GH-PR #N] markers and PATCHed in place,
+    // labels are deduped by name, milestones by title.
     const shouldMirrorIssuesThisRun =
-      !!config.giteaConfig?.mirrorIssues &&
-      !skipMetadataForStarred &&
-      !metadataState.components.issues;
+      !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, alreadyMirrored=${metadataState.components.issues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
+      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
     );
 
     if (shouldMirrorIssuesThisRun) {
@@ -931,19 +932,13 @@ export const mirrorGithubRepoToGitea = async ({
         );
         // Continue with other metadata operations even if issues fail
       }
-    } else if (config.giteaConfig?.mirrorIssues && metadataState.components.issues) {
-      console.log(
-        `[Metadata] Issues already mirrored for ${repository.name}; skipping to avoid duplicates`
-      );
     }
 
     const shouldMirrorPullRequests =
-      !!config.giteaConfig?.mirrorPullRequests &&
-      !skipMetadataForStarred &&
-      !metadataState.components.pullRequests;
+      !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, alreadyMirrored=${metadataState.components.pullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
+      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
     );
 
     if (shouldMirrorPullRequests) {
@@ -968,23 +963,16 @@ export const mirrorGithubRepoToGitea = async ({
         );
         // Continue with other metadata operations even if PRs fail
       }
-    } else if (
-      config.giteaConfig?.mirrorPullRequests &&
-      metadataState.components.pullRequests
-    ) {
-      console.log(
-        `[Metadata] Pull requests already mirrored for ${repository.name}; skipping`
-      );
     }
 
+    // Labels-only path; issues run above already creates/reconciles labels.
     const shouldMirrorLabels =
       !!config.giteaConfig?.mirrorLabels &&
       !skipMetadataForStarred &&
-      !shouldMirrorIssuesThisRun &&
-      !metadataState.components.labels;
+      !shouldMirrorIssuesThisRun;
 
     console.log(
-      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, alreadyMirrored=${metadataState.components.labels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
+      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
     );
 
     if (shouldMirrorLabels) {
@@ -1009,19 +997,13 @@ export const mirrorGithubRepoToGitea = async ({
         );
         // Continue with other metadata operations even if labels fail
       }
-    } else if (config.giteaConfig?.mirrorLabels && metadataState.components.labels) {
-      console.log(
-        `[Metadata] Labels already mirrored for ${repository.name}; skipping`
-      );
     }
 
     const shouldMirrorMilestones =
-      !!config.giteaConfig?.mirrorMilestones &&
-      !skipMetadataForStarred &&
-      !metadataState.components.milestones;
+      !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, alreadyMirrored=${metadataState.components.milestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
+      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
     );
 
     if (shouldMirrorMilestones) {
@@ -1046,13 +1028,6 @@ export const mirrorGithubRepoToGitea = async ({
         );
         // Continue with other metadata operations even if milestones fail
       }
-    } else if (
-      config.giteaConfig?.mirrorMilestones &&
-      metadataState.components.milestones
-    ) {
-      console.log(
-        `[Metadata] Milestones already mirrored for ${repository.name}; skipping`
-      );
     }
 
     if (metadataUpdated) {
@@ -1587,13 +1562,13 @@ export async function mirrorGitHubRepoToGiteaOrg({
       }
     }
 
+    // Reconcile metadata on every sync. See note in mirrorGithubRepoToGitea
+    // above. The underlying mirror* functions are idempotent.
     const shouldMirrorIssuesThisRun =
-      !!config.giteaConfig?.mirrorIssues &&
-      !skipMetadataForStarred &&
-      !metadataState.components.issues;
+      !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, alreadyMirrored=${metadataState.components.issues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
+      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
     );
 
     if (shouldMirrorIssuesThisRun) {
@@ -1619,22 +1594,13 @@ export async function mirrorGitHubRepoToGiteaOrg({
         );
         // Continue with other metadata operations even if issues fail
       }
-    } else if (
-      config.giteaConfig?.mirrorIssues &&
-      metadataState.components.issues
-    ) {
-      console.log(
-        `[Metadata] Issues already mirrored for ${repository.name}; skipping`
-      );
     }
 
     const shouldMirrorPullRequests =
-      !!config.giteaConfig?.mirrorPullRequests &&
-      !skipMetadataForStarred &&
-      !metadataState.components.pullRequests;
+      !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, alreadyMirrored=${metadataState.components.pullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
+      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
     );
 
     if (shouldMirrorPullRequests) {
@@ -1659,23 +1625,16 @@ export async function mirrorGitHubRepoToGiteaOrg({
         );
         // Continue with other metadata operations even if PRs fail
       }
-    } else if (
-      config.giteaConfig?.mirrorPullRequests &&
-      metadataState.components.pullRequests
-    ) {
-      console.log(
-        `[Metadata] Pull requests already mirrored for ${repository.name}; skipping`
-      );
     }
 
+    // Labels-only path; issues run above already creates/reconciles labels.
     const shouldMirrorLabels =
       !!config.giteaConfig?.mirrorLabels &&
       !skipMetadataForStarred &&
-      !shouldMirrorIssuesThisRun &&
-      !metadataState.components.labels;
+      !shouldMirrorIssuesThisRun;
 
     console.log(
-      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, alreadyMirrored=${metadataState.components.labels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
+      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
     );
 
     if (shouldMirrorLabels) {
@@ -1700,22 +1659,13 @@ export async function mirrorGitHubRepoToGiteaOrg({
         );
         // Continue with other metadata operations even if labels fail
       }
-    } else if (
-      config.giteaConfig?.mirrorLabels &&
-      metadataState.components.labels
-    ) {
-      console.log(
-        `[Metadata] Labels already mirrored for ${repository.name}; skipping`
-      );
     }
 
     const shouldMirrorMilestones =
-      !!config.giteaConfig?.mirrorMilestones &&
-      !skipMetadataForStarred &&
-      !metadataState.components.milestones;
+      !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
 
     console.log(
-      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, alreadyMirrored=${metadataState.components.milestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
+      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
     );
 
     if (shouldMirrorMilestones) {
@@ -1740,13 +1690,6 @@ export async function mirrorGitHubRepoToGiteaOrg({
         );
         // Continue with other metadata operations even if milestones fail
       }
-    } else if (
-      config.giteaConfig?.mirrorMilestones &&
-      metadataState.components.milestones
-    ) {
-      console.log(
-        `[Metadata] Milestones already mirrored for ${repository.name}; skipping`
-      );
     }
 
     if (metadataUpdated) {


### PR DESCRIPTION
## Summary

After the first successful sync of a repository, subsequent syncs no longer reconcile metadata (issue/PR titles, bodies, labels, milestones). Changes made on GitHub never propagate to Gitea on re-sync, even though the underlying mirror functions are already designed to perform idempotent upserts via `[GH-ISSUE #N]` / `[GH-PR #N]` markers.

The log signature is:

```
[Sync] Issues already mirrored for <repo>; skipping
[Sync] Pull requests already mirrored for <repo>; skipping
[Sync] Labels already mirrored for <repo>; skipping
[Sync] Milestones already mirrored for <repo>; skipping
```

This is a regression: the exact same behavior was the subject of #165 (Jan 2026), which was fixed by #184. The regression was reintroduced by #266.

## Root Cause

PR #184 (`Implement incremental issue and PR metadata sync`) added marker-based idempotent upserts so re-syncs would update existing entries instead of creating duplicates. That solved #165, where the maintainer wrote:

> *"It's a mistake on my part. I kept that resyncing for later cause the tracking and de-duplicating across github and gitea was getting too complex."*
> — @arunavo4 in [#165](https://github.com/RayLabsHQ/gitea-mirror/issues/165#issuecomment-3742337429)

Later, PR #266 (`fix: prevent duplicate issue/PR mirroring`, fixes #262) added one-shot guards in `gitea.ts` and `gitea-enhanced.ts`:

```ts
const shouldMirrorIssuesThisRun =
  !!config.giteaConfig?.mirrorIssues &&
  !skipMetadataForStarred &&
  !metadataState.components.issues; // locks the path off after first run
// same pattern for pullRequests, labels, milestones
```

The intent was duplicate prevention, but #184 already handled duplicates via marker-based deduplication. The guard turned a *reconciling* re-sync into a *one-shot* mirror, re-introducing the original #165 symptom.

The releases mirror path in the same files (`shouldMirrorReleases`) does **not** have such a guard and runs unconditionally on every sync — that is the correct pattern, and the model this PR aligns the other metadata paths with.

## Fix

Remove the `!metadataState.components.X` guards in `src/lib/gitea.ts` and `src/lib/gitea-enhanced.ts` (4 sites each, 2 files × 2 duplicated code blocks). The metadata mirror paths now run on every sync; the underlying mirror functions handle idempotency via their existing markers and dedup logic.

Per-mirror deduplication is unchanged:

| Component | Dedup key |
|---|---|
| Issues | `[GH-ISSUE #N]` marker in Gitea issue title |
| Pull Requests | `[GH-PR #N]` marker in Gitea issue title |
| Labels | name (Gitea API uniqueness) |
| Milestones | title |

**Note on labels:** the labels mirror path still has its existing `!shouldMirrorIssuesThisRun` guard, because the issue mirror creates labels inline as a side effect of creating each issue. Calling `mirrorGitRepoLabelsToGitea` separately would be redundant when issues are about to run. This is unchanged behavior.

## Testing

`src/lib/gitea-enhanced.test.ts` had a test that was actively enforcing the buggy behavior:

```ts
// before
expect(mockMirrorGitHubReleasesToGitea).not.toHaveBeenCalled();
expect(mockMirrorGitRepoIssuesToGitea).not.toHaveBeenCalled();
expect(mockMirrorGitRepoPullRequestsToGitea).not.toHaveBeenCalled();
expect(mockMirrorGitRepoLabelsToGitea).not.toHaveBeenCalled();
expect(mockMirrorGitRepoMilestonesToGitea).not.toHaveBeenCalled();
```

Updated to reflect the corrected behavior:

```ts
// after
expect(mockMirrorGitHubReleasesToGitea).not.toHaveBeenCalled();
expect(mockMirrorGitRepoIssuesToGitea).toHaveBeenCalledTimes(1);
expect(mockMirrorGitRepoPullRequestsToGitea).toHaveBeenCalledTimes(1);
expect(mockMirrorGitRepoLabelsToGitea).not.toHaveBeenCalled(); // skipped because issues runs
expect(mockMirrorGitRepoMilestonesToGitea).toHaveBeenCalledTimes(1);
```

```
bun test src/lib/gitea-enhanced.test.ts
```

## Steps to Reproduce (pre-fix)

1. Mirror any repository with issues.
2. On GitHub, rename an issue title (or edit body / change a label / move milestone).
3. Trigger a re-sync in gitea-mirror.
4. Observe `[Sync] Issues already mirrored ...; skipping` in the logs.
5. Confirm the change is **not** present in Gitea.

After the fix, the renamed title is PATCH'd to the existing Gitea issue (matched by `[GH-ISSUE #N]` marker), no duplicates are created.

## Related

- Fixes #165 — regression reintroduced after the original fix in #184.
- Regression source: #266.

## Possible follow-up (not in this PR)

This change reconciles metadata on every sync. For repos with many issues, that means a small bump in GitHub API usage per sync. A natural optimization is to pass `since=metadataState.components.issues.lastSyncedAt` to the GitHub issues API so only issues updated since the last successful sync are fetched. That belongs in a separate PR; this one focuses on restoring correctness first.