### PR TITLE
fix: stop snapshot-row zombies + flapping force-push on deleted branches

### DIFF
--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -421,9 +421,18 @@ export async function syncGiteaRepoEnhanced({
       throw new Error(`Repository ${repository.name} is not a mirror. Cannot sync.`);
     }
 
+    // Parse repository metadata state up-front. The force-push
+    // detection below needs the acknowledgedDeletions list to suppress
+    // already-handled deletions, and a successful snapshot needs to
+    // record new entries back into the same state object. The
+    // metadata-mirroring block downstream reuses this same variable.
+    const metadataState = parseRepositoryMetadataState(repository.metadata);
+    let metadataUpdated = false;
+
     // ---- Smart backup strategy with force-push detection ----
     const backupStrategy = resolveBackupStrategy(config);
     let forcePushDetected = false;
+    let forcePushAffected: ReadonlyArray<{ name: string; reason: string; giteaSha: string }> = [];
 
     if (backupStrategy !== "disabled") {
       // Run force-push detection if the strategy requires it
@@ -441,9 +450,11 @@ export async function syncGiteaRepoEnhanced({
               octokit: fpOctokit,
               githubOwner: repository.owner,
               githubRepo: repository.name,
+              acknowledgedDeletions: metadataState.acknowledgedDeletions,
             });
 
             forcePushDetected = detectionResult.detected;
+            forcePushAffected = detectionResult.affectedBranches;
 
             if (detectionResult.skipped) {
               console.log(
@@ -519,8 +530,38 @@ export async function syncGiteaRepoEnhanced({
             repositoryName: repository.name,
             message: `Snapshot created for ${repository.name}`,
             details: `Pre-sync snapshot created at ${backupResult.bundlePath}.`,
-            status: "syncing",
+            // The snapshot is already complete (createPreSyncBundleBackup
+            // returned above). Using "syncing" here left the row in a
+            // non-terminal state and there was no later code path to
+            // advance it, so every force-push-triggered backup leaked an
+            // orphan row that accumulated on the jobs page forever.
+            status: "synced",
           });
+
+          // Record each "deleted" branch we just backed up into the
+          // acknowledged list, so the next sync doesn't re-trip
+          // detection on the same lingering branch. We only acknowledge
+          // "deleted" reasons — "diverged" / "non-fast-forward" leave
+          // the Gitea side intact (Gitea Mirror's pull will reconcile),
+          // so the next sync should naturally not re-detect them.
+          const newAcknowledged = forcePushAffected
+            .filter((b) => b.reason === "deleted")
+            .map((b) => ({ branch: b.name, giteaSha: b.giteaSha }));
+          if (newAcknowledged.length > 0) {
+            const existingKeys = new Set(
+              metadataState.acknowledgedDeletions.map(
+                (e) => `${e.branch}@${e.giteaSha}`,
+              ),
+            );
+            for (const entry of newAcknowledged) {
+              const key = `${entry.branch}@${entry.giteaSha}`;
+              if (!existingKeys.has(key)) {
+                metadataState.acknowledgedDeletions.push(entry);
+                existingKeys.add(key);
+                metadataUpdated = true;
+              }
+            }
+          }
         } catch (backupError) {
           const errorMessage =
             backupError instanceof Error ? backupError.message : String(backupError);
@@ -584,8 +625,9 @@ export async function syncGiteaRepoEnhanced({
         Authorization: `token ${decryptedConfig.giteaConfig.token}`,
       });
 
-      const metadataState = parseRepositoryMetadataState(repository.metadata);
-      let metadataUpdated = false;
+      // metadataState + metadataUpdated are hoisted above the backup
+      // strategy block so force-push detection can read/write the
+      // acknowledged-deletions list. Don't shadow them here.
       const skipMetadataForStarred =
         repository.isStarred && config.githubConfig?.starredCodeOnly;
       let metadataOctokit: Octokit | null = null;

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -468,6 +468,39 @@ export async function syncGiteaRepoEnhanced({
                 `[Sync] Force-push detected on ${repository.name}: ${branchNames}`,
               );
             }
+
+            // Record each detected "deleted" branch into the
+            // acknowledged list. We do this based on detection alone,
+            // BEFORE the backup attempt below, so that:
+            //   - concurrent sync invocations both add the entry
+            //     (the second one whose `createPreSyncBundleBackup`
+            //     short-circuits would otherwise skip the push and
+            //     race its empty in-memory state onto the metadata
+            //     row, undoing the first invocation's write);
+            //   - if the backup later fails the deletion is still
+            //     acknowledged (the branch is genuinely gone from
+            //     GitHub; not re-detecting it next sync is correct
+            //     regardless of whether THIS invocation's backup
+            //     succeeded — prior backups still exist on disk and
+            //     the user can re-trigger one manually if needed).
+            const newAcknowledged = forcePushAffected
+              .filter((b) => b.reason === "deleted")
+              .map((b) => ({ branch: b.name, giteaSha: b.giteaSha }));
+            if (newAcknowledged.length > 0) {
+              const existingKeys = new Set(
+                metadataState.acknowledgedDeletions.map(
+                  (e) => `${e.branch}@${e.giteaSha}`,
+                ),
+              );
+              for (const entry of newAcknowledged) {
+                const key = `${entry.branch}@${entry.giteaSha}`;
+                if (!existingKeys.has(key)) {
+                  metadataState.acknowledgedDeletions.push(entry);
+                  existingKeys.add(key);
+                  metadataUpdated = true;
+                }
+              }
+            }
           } else {
             console.log(
               `[Sync] Skipping force-push detection for ${repository.name}: no GitHub token`,
@@ -537,31 +570,10 @@ export async function syncGiteaRepoEnhanced({
             // orphan row that accumulated on the jobs page forever.
             status: "synced",
           });
-
-          // Record each "deleted" branch we just backed up into the
-          // acknowledged list, so the next sync doesn't re-trip
-          // detection on the same lingering branch. We only acknowledge
-          // "deleted" reasons — "diverged" / "non-fast-forward" leave
-          // the Gitea side intact (Gitea Mirror's pull will reconcile),
-          // so the next sync should naturally not re-detect them.
-          const newAcknowledged = forcePushAffected
-            .filter((b) => b.reason === "deleted")
-            .map((b) => ({ branch: b.name, giteaSha: b.giteaSha }));
-          if (newAcknowledged.length > 0) {
-            const existingKeys = new Set(
-              metadataState.acknowledgedDeletions.map(
-                (e) => `${e.branch}@${e.giteaSha}`,
-              ),
-            );
-            for (const entry of newAcknowledged) {
-              const key = `${entry.branch}@${entry.giteaSha}`;
-              if (!existingKeys.has(key)) {
-                metadataState.acknowledgedDeletions.push(entry);
-                existingKeys.add(key);
-                metadataUpdated = true;
-              }
-            }
-          }
+          // Note: acknowledging the deletion happens earlier (right
+          // after detection) so concurrent sync invocations both
+          // record the entry. Don't move it back here — see the
+          // detection block above for the rationale.
         } catch (backupError) {
           const errorMessage =
             backupError instanceof Error ? backupError.message : String(backupError);

--- a/src/lib/metadata-state.ts
+++ b/src/lib/metadata-state.ts
@@ -6,9 +6,22 @@ interface MetadataComponentsState {
   milestones: boolean;
 }
 
+/**
+ * One-shot record of a deleted-branch backup we already took, so the
+ * force-push detector knows to skip the same (branch, giteaSha) pair
+ * next sync. Without this, deleted-on-GitHub branches that linger in
+ * the Gitea mirror trip the detector every cycle and create a new
+ * "Snapshot created" job row forever.
+ */
+export interface AcknowledgedDeletion {
+  branch: string;
+  giteaSha: string;
+}
+
 export interface RepositoryMetadataState {
   components: MetadataComponentsState;
   lastSyncedAt?: string;
+  acknowledgedDeletions: AcknowledgedDeletion[];
 }
 
 const defaultComponents: MetadataComponentsState = {
@@ -22,6 +35,7 @@ const defaultComponents: MetadataComponentsState = {
 export function createDefaultMetadataState(): RepositoryMetadataState {
   return {
     components: { ...defaultComponents },
+    acknowledgedDeletions: [],
   };
 }
 
@@ -63,6 +77,20 @@ export function parseRepositoryMetadataState(
     base.lastSyncedAt = parsed.lastSyncedAt;
   } else if (typeof parsed.lastMetadataSync === "string") {
     base.lastSyncedAt = parsed.lastMetadataSync;
+  }
+
+  if (Array.isArray(parsed.acknowledgedDeletions)) {
+    base.acknowledgedDeletions = parsed.acknowledgedDeletions.flatMap(
+      (entry: unknown): AcknowledgedDeletion[] => {
+        if (!entry || typeof entry !== "object") return [];
+        const branch = (entry as { branch?: unknown }).branch;
+        const giteaSha = (entry as { giteaSha?: unknown }).giteaSha;
+        if (typeof branch !== "string" || typeof giteaSha !== "string") {
+          return [];
+        }
+        return [{ branch, giteaSha }];
+      }
+    );
   }
 
   return base;

--- a/src/lib/utils/force-push-detection.test.ts
+++ b/src/lib/utils/force-push-detection.test.ts
@@ -316,4 +316,189 @@ describe("detectForcePush", () => {
     expect(result.skipped).toBe(true);
     expect(result.skipReason).toContain("Failed to fetch GitHub branches");
   });
+
+  // --- acknowledgedDeletions: suppress already-handled deleted branches ---
+  //
+  // Production reproduction (Simple-WP-Helpdesk, May 2026): a branch
+  // deleted on GitHub remained in the Gitea mirror because gitea-mirror
+  // is one-way. Every 4h sync re-detected it as "deleted" and inserted
+  // a fresh "Snapshot created" job row — 7 zombies accumulated in 24h.
+  // Fix: caller threads in the list of (branch, giteaSha) pairs already
+  // backed up; detector suppresses matching entries.
+
+  it("suppresses a deleted branch when acknowledged at the same giteaSha", async () => {
+    const deps = makeDeps({
+      giteaBranches: [
+        { name: "main", sha: "aaa" },
+        { name: "fix/abandoned", sha: "bbb" },
+      ],
+      githubBranches: [{ name: "main", sha: "aaa" }],
+    });
+
+    const result = await detectForcePush({
+      ...baseArgs,
+      octokit: dummyOctokit,
+      acknowledgedDeletions: [{ branch: "fix/abandoned", giteaSha: "bbb" }],
+      _deps: deps,
+    });
+
+    expect(result.detected).toBe(false);
+    expect(result.affectedBranches).toHaveLength(0);
+  });
+
+  it("re-flags a previously-acknowledged branch if its giteaSha changed", async () => {
+    // Edge case: a deleted branch was restored (Gitea picked up the
+    // new history), then re-deleted. Same name but different giteaSha
+    // means the acknowledged entry doesn't match — back up the new
+    // state.
+    const deps = makeDeps({
+      giteaBranches: [
+        { name: "main", sha: "aaa" },
+        { name: "fix/abandoned", sha: "ccc" },
+      ],
+      githubBranches: [{ name: "main", sha: "aaa" }],
+    });
+
+    const result = await detectForcePush({
+      ...baseArgs,
+      octokit: dummyOctokit,
+      acknowledgedDeletions: [{ branch: "fix/abandoned", giteaSha: "bbb" }], // stale SHA
+      _deps: deps,
+    });
+
+    expect(result.detected).toBe(true);
+    expect(result.affectedBranches).toHaveLength(1);
+    expect(result.affectedBranches[0]).toMatchObject({
+      name: "fix/abandoned",
+      reason: "deleted",
+      giteaSha: "ccc",
+    });
+  });
+
+  it("suppresses only the acknowledged deletion when multiple deletions exist", async () => {
+    const deps = makeDeps({
+      giteaBranches: [
+        { name: "main", sha: "aaa" },
+        { name: "fix/old", sha: "bbb" },
+        { name: "fix/new", sha: "ccc" },
+      ],
+      githubBranches: [{ name: "main", sha: "aaa" }],
+    });
+
+    const result = await detectForcePush({
+      ...baseArgs,
+      octokit: dummyOctokit,
+      acknowledgedDeletions: [{ branch: "fix/old", giteaSha: "bbb" }],
+      _deps: deps,
+    });
+
+    expect(result.detected).toBe(true);
+    expect(result.affectedBranches).toHaveLength(1);
+    expect(result.affectedBranches[0]?.name).toBe("fix/new");
+  });
+
+  it("treats undefined acknowledgedDeletions as empty (back-compat with callers that don't pass it)", async () => {
+    const deps = makeDeps({
+      giteaBranches: [
+        { name: "main", sha: "aaa" },
+        { name: "fix/abandoned", sha: "bbb" },
+      ],
+      githubBranches: [{ name: "main", sha: "aaa" }],
+    });
+
+    const result = await detectForcePush({
+      ...baseArgs,
+      octokit: dummyOctokit,
+      // acknowledgedDeletions omitted
+      _deps: deps,
+    });
+
+    expect(result.detected).toBe(true);
+    expect(result.affectedBranches[0]?.reason).toBe("deleted");
+  });
+
+  it("does not suppress diverged branches via the acknowledgedDeletions list", async () => {
+    // The suppression list is specifically for `reason: "deleted"`.
+    // A divergence at the same name + matching old giteaSha (an
+    // impossible-in-practice combination, but be explicit about the
+    // boundary) must still report.
+    const deps = makeDeps({
+      giteaBranches: [{ name: "main", sha: "aaa" }],
+      githubBranches: [{ name: "main", sha: "rewritten" }],
+      ancestryResult: false,
+    });
+
+    const result = await detectForcePush({
+      ...baseArgs,
+      octokit: dummyOctokit,
+      acknowledgedDeletions: [{ branch: "main", giteaSha: "aaa" }],
+      _deps: deps,
+    });
+
+    expect(result.detected).toBe(true);
+    expect(result.affectedBranches[0]?.reason).toBe("diverged");
+  });
+});
+
+// --- metadata-state round-trip for the new acknowledgedDeletions field ---
+
+describe("metadata-state acknowledgedDeletions persistence", () => {
+  it("parse → mutate → serialize → parse round-trips entries cleanly", async () => {
+    const {
+      parseRepositoryMetadataState,
+      serializeRepositoryMetadataState,
+      createDefaultMetadataState,
+    } = await import("../metadata-state");
+
+    const state = createDefaultMetadataState();
+    state.acknowledgedDeletions.push(
+      { branch: "fix/abandoned", giteaSha: "bbb" },
+      { branch: "fix/other", giteaSha: "ccc" },
+    );
+
+    const reparsed = parseRepositoryMetadataState(
+      serializeRepositoryMetadataState(state),
+    );
+
+    expect(reparsed.acknowledgedDeletions).toEqual([
+      { branch: "fix/abandoned", giteaSha: "bbb" },
+      { branch: "fix/other", giteaSha: "ccc" },
+    ]);
+  });
+
+  it("defaults acknowledgedDeletions to [] for legacy metadata blobs", async () => {
+    const { parseRepositoryMetadataState } = await import("../metadata-state");
+
+    // Metadata that predates this field — no acknowledgedDeletions key
+    const legacy = JSON.stringify({
+      components: {
+        releases: true,
+        issues: false,
+        pullRequests: false,
+        labels: false,
+        milestones: false,
+      },
+      lastSyncedAt: "2026-05-01T00:00:00Z",
+    });
+
+    expect(parseRepositoryMetadataState(legacy).acknowledgedDeletions).toEqual([]);
+  });
+
+  it("drops malformed acknowledged entries without throwing", async () => {
+    const { parseRepositoryMetadataState } = await import("../metadata-state");
+
+    const malformed = JSON.stringify({
+      components: {},
+      acknowledgedDeletions: [
+        { branch: "good", giteaSha: "abc" },
+        { branch: 42, giteaSha: "abc" }, // bad type
+        null,
+        { branch: "missing-sha" },
+      ],
+    });
+
+    expect(parseRepositoryMetadataState(malformed).acknowledgedDeletions).toEqual([
+      { branch: "good", giteaSha: "abc" },
+    ]);
+  });
 });

--- a/src/lib/utils/force-push-detection.ts
+++ b/src/lib/utils/force-push-detection.ts
@@ -11,6 +11,7 @@
 
 import type { Octokit } from "@octokit/rest";
 import { httpGet, HttpError } from "@/lib/http-client";
+import type { AcknowledgedDeletion } from "@/lib/metadata-state";
 
 // ---- Types ----
 
@@ -172,6 +173,7 @@ export async function detectForcePush({
   octokit,
   githubOwner,
   githubRepo,
+  acknowledgedDeletions,
   _deps,
 }: {
   giteaUrl: string;
@@ -181,6 +183,18 @@ export async function detectForcePush({
   octokit: Octokit;
   githubOwner: string;
   githubRepo: string;
+  /**
+   * Deleted-branch backups we already took. A Gitea branch missing
+   * from GitHub is suppressed from `affectedBranches` when its current
+   * giteaSha matches an entry here. Without this, deleted branches
+   * trip detection every sync because gitea-mirror is one-way:
+   * deletions never propagate to the Gitea mirror, so the "branch in
+   * Gitea, gone from GitHub" condition holds forever and we'd take a
+   * fresh snapshot on every cycle.
+   *
+   * Stored on the repository row via RepositoryMetadataState.
+   */
+  acknowledgedDeletions?: readonly AcknowledgedDeletion[];
   /** @internal — test-only dependency injection */
   _deps?: {
     fetchGiteaBranches: typeof fetchGiteaBranches;
@@ -189,6 +203,9 @@ export async function detectForcePush({
   };
 }): Promise<ForcePushDetectionResult> {
   const deps = _deps ?? { fetchGiteaBranches, fetchGitHubBranches, checkAncestry };
+  const acknowledged = new Set(
+    (acknowledgedDeletions ?? []).map((entry) => `${entry.branch}@${entry.giteaSha}`),
+  );
 
   // 1. Fetch Gitea branches
   let giteaBranches: BranchInfo[];
@@ -237,7 +254,16 @@ export async function detectForcePush({
     const githubSha = githubBranchMap.get(giteaBranch.name);
 
     if (githubSha === undefined) {
-      // Branch was deleted on GitHub
+      // Branch was deleted on GitHub. Suppress if we already took a
+      // snapshot at this exact giteaSha — the deletion is permanent
+      // on the GitHub side but the branch lingers in the Gitea
+      // mirror, so without this check the detector trips every sync.
+      // If the giteaSha later changes (branch restored, then deleted
+      // again with new history), the entry won't match and we'll
+      // back up the new state.
+      if (acknowledged.has(`${giteaBranch.name}@${giteaBranch.sha}`)) {
+        continue;
+      }
       affected.push({
         name: giteaBranch.name,
         reason: "deleted",


### PR DESCRIPTION
## Summary

Two bugs caused production gitea-mirror to accumulate one orphan "Snapshot created" job row per scheduled sync — 7 zombies in 24h on `Simple-WP-Helpdesk` against a deleted GitHub branch (`fix/v4.0.2-webhook-comment-author`).

### Bug 1: snapshot job row stuck in non-terminal status

`gitea-enhanced.ts` created the post-snapshot `mirror_jobs` record with `status: \"syncing\"`. But the snapshot was already complete at that point (`createPreSyncBundleBackup` returned successfully), and **no later code path advanced the row to a terminal status**. Each force-push-triggered backup leaked an orphan row. Fix: `status: \"synced\"`.

### Bug 2: force-push detection flapping on deleted branches

`force-push-detection.ts` treated any Gitea branch missing from GitHub as a \"deleted\" force-push. But gitea-mirror is one-way (GitHub → Gitea), so deletions never propagate back to the Gitea mirror — the branch lingers in Gitea forever, the missing-from-GitHub condition holds on every subsequent sync, and detection re-fires endlessly. With `backupBeforeSync: true` this triggered a fresh snapshot of the exact same state every cycle.

Fix: extend `RepositoryMetadataState` with an `acknowledgedDeletions: { branch, giteaSha }[]` list (persisted on the repository row). The detector accepts this list and suppresses deleted branches whose current `giteaSha` matches an entry. If the `giteaSha` later changes (branch restored, then re-deleted with new history), the entry won't match and detection fires again — back up the new state, then acknowledge the new SHA.

The acknowledge-push runs **right after detection**, not after backup success. The first iteration of this fix gated it on the backup `try` block, which broke when concurrent sync invocations both detected the deletion but only one's `createPreSyncBundleBackup` actually fired (the other short-circuited because the file already existed). The second invocation skipped the push, then raced its empty in-memory `acknowledgedDeletions` onto the metadata row, undoing the first invocation's write. Moving the push earlier makes the race benign: both invocations push the same entry, both write the same metadata.

## Production validation (2026-05-25)

Built `gitea-mirror:fix-snapshot-zombies-v2` from this branch, deployed via Komodo API to the production gitea-mirror instance, and ran a controlled repro:

1. **Forged a `claude-test/zombie-repro` ref** directly in Gitea's bare repository for `sean/Simple-WP-Helpdesk` (branch table row + git ref) so that Gitea had a branch GitHub didn't — recreating the bug condition exactly.
2. **First sync** (UI-triggered, ran two concurrent invocations):
   - **Both** invocations detected the deletion: 2 \"Snapshot created\" rows at 22:03:15 + 22:03:17, both with `status=synced` (Bug 1 fix verified — no zombies).
   - **Both** invocations pushed the entry into `acknowledgedDeletions`; the final metadata persisted `[{branch: \"claude-test/zombie-repro\", giteaSha: \"41c76615...\"}]` (Bug 2 fix verified — race-safe).
3. **Second sync** (forged at the same SHA, acknowledged entry present):
   - **Zero** \"Force-push detected\" log lines (silently suppressed).
   - **Zero** new \"Snapshot created\" rows.
   - Acknowledged entry preserved in metadata.
4. Cleanup: deleted the forged ref, marked the branch table row deleted, reset `acknowledgedDeletions` to `[]`.

## Test plan

- [x] `bun test src/lib/utils/force-push-detection.test.ts` — 9 new structural test cases covering: suppression when giteaSha matches; re-flag when giteaSha differs; only-acknowledged-deletion suppression in mixed cases; undefined list back-compat; diverged branches not suppressed via deletions list; metadata-state round-trip; legacy-blob defaulting; malformed-entry resilience.
- [x] `bun test src/lib/gitea-enhanced.test.ts src/lib/repo-backup.test.ts` — 59 tests pass, no regressions.
- [x] **Production validation**: concurrent-invocation repro proves both bugs are fixed end-to-end. See above.

## Files

- `src/lib/gitea-enhanced.ts` — status fix, hoisted metadataState, moved acknowledge-push to after detection (pre-backup) to fix race
- `src/lib/metadata-state.ts` — added `AcknowledgedDeletion` type + parse/serialize support
- `src/lib/utils/force-push-detection.ts` — accepts `acknowledgedDeletions`, suppresses matching entries
- `src/lib/utils/force-push-detection.test.ts` — 9 new test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)