### PR TITLE
feat: add Change password and Change email to account dropdown

### DIFF
--- a/src/components/auth/AccountMenu.tsx
+++ b/src/components/auth/AccountMenu.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { KeyRound, LogOut, Mail } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import { authClient } from "@/lib/auth-client";
+import { withBase } from "@/lib/base-path";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChangePasswordDialog } from "./ChangePasswordDialog";
+import { ChangeEmailDialog } from "./ChangeEmailDialog";
+
+export function AccountMenu() {
+  const { user, logout, refreshUser } = useAuth();
+  const [hasPassword, setHasPassword] = useState<boolean | null>(null);
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [emailOpen, setEmailOpen] = useState(false);
+
+  useEffect(() => {
+    if (!user) {
+      setHasPassword(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const accounts = await authClient.listAccounts();
+        if (cancelled) return;
+        const list = Array.isArray(accounts) ? accounts : accounts?.data;
+        setHasPassword(
+          Array.isArray(list) && list.some((a) => a.providerId === "credential")
+        );
+      } catch {
+        // Fail open: if we can't check, show the option rather than locking the
+        // user out of changing their password.
+        if (!cancelled) setHasPassword(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id]);
+
+  if (!user) {
+    return (
+      <Button variant="outline" size="sm" asChild>
+        <a href={withBase("/login")}>Login</a>
+      </Button>
+    );
+  }
+
+  const handleLogout = async () => {
+    toast.success("Logged out successfully");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    logout();
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="lg"
+            className="relative h-10 w-10 rounded-full p-0"
+          >
+            <Avatar className="h-full w-full">
+              <AvatarImage src={user.image || ""} alt={user.name || user.email} />
+              <AvatarFallback>
+                {(user.name || user.email || "U").charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-60">
+          <DropdownMenuLabel className="font-normal">
+            <div className="flex flex-col gap-0.5">
+              {user.name && (
+                <span className="text-sm font-medium leading-none">
+                  {user.name}
+                </span>
+              )}
+              <span className="text-xs leading-none text-muted-foreground truncate">
+                {user.email}
+              </span>
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {hasPassword && (
+            <DropdownMenuItem
+              onSelect={() => setPasswordOpen(true)}
+              className="cursor-pointer"
+            >
+              <KeyRound className="h-4 w-4 mr-2" />
+              Change password
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            onSelect={() => setEmailOpen(true)}
+            className="cursor-pointer"
+          >
+            <Mail className="h-4 w-4 mr-2" />
+            Change email
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={handleLogout} className="cursor-pointer">
+            <LogOut className="h-4 w-4 mr-2" />
+            Logout
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {hasPassword && (
+        <ChangePasswordDialog
+          open={passwordOpen}
+          onOpenChange={setPasswordOpen}
+        />
+      )}
+      <ChangeEmailDialog
+        open={emailOpen}
+        onOpenChange={setEmailOpen}
+        currentEmail={user.email}
+        onUpdated={refreshUser}
+      />
+    </>
+  );
+}

--- a/src/components/auth/ChangeEmailDialog.tsx
+++ b/src/components/auth/ChangeEmailDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ChangeEmailDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentEmail: string;
+  onUpdated?: () => void;
+}
+
+export function ChangeEmailDialog({
+  open,
+  onOpenChange,
+  currentEmail,
+  onUpdated,
+}: ChangeEmailDialogProps) {
+  const [newEmail, setNewEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reset = () => {
+    setNewEmail("");
+    setIsSubmitting(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = newEmail.trim();
+    if (!trimmed) {
+      toast.error("Please enter a new email");
+      return;
+    }
+    if (trimmed.toLowerCase() === currentEmail.toLowerCase()) {
+      toast.error("New email must differ from current email");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const { error } = await authClient.changeEmail({ newEmail: trimmed });
+      if (error) {
+        toast.error(error.message || "Failed to change email");
+        return;
+      }
+      toast.success("Email updated.");
+      onUpdated?.();
+      handleOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to change email");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change email</DialogTitle>
+          <DialogDescription>
+            Current: <span className="font-medium">{currentEmail}</span>
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-email">New email</Label>
+            <Input
+              id="new-email"
+              type="email"
+              autoComplete="email"
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              disabled={isSubmitting}
+              required
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Updating..." : "Update email"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/auth/ChangePasswordDialog.tsx
+++ b/src/components/auth/ChangePasswordDialog.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ChangePasswordDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [revokeOtherSessions, setRevokeOtherSessions] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const reset = () => {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setRevokeOtherSessions(true);
+    setIsSubmitting(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!currentPassword || !newPassword) {
+      toast.error("Please fill in all fields");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error("New passwords do not match");
+      return;
+    }
+    if (newPassword === currentPassword) {
+      toast.error("New password must differ from current password");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const { error } = await authClient.changePassword({
+        currentPassword,
+        newPassword,
+        revokeOtherSessions,
+      });
+      if (error) {
+        toast.error(error.message || "Failed to change password");
+        return;
+      }
+      toast.success(
+        revokeOtherSessions
+          ? "Password updated. Other sessions signed out."
+          : "Password updated."
+      );
+      handleOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to change password");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change password</DialogTitle>
+          <DialogDescription>
+            Enter your current password and a new one. You'll stay signed in on this device.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="current-password">Current password</Label>
+            <Input
+              id="current-password"
+              type="password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              disabled={isSubmitting}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              disabled={isSubmitting}
+              required
+              minLength={8}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirm-password">Confirm new password</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={isSubmitting}
+              required
+              minLength={8}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="revoke-sessions"
+              checked={revokeOtherSessions}
+              onCheckedChange={(checked) => setRevokeOtherSessions(checked === true)}
+              disabled={isSubmitting}
+            />
+            <Label htmlFor="revoke-sessions" className="text-sm font-normal cursor-pointer">
+              Sign out other devices
+            </Label>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Updating..." : "Update password"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,18 +2,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 
 import { ModeToggle } from "@/components/theme/ModeToggle";
-import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useLiveRefresh } from "@/hooks/useLiveRefresh";
 import { useConfigStatus } from "@/hooks/useConfigStatus";
-import { Menu, LogOut, PanelRightOpen, PanelRightClose } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { PanelRightOpen, PanelRightClose } from "lucide-react";
+import { AccountMenu } from "@/components/auth/AccountMenu";
 import { withBase } from "@/lib/base-path";
 
 interface HeaderProps {
@@ -26,7 +19,7 @@ interface HeaderProps {
 }
 
 export function Header({ currentPage, onNavigate, onMenuClick, onToggleCollapse, isSidebarCollapsed, isSidebarOpen }: HeaderProps) {
-  const { user, logout, isLoading } = useAuth();
+  const { isLoading } = useAuth();
   const { isLiveEnabled, toggleLive } = useLiveRefresh();
   const { isFullyConfigured, isLoading: configLoading } = useConfigStatus();
 
@@ -45,13 +38,6 @@ export function Header({ currentPage, onNavigate, onMenuClick, onToggleCollapse,
         : 'Enable live refresh (requires GitHub and Gitea configuration)';
     }
     return isLiveEnabled ? 'Disable live refresh' : 'Enable live refresh';
-  };
-
-  const handleLogout = async () => {
-    toast.success("Logged out successfully");
-    // Small delay to show the toast before redirecting
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    logout();
   };
 
   // Auth buttons skeleton loader
@@ -141,32 +127,7 @@ export function Header({ currentPage, onNavigate, onMenuClick, onToggleCollapse,
 
           <ModeToggle />
 
-          {isLoading ? (
-            <AuthButtonsSkeleton />
-          ) : user ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="lg" className="relative h-10 w-10 rounded-full p-0">
-                  <Avatar className="h-full w-full">
-                    <AvatarImage src={user.image || ""} alt={user.name || user.email} />
-                    <AvatarFallback>
-                      {(user.name || user.email || "U").charAt(0).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
-                  <LogOut className="h-4 w-4 mr-2" />
-                  Logout
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <Button variant="outline" size="sm" asChild>
-              <a href={withBase('/login')}>Login</a>
-            </Button>
-          )}
+          {isLoading ? <AuthButtonsSkeleton /> : <AccountMenu />}
         </div>
       </div>
     </header>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -145,6 +145,12 @@ export const auth = betterAuth({
         input: false, // Don't show in signup form - we'll derive from email
       }
     },
+    changeEmail: {
+      enabled: true,
+      // Email verification isn't wired up (sendResetPassword is a TODO),
+      // so allow direct updates. Safe here because emails stay unverified.
+      updateEmailWithoutVerification: true,
+    },
   },
 
   // Plugins configuration


### PR DESCRIPTION
## Summary

Resolves [discussion #291](https://github.com/RayLabsHQ/gitea-mirror/discussions/291) — the app exposes Better Auth's `change-password` / `change-email` endpoints server-side but had no UI to reach them.

- Avatar dropdown in the header now shows **user info** + **Change password** + **Change email** + Logout
- Each item opens a small dialog that calls `authClient.changePassword` / `authClient.changeEmail` directly — no new API routes
- **Change password is hidden for SSO-only users** (users with no `credential` provider account). Probe via `GET /api/auth/list-accounts`; fails open so a transient probe error doesn't lock anyone out of changing their password.
- Enables `user.changeEmail.enabled = true` with `updateEmailWithoutVerification: true` in `src/lib/auth.ts` — safe because `requireEmailVerification` is already off and the project has no email sender wired up.

## Test plan

End-to-end browser test (Playwright against the dev server) — all passed:

- [x] Fresh signup → dropdown renders with user info, Change password, Change email, Logout
- [x] Mismatched new/confirm password → validation toast, dialog stays open
- [x] Valid password change → success toast, dialog closes, log out + log back in with new password works
- [x] Email change → success toast, dropdown immediately shows new email (`refreshUser`), DB row updated, log in with new email works
- [x] `revokeOtherSessions: true` checkbox → verified a second session (curl-issued cookie) is invalidated on the next request after the change; current browser session stays alive
- [x] `bun run build` — clean