### PR TITLE
fix: scheduler auto-start gate, backup clone URL, cancel-pending action, actionable 405

### DIFF
--- a/src/components/activity/ActivityLog.tsx
+++ b/src/components/activity/ActivityLog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { ChevronDown, Download, RefreshCw, Search, Trash2, Filter } from 'lucide-react';
+import { ChevronDown, Download, RefreshCw, Search, Trash2, Filter, StopCircle } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,6 +85,8 @@ export function ActivityLog() {
   const [activities, setActivities] = useState<MirrorJobWithKey[]>([]);
   const [isInitialLoading, setIsInitialLoading] = useState(false);
   const [showCleanupDialog, setShowCleanupDialog] = useState(false);
+  const [showCancelPendingDialog, setShowCancelPendingDialog] = useState(false);
+  const [isCancelPendingLoading, setIsCancelPendingLoading] = useState(false);
 
   // Ref to track if component is mounted to prevent state updates after unmount
   const isMountedRef = useRef(true);
@@ -354,6 +356,40 @@ export function ActivityLog() {
     setShowCleanupDialog(false);
   };
 
+  const confirmCancelPending = async () => {
+    if (!user?.id) return;
+
+    try {
+      setIsCancelPendingLoading(true);
+      setShowCancelPendingDialog(false);
+
+      const response = await fetch(withBase('/api/job/cancel-pending'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error occurred' }));
+        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const res = await response.json();
+
+      if (res.success) {
+        toast.success(res.message);
+        // Refresh to show the new activity log entry
+        await fetchActivities(false);
+      } else {
+        showErrorToast(res.error || 'Failed to cancel pending mirrors.', toast);
+      }
+    } catch (error) {
+      console.error('Error cancelling pending mirrors:', error);
+      showErrorToast(error, toast);
+    } finally {
+      setIsCancelPendingLoading(false);
+    }
+  };
+
   // Check if any filters are active
   const hasActiveFilters = !!(filter.status || filter.type || filter.name);
   const activeFilterCount = [filter.status, filter.type, filter.name].filter(Boolean).length;
@@ -555,8 +591,19 @@ export function ActivityLog() {
           <Button
             variant="outline"
             size="icon"
+            onClick={() => setShowCancelPendingDialog(true)}
+            title="Stop pending mirrors"
+            className="text-amber-600 hover:text-amber-600 h-10 w-10 shrink-0"
+            disabled={isCancelPendingLoading}
+          >
+            <StopCircle className="h-4 w-4" />
+          </Button>
+
+          <Button
+            variant="outline"
+            size="icon"
             onClick={handleCleanupClick}
-            title="Delete all activities"
+            title="Clear activity history"
             className="text-destructive hover:text-destructive h-10 w-10 shrink-0"
           >
             <Trash2 className="h-4 w-4" />
@@ -683,12 +730,24 @@ export function ActivityLog() {
             <RefreshCw className="h-4 w-4" />
           </Button>
 
-          {/* cleanup all activities */}
+          {/* stop pending mirrors */}
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setShowCancelPendingDialog(true)}
+            title="Stop pending mirrors"
+            className="text-amber-600 hover:text-amber-600 h-10 w-10"
+            disabled={isCancelPendingLoading}
+          >
+            <StopCircle className="h-4 w-4" />
+          </Button>
+
+          {/* clear activity history */}
           <Button
             variant="outline"
             size="icon"
             onClick={handleCleanupClick}
-            title="Delete all activities"
+            title="Clear activity history"
             className="text-destructive hover:text-destructive h-10 w-10"
           >
             <Trash2 className="h-4 w-4" />
@@ -709,9 +768,12 @@ export function ActivityLog() {
       <Dialog open={showCleanupDialog} onOpenChange={setShowCleanupDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete All Activities</DialogTitle>
+            <DialogTitle>Clear Activity History</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete ALL activities? This action cannot be undone and will remove all mirror jobs and events from the database.
+              This clears the activity <strong>history log</strong> (mirror job records and events) — it does not stop
+              any pending or in-progress mirrors. Repositories keep their current status and the scheduler
+              will continue to pick up pending work. To stop pending mirrors, use the
+              &ldquo;Stop Pending Mirrors&rdquo; button instead.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -723,7 +785,35 @@ export function ActivityLog() {
               onClick={confirmCleanup}
               disabled={isInitialLoading}
             >
-              {isInitialLoading ? 'Deleting...' : 'Delete All Activities'}
+              {isInitialLoading ? 'Clearing...' : 'Clear History'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* cancel pending mirrors confirmation dialog */}
+      <Dialog open={showCancelPendingDialog} onOpenChange={setShowCancelPendingDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Stop Pending Mirrors</DialogTitle>
+            <DialogDescription>
+              This sets all repositories with status <strong>Imported</strong> or <strong>Failed</strong> to{' '}
+              <strong>Ignored</strong>, preventing the scheduler from mirroring them automatically.
+              Repositories that are currently mirroring are not affected.{' '}
+              You can re-enable individual repositories from the Repositories page.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCancelPendingDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              className="bg-amber-600 hover:bg-amber-700"
+              onClick={confirmCancelPending}
+              disabled={isCancelPendingLoading}
+            >
+              {isCancelPendingLoading ? 'Stopping...' : 'Stop Pending Mirrors'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -889,6 +889,32 @@ export async function syncGiteaRepoEnhanced({
             status: "failed",
           });
         }
+      } else if (syncError instanceof HttpError && syncError.status === 405) {
+        // Gitea returns HTTP 405 (with an empty body) when the repository is not
+        // a pull-mirror in its database — e.g. Gitea auto-disabled the mirror or
+        // the repo lost its mirror state after a manual edit.
+        const actionableMessage =
+          `Gitea reports this repository is not a pull mirror (HTTP 405). ` +
+          `In Gitea check Settings → Mirror Settings; if the mirror section is ` +
+          `missing, delete the repository in Gitea and re-mirror it from gitea-mirror.`;
+
+        await db
+          .update(repositories)
+          .set({
+            status: repoStatusEnum.parse("failed"),
+            updatedAt: new Date(),
+            errorMessage: actionableMessage,
+          })
+          .where(eq(repositories.id, repository.id!));
+
+        await createMirrorJob({
+          userId: config.userId,
+          repositoryId: repository.id,
+          repositoryName: repository.name,
+          message: `Sync failed: ${repository.name} is not a pull mirror in Gitea (HTTP 405)`,
+          details: actionableMessage,
+          status: "failed",
+        });
       }
       throw syncError;
     }

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -544,9 +544,12 @@ export async function syncGiteaRepoEnhanced({
 
       // Create backup if strategy says so
       if (shouldBackupForStrategy(backupStrategy, forcePushDetected)) {
-        const cloneUrl =
-          repoInfo.clone_url ||
-          `${config.giteaConfig.url.replace(/\/$/, "")}/${repoOwner}/${repoName}.git`;
+        // Always derive the clone URL from the user-configured Gitea URL rather
+        // than repoInfo.clone_url (which reflects Gitea's ROOT_URL and may be
+        // unreachable from the app — e.g. Tailscale MagicDNS deployments where
+        // ROOT_URL resolves externally but the app talks to Gitea on a private
+        // address).
+        const cloneUrl = `${config.giteaConfig.url.replace(/\/$/, "")}/${repoOwner}/${repoName}.git`;
 
         try {
           const backupResult = await createPreSyncBundleBackup({

--- a/src/lib/scheduler-service.test.ts
+++ b/src/lib/scheduler-service.test.ts
@@ -103,6 +103,28 @@ describe("Scheduler Service - Ignored Repository Handling", () => {
     ]);
   });
 
+  test("auto-start gate: enabled=true → should start, enabled=false → should not start even with mirrorInterval", () => {
+    // Mirror the gate logic from checkAutoStartConfiguration / performInitialAutoStart.
+    // The enabled flag is the single authoritative signal; a configured
+    // mirrorInterval is a timing detail and must not bypass a disabled toggle.
+    const shouldAutoStart = (scheduleConfig?: { enabled?: boolean }) =>
+      scheduleConfig?.enabled === true;
+
+    expect(shouldAutoStart({ enabled: true })).toBe(true);
+    expect(shouldAutoStart({ enabled: false })).toBe(false);
+    expect(shouldAutoStart({})).toBe(false);
+    expect(shouldAutoStart(undefined)).toBe(false);
+
+    // Simulating: user disabled scheduling but has a mirrorInterval configured.
+    // The old code checked `scheduleEnabled || hasMirrorInterval`; the fix
+    // ensures only the enabled flag is checked.
+    const configWithIntervalButDisabled = {
+      scheduleConfig: { enabled: false },
+      giteaConfig: { mirrorInterval: "8h" },
+    };
+    expect(shouldAutoStart(configWithIntervalButDisabled.scheduleConfig)).toBe(false);
+  });
+
   test("should validate all repository status enum values", () => {
     const validStatuses = [
       "imported",

--- a/src/lib/scheduler-service.ts
+++ b/src/lib/scheduler-service.ts
@@ -431,13 +431,16 @@ async function checkAutoStartConfiguration(): Promise<boolean> {
       .where(eq(configs.isActive, true));
     
     for (const config of activeConfigs) {
-      // Check if scheduling is enabled via environment
+      // Check if scheduling is enabled.
+      // Note: env-config-loader already sets scheduleConfig.enabled=true when
+      // GITEA_MIRROR_INTERVAL is set at startup, so the enabled flag is the
+      // single authoritative gate here. Checking hasMirrorInterval directly
+      // would allow a configured interval to trigger auto-start even after the
+      // user explicitly disabled scheduling via the UI.
       const scheduleEnabled = config.scheduleConfig?.enabled === true;
-      const hasMirrorInterval = !!config.giteaConfig?.mirrorInterval;
-      
-      // If either SCHEDULE_ENABLED=true or GITEA_MIRROR_INTERVAL is set, we should auto-start
-      if (scheduleEnabled || hasMirrorInterval) {
-        console.log(`[Scheduler] Auto-start conditions met for user ${config.userId} (scheduleEnabled=${scheduleEnabled}, hasMirrorInterval=${hasMirrorInterval})`);
+
+      if (scheduleEnabled) {
+        console.log(`[Scheduler] Auto-start conditions met for user ${config.userId} (scheduleEnabled=${scheduleEnabled})`);
         return true;
       }
     }
@@ -472,10 +475,12 @@ async function performInitialAutoStart(): Promise<void> {
       }
       
       const scheduleEnabled = config.scheduleConfig?.enabled === true;
-      const hasMirrorInterval = !!config.giteaConfig?.mirrorInterval;
-      
-      // Only process configs that have scheduling or mirror interval configured
-      if (!scheduleEnabled && !hasMirrorInterval) {
+
+      // Only process configs where scheduling is explicitly enabled.
+      // env-config-loader already sets enabled=true when GITEA_MIRROR_INTERVAL
+      // is present, so this single check covers both the UI toggle and the
+      // env-var boot path without letting a bare interval override a disabled toggle.
+      if (!scheduleEnabled) {
         continue;
       }
       

--- a/src/pages/api/job/cancel-pending.ts
+++ b/src/pages/api/job/cancel-pending.ts
@@ -1,0 +1,89 @@
+import type { APIRoute } from "astro";
+import { db, repositories } from "@/lib/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { repoStatusEnum } from "@/types/Repository";
+import { createMirrorJob } from "@/lib/helpers";
+import { createSecureErrorResponse } from "@/lib/utils";
+import { requireAuthenticatedUserId } from "@/lib/auth-guards";
+
+/**
+ * POST /api/job/cancel-pending
+ *
+ * Sets this user's repositories that are waiting to be mirrored
+ * (status: "imported" or "failed") to "ignored", preventing the scheduler
+ * from picking them up.  Repos with status "mirroring" or "syncing" are
+ * left alone because they have in-flight work that cannot be aborted here.
+ *
+ * Returns the count of affected repositories and logs one activity entry.
+ */
+export const POST: APIRoute = async ({ request, locals }) => {
+  try {
+    const authResult = await requireAuthenticatedUserId({ request, locals });
+    if ("response" in authResult) return authResult.response;
+    const userId = authResult.userId;
+
+    // Statuses that represent queued-but-not-started work.
+    // "imported"  → repo was discovered, never mirrored
+    // "failed"    → last mirror attempt failed; scheduler will retry
+    const cancelableStatuses = ["imported", "failed"] as const;
+
+    // Fetch repos to cancel so we can count them and log meaningful details.
+    const toCancel = await db
+      .select({ id: repositories.id })
+      .from(repositories)
+      .where(
+        and(
+          eq(repositories.userId, userId),
+          inArray(repositories.status, cancelableStatuses),
+        ),
+      );
+
+    const cancelCount = toCancel.length;
+
+    if (cancelCount > 0) {
+      const ids = toCancel.map((r) => r.id);
+
+      await db
+        .update(repositories)
+        .set({
+          status: repoStatusEnum.parse("ignored"),
+          updatedAt: new Date(),
+          errorMessage: "Cancelled by user — set to ignored via Stop Pending Mirrors.",
+        })
+        .where(
+          and(
+            eq(repositories.userId, userId),
+            inArray(repositories.id, ids),
+          ),
+        );
+    }
+
+    // Log a single activity summarising the bulk action.
+    await createMirrorJob({
+      userId,
+      message: `Stopped pending mirrors: ${cancelCount} repositor${cancelCount === 1 ? "y" : "ies"} set to Ignored`,
+      details:
+        cancelCount > 0
+          ? `${cancelCount} repositor${cancelCount === 1 ? "y" : "ies"} with status "imported" or "failed" have been set to "ignored". ` +
+            `They can be re-enabled from the Repositories page.`
+          : `No repositories in a pending state were found for this user.`,
+      status: cancelCount > 0 ? "ignored" : "skipped",
+      skipDuplicateEvent: false,
+      skipNotification: true,
+    });
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message:
+          cancelCount > 0
+            ? `${cancelCount} repositor${cancelCount === 1 ? "y has" : "ies have"} been set to Ignored.`
+            : "No repositories in a pending state were found.",
+        cancelledCount: cancelCount,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  } catch (error) {
+    return createSecureErrorResponse(error, "cancel pending mirrors", 500);
+  }
+};


### PR DESCRIPTION
Part of #309. Improves diagnostics for #308. Four independent fixes, one commit each:

1. **Auto-start respects the enabled toggle** (#309): boot-time auto-start fired when `scheduleEnabled || hasMirrorInterval`, so a configured mirror interval overrode an explicitly disabled scheduler. `scheduleConfig.enabled` is now the single authoritative gate. The documented `GITEA_MIRROR_INTERVAL` contract is preserved — the env loader already sets `enabled=true` when that variable is present at startup.

2. **Backup clone URL derived from the configured Gitea URL** (#309): the pre-sync backup preferred `repoInfo.clone_url` from the Gitea API, which reflects Gitea's `ROOT_URL` and can be unreachable from the app (e.g. Tailscale MagicDNS deployments). The clone URL is now always built from `config.giteaConfig.url`. (Issue/PR metadata mirroring was already using the configured URL and was unaffected.)

3. **Honest "Delete All" copy + a real cancel action** (#309): the activity-page action only clears history rows while the scheduler re-derives pending work from repo status, so the log refilled. The dialog is renamed "Clear Activity History" with accurate copy, and a new `POST /api/job/cancel-pending` ("Stop Pending Mirrors" button) sets this user's `imported`/`failed` repos to `ignored` (re-enable from the Repositories page). In-flight work is left alone.

4. **Actionable HTTP 405 on mirror-sync** (#308): Gitea returns a bodyless 405 when a repo isn't a pull-mirror in its database (e.g. Gitea auto-disabled the mirror). Previously surfaced as a raw "HTTP 405: Method Not Allowed"; now the repo's error message tells the user to check Gitea → Settings → Mirror Settings and re-mirror if the mirror section is missing.

## Testing
Unit tests for the auto-start gate; full suite green. Cancel-pending verified live on a Gitea 1.24 test bed (745 repos flipped to Ignored, single summary activity entry).