### PR TITLE
chore: prune npm overrides that are no longer load-bearing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,17 +83,12 @@
   "overrides": {
     "@esbuild-kit/esm-loader": "npm:tsx@^4.21.0",
     "@xmldom/xmldom": "^0.8.13",
-    "defu": "^6.1.7",
     "devalue": "^5.8.1",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",
-    "fast-xml-parser": "^5.5.6",
     "kysely": "^0.28.17",
     "lodash": "^4.18.1",
-    "node-forge": "^1.3.3",
     "picomatch": "^4.0.4",
-    "rollup": ">=4.59.0",
-    "svgo": "^4.0.1",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],

--- a/package.json
+++ b/package.json
@@ -46,17 +46,12 @@
   "overrides": {
     "@esbuild-kit/esm-loader": "npm:tsx@^4.21.0",
     "@xmldom/xmldom": "^0.8.13",
-    "defu": "^6.1.7",
     "devalue": "^5.8.1",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",
-    "fast-xml-parser": "^5.5.6",
     "kysely": "^0.28.17",
     "lodash": "^4.18.1",
-    "node-forge": "^1.3.3",
-    "picomatch": "^4.0.4",
-    "rollup": ">=4.59.0",
-    "svgo": "^4.0.1"
+    "picomatch": "^4.0.4"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.7",


### PR DESCRIPTION
## Summary

Follow-up to #289. Audited every entry in `package.json` `overrides` to see which still affect the dep tree, and removed 5 that don't.

## Method

For each candidate override I:

1. Captured the resolved version (and any duplicate copies) **with** the override in place: `bun pm ls --all | grep <pkg>`
2. Removed the override, re-ran `bun install`
3. Re-captured the tree
4. Removed the override only if the resolved version and tree shape were identical

## Removed (5)

| Override | Old constraint | Resolved with override | Resolved without override | Verdict |
|---|---|---|---|---|
| `defu` | `^6.1.7` | `6.1.7` | `6.1.7` | redundant |
| `fast-xml-parser` | `^5.5.6` | `5.5.6` | `5.5.6` | redundant |
| `node-forge` | `^1.3.3` | _not in tree_ | _not in tree_ | dead — package isn't a transitive of anything we depend on |
| `rollup` | `>=4.59.0` | `4.59.0` | `4.59.0` | redundant |
| `svgo` | `^4.0.1` | `4.0.1` | `4.0.1` | redundant |

## Kept

- **`@esbuild-kit/esm-loader` → `npm:tsx@^4.21.0`** — deliberate replacement shim, not a pin
- **`@xmldom/xmldom`, `devalue`, `fast-uri`, `fast-xml-builder`, `kysely`** — active CVE pins just landed in #289
- **`lodash ^4.18.1`** — load-bearing; pins the newer 4.18.x line over legacy 4.17.x that several transitives still ask for
- **`picomatch ^4.0.4`** — load-bearing; without it, `picomatch@2.3.2` reappears as a duplicate copy via a transitive that asks for 2.x

## Safety net

Future drift (a transitive bump asking for a lower or vulnerable version) is caught by:
- Dependabot alerts on the default branch
- Weekly Docker Scout scan (cron `0 0 * * 0`)
- CodeQL on every push

If any of those flag a regression on one of the removed overrides, restoring it is one line.

## Test plan

- [x] `bun install` — lockfile in sync, no changes after removal
- [x] `bun pm ls --all` — verified resolved versions identical to pre-removal baseline
- [x] `bun test` — 243 pass, 4 skip, 0 fail
- [x] `bunx --bun astro build` — completes cleanly
- [ ] CI re-runs the same checks