### PR TITLE
Fix Docker image line in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ PUBLIC_BETTER_AUTH_URL=http://localhost:4321
 
 # Docker Registry Configuration
 DOCKER_REGISTRY=ghcr.io
-DOCKER_IMAGE=raylabshq/gitea-mirror:
+DOCKER_IMAGE=raylabshq/gitea-mirror
 DOCKER_TAG=latest
 
 # ===========================================


### PR DESCRIPTION
This pull request makes a minor update to the `.env.example` file by removing the colon at the end of the `DOCKER_IMAGE` value. This change ensures that the Docker image name is correctly formatted.

<img width="540" height="46" alt="image" src="https://github.com/user-attachments/assets/91e99963-8fce-440e-a0f2-3d0be5fcac98" />
