### PR TITLE
Skip the user defined orgs to ignore

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -678,9 +678,11 @@ export async function getGithubStarredListNames({
 export async function getGithubOrganizations({
   octokit,
   config,
+  skipOrgNames,
 }: {
   octokit: Octokit;
   config: Partial<Config>;
+  skipOrgNames?: Set<string>;
 }): Promise<{ organizations: GitOrg[]; failedOrgs: { name: string; avatarUrl: string; reason: string }[] }> {
   try {
     const { data: orgs } = await octokit.orgs.listForAuthenticatedUser({
@@ -693,12 +695,16 @@ export async function getGithubOrganizations({
       ? excludedOrgsEnv.split(",").map((org) => org.trim().toLowerCase())
       : [];
 
-    // Filter out excluded organizations
+    // Filter out excluded and user-ignored organizations
     const filteredOrgs = orgs.filter((org) => {
       if (excludedOrgs.includes(org.login.toLowerCase())) {
         console.log(
           `Skipping organization ${org.login} - excluded via GITHUB_EXCLUDED_ORGS environment variable`,
         );
+        return false;
+      }
+      if (skipOrgNames?.has(org.login.toLowerCase())) {
+        console.log(`Skipping organization ${org.login} - ignored by user`);
         return false;
       }
       return true;

--- a/src/pages/api/sync/index.ts
+++ b/src/pages/api/sync/index.ts
@@ -49,13 +49,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const githubUsername = config.githubConfig?.owner || undefined;
     const octokit = createGitHubClient(decryptedToken, userId, githubUsername);
 
+    // Load ignored orgs from the DB so we can skip them during import
+    const ignoredOrgRows = await db
+      .select({ normalizedName: organizations.normalizedName })
+      .from(organizations)
+      .where(and(eq(organizations.userId, userId), eq(organizations.status, "ignored")));
+    const ignoredOrgNames = new Set(ignoredOrgRows.map((o) => o.normalizedName));
+
     // Fetch GitHub data in parallel
     const [basicAndForkedRepos, starredRepos, orgResult] = await Promise.all([
       getGithubRepositories({ octokit, config }),
       config.githubConfig?.includeStarred
         ? getGithubStarredRepositories({ octokit, config })
         : Promise.resolve([]),
-      getGithubOrganizations({ octokit, config }),
+      getGithubOrganizations({ octokit, config, skipOrgNames: ignoredOrgNames }),
     ]);
     const { organizations: gitOrgs, failedOrgs } = orgResult;
 
@@ -152,7 +159,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
       const existingOrgMap = new Map(existingOrgs.map((o) => [o.normalizedName, o.status]));
 
       insertedRepos = newRepos.filter(
-        (r) => !existingRepoNames.has(r.normalizedFullName)
+        (r) =>
+          !existingRepoNames.has(r.normalizedFullName) &&
+          (!r.organization || !ignoredOrgNames.has(r.organization.toLowerCase()))
       );
       insertedOrgs = newOrgs.filter((o) => !existingOrgMap.has(o.normalizedName));
 
@@ -258,7 +267,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         newRepositories: insertedRepos.length,
         newOrganizations: insertedOrgs.length,
         skippedDisabledRepositories: allGithubRepos.length - mirrorableGithubRepos.length,
-        failedOrgs: failedOrgs.map((o) => o.name),
+        failedOrgs: failedOrgs.filter((o) => !ignoredOrgNames.has(o.name.toLowerCase())).map((o) => o.name),
         recoveredOrgs: recoveredOrgCount,
       },
     });


### PR DESCRIPTION
# What does this do?
- When I ignore an org, and click import github data, the org fails to import as my token is not authenticated for that org. This PR omits syncing an org that the user explicitly set to ignore