### PR TITLE
chore: bump and digest-pin Bun base image to 1.3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM oven/bun:1.3.13-debian AS base
+FROM oven/bun:1.3.14-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS base
 WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   python3 make g++ gcc wget sqlite3 openssl ca-certificates \
@@ -49,7 +49,7 @@ RUN git clone --branch "v${GIT_LFS_VERSION}" --depth 1 https://github.com/git-lf
   && install -m 755 /tmp/git-lfs/bin/git-lfs /usr/local/bin/git-lfs
 
 # ----------------------------
-FROM oven/bun:1.3.13-debian AS runner
+FROM oven/bun:1.3.14-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS runner
 WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   git wget sqlite3 openssl ca-certificates \


### PR DESCRIPTION
## Summary

Extends the supply-chain hardening from #293 (GitHub Actions → SHA pins) to the Dockerfile.

- **Bumps Bun**: `oven/bun:1.3.13-debian` → `1.3.14-debian` (released 2026-05-13)
- **Pins to digest**: `@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f` (multi-arch manifest list, covers both `linux/amd64` and `linux/arm64`)
- Applies to both `base` and `runner` stages so every layer derives from the exact same digest

A tag like `1.3.14-debian` is mutable on Docker Hub the same way a GH Action tag is mutable on GitHub — the maintainer can re-push it to a different image at any time. Pinning to the digest means even a compromised Docker Hub account can't change what we pull on the next build.

## Test plan

- [x] Confirmed `oven/bun:1.3.14-debian` exists on Docker Hub and resolved its multi-arch digest
- [ ] CI's `docker` job pulls the new digest and builds successfully (validates the digest is correct and the image is reachable from GitHub runners)

## Follow-ups not in this PR

- `BUN_VERSION: "1.3.13"` in `e2e-tests.yml` and the bare `1.3.13` literal in `astro-build-test.yml` — those install Bun on the runner via `oven-sh/setup-bun`, separate concern from the Docker base image. Worth bumping to match, but not strictly part of "pin the image."