### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,13 +51,13 @@ jobs:
           ref: ${{ env.SHA }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: network=host
 
       - name: Log into registry
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
       # Login to Docker Hub for Docker Scout (optional - provides better vulnerability data)
       # Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to enable this
       - name: Log into Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -108,7 +108,7 @@ jobs:
       # Extract metadata for Docker
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           labels: |
@@ -124,7 +124,7 @@ jobs:
       # Build and push Docker image
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -139,7 +139,7 @@ jobs:
       # Load image locally for security scanning (PRs only)
       - name: Load image for scanning
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           platforms: linux/amd64
@@ -212,7 +212,7 @@ jobs:
 
       # Docker Scout comprehensive security analysis
       - name: Docker Scout - Vulnerability Analysis & Recommendations
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         if: github.event_name != 'pull_request'
         with:
           command: cves,recommendations
@@ -226,7 +226,7 @@ jobs:
 
       # Docker Scout for Pull Requests (using local image)
       - name: Docker Scout - Vulnerability Analysis (PR)
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         if: github.event_name == 'pull_request'
         with:
           command: cves,recommendations
@@ -240,7 +240,7 @@ jobs:
 
       # Compare to latest for PRs and pushes
       - name: Docker Scout - Compare to Latest
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
         if: github.event_name == 'pull_request'
         with:
           command: compare

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Setup Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
 
       - name: Regenerate bun.nix from bun.lock
         run: nix run --accept-flake-config github:nix-community/bun2nix -- -o bun.nix


### PR DESCRIPTION
## Summary

Hardens our CI against the tag-mutation supply-chain attack pattern that recently hit [`actions-cool/issues-helper` and `actions-cool/maintain-one-comment`](https://thehackernews.com/2026/05/github-actions-supply-chain-attack.html) (and `tj-actions/changed-files` earlier this year).

**Threat model**: tag refs (`@v3`) are mutable. A compromised maintainer can force-move `v3` to point at malicious code, and every workflow using `@v3` picks it up on the next run. The `actions-cool` payload read memory from `Runner.Worker` to steal credentials and exfiltrated them via HTTPS. Pinning to a 40-char commit SHA makes the ref immutable.

This PR covers the highest-risk subset:

- `nix-build.yml` had two **branch refs** (`@main`) — worse than tags because they move on every push. Pinned to the latest release SHA (v22 / v13).
- `docker-build.yml` is our most secret-bearing workflow (GHCR push token, Docker Hub login, Docker Scout). All five third-party actions there are now SHA-pinned.

We're not affected by the current actions-cool incident — neither action is in our chain — but the pattern keeps recurring, so the hygiene matters.

## What's not in this PR

- First-party `actions/checkout`, `actions/upload-artifact`, `actions/setup-python`, `actions/setup-node`, `actions/github-script`, `github/codeql-action/*` — lower risk (well-resourced GitHub-owned orgs), separate follow-up.
- `oven-sh/setup-bun`, `azure/setup-helm` in `helm-test.yml` / `astro-build-test.yml` / `e2e-tests.yml` — those workflows don't hold publish secrets, also a follow-up.
- Dependabot config for `github-actions` ecosystem — recommended next so SHA pins still get bumped automatically with the version comment trailer.

## Test plan

- [x] Diff is purely `@v3` → `@<sha> # v3.x.y` — no semantic change to workflow behavior, just the ref
- [x] All SHAs verified via `gh api repos/<org>/<repo>/git/ref/tags/<tag>` against the latest released tag at time of pin
- [ ] First post-merge CI run on `docker-build.yml` succeeds (validates the SHA pins resolve correctly on GitHub's runners)