### PR TITLE
fix: resume interrupted jobs after startup (not only at boot)

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -216,9 +216,21 @@ export async function updateMirrorJobProgress({
 }
 
 /**
- * Finds interrupted jobs that need to be resumed with enhanced criteria
+ * Finds interrupted jobs that need to be resumed with enhanced criteria.
+ *
+ * `logFound` defaults to false because this function is polled from
+ * passive callers (`hasJobsNeedingRecovery` from the health endpoint
+ * and middleware checks). Logging on every poll produces log spam at
+ * one-line-per-poll-per-stuck-job for as long as a job stays stuck.
+ *
+ * Callers that intend to act on the result (i.e. immediately resume
+ * the returned jobs) should pass `logFound: true` so the surfacing
+ * still happens in the recovery flow.
  */
-export async function findInterruptedJobs() {
+export async function findInterruptedJobs(
+  options: { logFound?: boolean } = {}
+) {
+  const { logFound = false } = options;
   try {
     // Find jobs that are marked as in-progress but haven't been updated recently
     const cutoffTime = new Date();
@@ -243,8 +255,9 @@ export async function findInterruptedJobs() {
         )
       );
 
-    // Log details about found jobs for debugging
-    if (interruptedJobs.length > 0) {
+    // Log details about found jobs for debugging — opt-in to avoid
+    // spamming the log when called from periodic passive checks.
+    if (logFound && interruptedJobs.length > 0) {
       console.log(`Found ${interruptedJobs.length} interrupted jobs:`);
       interruptedJobs.forEach(job => {
         const lastCheckpoint = job.lastCheckpoint ? new Date(job.lastCheckpoint).toISOString() : 'never';

--- a/src/lib/orchestrator-resume-after-startup.test.ts
+++ b/src/lib/orchestrator-resume-after-startup.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for the "interrupted jobs never resume after
+ * startup" orchestration bug.
+ *
+ * Symptom (before this fix):
+ *   - Server starts cleanly. Middleware runs initial recovery pass,
+ *     finds no interrupted jobs, sets `recoveryAttempted = true` and
+ *     `recoveryInitialized = true`.
+ *   - User triggers a sync at T=N (well after startup). The sync
+ *     creates a `mirrorJobs` row with `inProgress=true`.
+ *   - The sync fails mid-flight (deadlock retry, network blip,
+ *     container restart of an upstream service, etc.) and never
+ *     reaches the resume codepath, so the row stays
+ *     `inProgress=true` with no checkpoint.
+ *   - `findInterruptedJobs` (called periodically from the health
+ *     endpoint via `hasJobsNeedingRecovery`) detects it and logs
+ *     `Found 1 interrupted jobs:` on every poll.
+ *   - But the resumer (`resumeInterruptedJob`) is only invoked from
+ *     `initializeRecovery`, which is gated behind the
+ *     once-per-process `!recoveryAttempted` check in
+ *     `src/middleware.ts`. That check is false after startup, so the
+ *     resumer NEVER fires again. The job is stuck forever.
+ *
+ * Root cause: the middleware gate was symmetric — "skip recovery if
+ * we've ever attempted it" — but it should have been "always
+ * re-evaluate; only the recovery routine's own 5-minute throttle
+ * (`skipIfRecentAttempt` inside `initializeRecovery`) prevents
+ * thrashing".
+ *
+ * Secondary issue: `findInterruptedJobs` logged unconditionally on
+ * every call, even from passive checks like `hasJobsNeedingRecovery`,
+ * producing log spam at one line per poll per stuck job.
+ *
+ * This test asserts on the *structure* of the source rather than
+ * invoking the middleware, because exercising the middleware path
+ * requires a full Astro request pipeline with heavy mocks. See
+ * `gitea-mirror-failure-recovery.test.ts` and
+ * `gitea-issue-dedup-on-retry.test.ts` for the same convention.
+ */
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const MIDDLEWARE_SRC = readFileSync(
+  join(import.meta.dir, "../middleware.ts"),
+  "utf8"
+);
+const HELPERS_SRC = readFileSync(
+  join(import.meta.dir, "helpers.ts"),
+  "utf8"
+);
+const RECOVERY_SRC = readFileSync(
+  join(import.meta.dir, "recovery.ts"),
+  "utf8"
+);
+
+describe("orchestrator: resume interrupted jobs after startup", () => {
+  test("middleware no longer gates recovery behind once-per-process `recoveryAttempted`", () => {
+    // The old gate looked like:
+    //   if (!recoveryInitialized && !recoveryAttempted) {
+    //     recoveryAttempted = true;
+    //     ...
+    //   }
+    // Once both flags flipped on the first request, recovery never
+    // ran again — even if jobs got stuck mid-runtime.
+    expect(
+      /\brecoveryAttempted\b/.test(MIDDLEWARE_SRC),
+      "the `recoveryAttempted` once-per-process flag must be removed " +
+        "from middleware.ts so post-startup interruptions can recover"
+    ).toBe(false);
+  });
+
+  test("middleware uses an in-flight latch (not a one-shot gate) for runtime safety", () => {
+    // The replacement uses `recoveryInFlight` as a per-request
+    // mutex — set true at the start, set false in `finally`. The
+    // actual throttle (5-minute "recent attempt") lives inside
+    // `initializeRecovery()` in recovery.ts, which is the right
+    // place for it.
+    expect(
+      /\brecoveryInFlight\b/.test(MIDDLEWARE_SRC),
+      "middleware should use `recoveryInFlight` as the in-flight latch"
+    ).toBe(true);
+    expect(
+      /recoveryInFlight\s*=\s*false/.test(MIDDLEWARE_SRC) &&
+        /\bfinally\s*\{[\s\S]*?recoveryInFlight\s*=\s*false[\s\S]*?\}/.test(
+          MIDDLEWARE_SRC
+        ),
+      "the in-flight latch must be released in a `finally` block " +
+        "so an exception during recovery doesn't permanently jam the latch"
+    ).toBe(true);
+  });
+
+  test("findInterruptedJobs logging is opt-in (default off) to stop poll spam", () => {
+    // Active recovery callers (initializeRecovery) opt in by passing
+    // { logFound: true }; passive checks (hasJobsNeedingRecovery,
+    // health endpoint, etc.) default to silent.
+    expect(
+      /export async function findInterruptedJobs\(\s*options[^)]*\)/.test(
+        HELPERS_SRC
+      ),
+      "findInterruptedJobs should accept an options object"
+    ).toBe(true);
+    expect(
+      /logFound\s*=\s*false/.test(HELPERS_SRC),
+      "the `logFound` option should default to false " +
+        "so periodic passive checks (e.g. hasJobsNeedingRecovery) " +
+        "don't spam the log on every poll"
+    ).toBe(true);
+    expect(
+      /if\s*\(\s*logFound\s*&&\s*interruptedJobs\.length\s*>\s*0\s*\)/.test(
+        HELPERS_SRC
+      ),
+      "the `Found N interrupted jobs` log must be gated by `logFound`"
+    ).toBe(true);
+  });
+
+  test("active recovery path opts in to per-job logging", () => {
+    // Without this, the actual recovery cycle would also be silent
+    // — operators need to see which jobs are being resumed.
+    expect(
+      /findInterruptedJobs\(\s*\{\s*logFound:\s*true\s*\}\s*\)/.test(
+        RECOVERY_SRC
+      ),
+      "initializeRecovery() must pass { logFound: true } to findInterruptedJobs " +
+        "so the active recovery cycle still logs which jobs it's working on"
+    ).toBe(true);
+  });
+});

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -121,8 +121,9 @@ export async function initializeRecovery(options: {
       // Clean up stale jobs first
       await cleanupStaleJobs();
 
-      // Find interrupted jobs
-      const interruptedJobs = await findInterruptedJobs();
+      // Find interrupted jobs (with per-job logging — this is the
+      // active recovery path that will immediately try to resume them)
+      const interruptedJobs = await findInterruptedJobs({ logFound: true });
 
       if (interruptedJobs.length === 0) {
         console.log('No interrupted jobs found.');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,9 +17,16 @@ function prefixAstroInternalAssetPaths(html: string, basePath: string): string {
   return html.replace(ASTRO_INTERNAL_ASSET_PATH_PATTERN, `$1${basePath}/$2`);
 }
 
-// Flag to track if recovery has been initialized
+// Flag to track whether the *startup* recovery pass has run. This
+// only gates the post-startup chain (cleanup service, scheduler,
+// etc.) and the "startup script may not have run" log line — it does
+// NOT gate subsequent recovery attempts, see below.
 let recoveryInitialized = false;
-let recoveryAttempted = false;
+// Throttle for runtime recovery retries (separate from the
+// initializeRecovery() 5-minute throttle inside recovery.ts, which is
+// keyed on `lastRecoveryAttempt`). This prevents one middleware
+// invocation from triggering recovery while another is in flight.
+let recoveryInFlight = false;
 let cleanupServiceStarted = false;
 let schedulerServiceStarted = false;
 let repositoryCleanupServiceStarted = false;
@@ -118,17 +125,30 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
   }
 
-  // Initialize recovery system only once when the server starts
-  // This is a fallback in case the startup script didn't run
-  if (!recoveryInitialized && !recoveryAttempted) {
-    recoveryAttempted = true;
+  // Run recovery if jobs need it.
+  //
+  // The previous implementation used a once-per-process gate, so
+  // any mid-runtime interruption (a sync that started after boot,
+  // crashed mid-flight, and never got back to the resume path)
+  // would sit at `in_progress=true` forever — the periodic detector
+  // kept finding it, but the resumer never re-fired. This block
+  // now re-evaluates on every request, gated by `recoveryInFlight`
+  // (per-process) plus the 5-minute throttle inside
+  // `initializeRecovery()` (which prevents thrashing if a resume
+  // cycle keeps failing).
+  if (!recoveryInFlight) {
+    recoveryInFlight = true;
 
     try {
       // Check if recovery is actually needed before attempting
       const needsRecovery = await hasJobsNeedingRecovery();
 
       if (needsRecovery) {
-        console.log('⚠️  Middleware detected jobs needing recovery (startup script may not have run)');
+        if (!recoveryInitialized) {
+          console.log('⚠️  Middleware detected jobs needing recovery (startup script may not have run)');
+        } else {
+          console.log('⚠️  Middleware detected jobs needing recovery mid-run (sync interrupted after startup)');
+        }
         console.log('Attempting recovery from middleware...');
 
         // Run recovery with a shorter timeout since this is during request handling
@@ -148,7 +168,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
         } else {
           console.log('⚠️  Middleware recovery completed with some issues');
         }
-      } else {
+      } else if (!recoveryInitialized) {
+        // Only log this on the first request; otherwise we'd spam
+        // it on every request.
         console.log('✅ No recovery needed (startup script likely handled it)');
       }
 
@@ -161,7 +183,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
       const status = getRecoveryStatus();
       console.log('Recovery status:', status);
 
-      recoveryInitialized = true; // Mark as attempted to avoid retries
+      recoveryInitialized = true;
+    } finally {
+      recoveryInFlight = false;
     }
   }
 


### PR DESCRIPTION
## Summary

Stops `mirrorJobs` rows from getting permanently stuck at `inProgress=true, lastCheckpoint=never` when a sync fails mid-flight after server boot. Found while debugging a separate dedup issue (#296) and observing endless `Found 1 interrupted jobs:` log spam with no recovery action ever taking place.

## The bug

The middleware-level recovery trigger looked like this:

```ts
let recoveryInitialized = false;
let recoveryAttempted = false;
// ...
if (!recoveryInitialized && !recoveryAttempted) {  // ← once per process, ever
  recoveryAttempted = true;
  if (needsRecovery) initializeRecovery(...);
  recoveryInitialized = true;
}
```

Both flags get set on the first request. After that, recovery never re-engages — even if new interruptions appear later in the process lifetime.

So the failure mode is:

1. Server boots cleanly. Middleware runs initial recovery pass on the first request. No stuck jobs. Both flags flip to true.
2. User triggers a sync. Job row is created with `inProgress=true`.
3. The sync crashes mid-flight (deadlock retry hitting `maxRetries`, network blip, container restart of a dependency, `bun` runtime quirk — anything that exits the per-item callback without reaching the resume/finalize codepath).
4. `findInterruptedJobs` (called periodically from the health endpoint via `hasJobsNeedingRecovery`) detects it and logs `Found 1 interrupted jobs:` on every poll.
5. But `resumeInterruptedJob` is only invoked from inside `initializeRecovery`, which the middleware gate prevents from re-running. **The job is stuck forever.**

The detector kept finding the row but the resumer never re-fired, producing the symptom: a `mirroring`-state repo in the UI plus log spam on every health-check tick.

## The fix

### Middleware (primary fix)

Replace the one-shot gate with an in-flight latch released in a `finally` block. The actual "don't thrash" guarantee is delegated to the existing 5-minute `skipIfRecentAttempt` throttle inside `initializeRecovery()`, which is the right place for it:

```ts
let recoveryInFlight = false;  // per-process mutex
// ...
if (!recoveryInFlight) {
  recoveryInFlight = true;
  try {
    if (await hasJobsNeedingRecovery()) {
      await initializeRecovery({ skipIfRecentAttempt: true, ... });
    }
  } finally {
    recoveryInFlight = false;
  }
}
```

`recoveryInitialized` is kept and only used to control whether the "first run" log lines fire (so the log doesn't say "startup script may not have run" on every request).

### `findInterruptedJobs` logging (secondary fix)

It previously logged `Found N interrupted jobs:` unconditionally on every call, including from passive polls (`hasJobsNeedingRecovery` from the health endpoint and middleware). That produced one log line per poll per stuck job — minutes of log spam for a single stuck job. Made it opt-in:

```ts
export async function findInterruptedJobs(options: { logFound?: boolean } = {}) {
  const { logFound = false } = options;
  // ... detect ...
  if (logFound && interruptedJobs.length > 0) { /* log per-job details */ }
  return interruptedJobs;
}
```

The active recovery cycle in `initializeRecovery()` passes `{ logFound: true }` so operators still see which jobs are being worked on.

## Tests

Adds `src/lib/orchestrator-resume-after-startup.test.ts` using the structural-source test pattern from `gitea-mirror-failure-recovery.test.ts` (issue #268's regression test). 4 assertions:

- Middleware no longer references the once-per-process `recoveryAttempted` flag
- Middleware uses an in-flight latch (`recoveryInFlight`) released in a `finally` block (so an exception during recovery doesn't permanently jam the latch)
- `findInterruptedJobs` accepts a `{ logFound }` option that defaults to `false`
- The active recovery path in `initializeRecovery()` explicitly opts in with `{ logFound: true }`

`bun test` — 251 pass / 4 skip / 0 fail.

## Related

- **#268** — partially addressed. The PR #280 / v3.15.7 fix was about a JS scoping bug that made the *initial* migrate call's catch path crash before transitioning the repo to `failed`. That was one cause of stuck `mirroring` state; this PR addresses the orthogonal issue that even when a job *is* correctly detectable as interrupted, the post-startup recovery path never re-engages.
- **#296** — companion PR fixing dedup-on-retry. Independent code paths; ship either independently. The duplication symptom in #296 is what made the "stuck job" log spam visible in our test environment, but the two bugs are unrelated.

## Test plan

- [x] `bun install && bun test` — all green (251/4/0)
- [x] Confirmed the symptom on stock v3.16.0: `Found 1 interrupted jobs:` repeating with no recovery action
- [x] Confirmed the patched build re-engages recovery on subsequent requests when a runtime-interrupted job is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)