### PR TITLE
fix(config): persist Name Collision Strategy dropdown (#326)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -107,6 +107,7 @@ Standard GitHub Enterprise Cloud on `github.com` works with the default — no o
 | `MIRROR_STARRED_LISTS` | Optional comma-separated GitHub Star List names to mirror (only used when `MIRROR_STARRED=true`) | - | Comma-separated list names (empty = all starred repos) |
 | `STARRED_REPOS_ORG` | Organization name for starred repos | `starred` | Any string |
 | `STARRED_REPOS_MODE` | How starred repos are mirrored | `dedicated-org` | `dedicated-org`, `preserve-owner` |
+| `STARRED_DUPLICATE_STRATEGY` | Name collision strategy when two starred repos share a name from different owners (`suffix` = `repo-owner`, `prefix` = `owner-repo`) | `suffix` | `suffix`, `prefix`, `owner-org` |
 
 ### Organization Settings
 

--- a/src/lib/env-config-loader.ts
+++ b/src/lib/env-config-loader.ts
@@ -27,6 +27,7 @@ interface EnvConfig {
     autoMirrorStarred?: boolean;
     starredReposOrg?: string;
     starredReposMode?: 'dedicated-org' | 'preserve-owner';
+    starredDuplicateStrategy?: 'suffix' | 'prefix' | 'owner-org';
     starredLists?: string[];
     mirrorStrategy?: 'preserve' | 'single-org' | 'flat-user' | 'mixed';
   };
@@ -132,6 +133,7 @@ function parseEnvConfig(): EnvConfig {
       autoMirrorStarred: process.env.AUTO_MIRROR_STARRED === 'true',
       starredReposOrg: process.env.STARRED_REPOS_ORG,
       starredReposMode: process.env.STARRED_REPOS_MODE as 'dedicated-org' | 'preserve-owner',
+      starredDuplicateStrategy: process.env.STARRED_DUPLICATE_STRATEGY as 'suffix' | 'prefix' | 'owner-org',
       starredLists,
       mirrorStrategy: process.env.MIRROR_STRATEGY as 'preserve' | 'single-org' | 'flat-user' | 'mixed',
     },
@@ -287,6 +289,7 @@ export async function initializeConfigFromEnv(): Promise<void> {
       includeOrganizations: envConfig.github.includeOrganizations ?? existingConfig?.[0]?.githubConfig?.includeOrganizations ?? [],
       starredReposOrg: envConfig.github.starredReposOrg || existingConfig?.[0]?.githubConfig?.starredReposOrg || 'starred',
       starredReposMode: envConfig.github.starredReposMode || existingConfig?.[0]?.githubConfig?.starredReposMode || 'dedicated-org',
+      starredDuplicateStrategy: envConfig.github.starredDuplicateStrategy || existingConfig?.[0]?.githubConfig?.starredDuplicateStrategy || 'suffix',
       mirrorStrategy,
       defaultOrg: envConfig.gitea.organization || existingConfig?.[0]?.githubConfig?.defaultOrg || 'github-mirrors',
       starredCodeOnly: envConfig.github.starredCodeOnly ?? existingConfig?.[0]?.githubConfig?.starredCodeOnly ?? false,

--- a/src/lib/utils/config-mapper.test.ts
+++ b/src/lib/utils/config-mapper.test.ts
@@ -158,3 +158,36 @@ test("DB row missing skipPersonalRepos defaults to false on read", () => {
   const ui = mapDbToUiConfig({ githubConfig: { owner: "octo", token: "" } });
   expect(ui.advancedOptions.skipPersonalRepos).toBe(false);
 });
+
+// Regression for #326: the Name Collision Strategy dropdown didn't persist
+// because starredDuplicateStrategy was missing from both mapper directions.
+test("starredDuplicateStrategy round-trips UI -> DB -> UI when set to prefix", () => {
+  const ui = buildMinimalUiConfigs();
+  ui.githubConfig.starredDuplicateStrategy = "prefix";
+  const db = mapUiToDbConfig(ui.githubConfig, ui.giteaConfig, ui.mirrorOptions, ui.advancedOptions);
+  expect(db.githubConfig.starredDuplicateStrategy).toBe("prefix");
+
+  const roundTripped = mapDbToUiConfig({ githubConfig: db.githubConfig, giteaConfig: db.giteaConfig });
+  expect(roundTripped.githubConfig.starredDuplicateStrategy).toBe("prefix");
+});
+
+test("starredDuplicateStrategy round-trips UI -> DB -> UI when set to suffix", () => {
+  const ui = buildMinimalUiConfigs();
+  ui.githubConfig.starredDuplicateStrategy = "suffix";
+  const db = mapUiToDbConfig(ui.githubConfig, ui.giteaConfig, ui.mirrorOptions, ui.advancedOptions);
+  expect(db.githubConfig.starredDuplicateStrategy).toBe("suffix");
+
+  const roundTripped = mapDbToUiConfig({ githubConfig: db.githubConfig, giteaConfig: db.giteaConfig });
+  expect(roundTripped.githubConfig.starredDuplicateStrategy).toBe("suffix");
+});
+
+test("starredDuplicateStrategy defaults to suffix on save when unset", () => {
+  const ui = buildMinimalUiConfigs();
+  const db = mapUiToDbConfig(ui.githubConfig, ui.giteaConfig, ui.mirrorOptions, ui.advancedOptions);
+  expect(db.githubConfig.starredDuplicateStrategy).toBe("suffix");
+});
+
+test("DB row missing starredDuplicateStrategy defaults to suffix on read", () => {
+  const ui = mapDbToUiConfig({ githubConfig: { owner: "octo", token: "" } });
+  expect(ui.githubConfig.starredDuplicateStrategy).toBe("suffix");
+});

--- a/src/lib/utils/config-mapper.ts
+++ b/src/lib/utils/config-mapper.ts
@@ -81,6 +81,7 @@ export function mapUiToDbConfig(
     starredReposOrg: giteaConfig.starredReposOrg,
     starredReposMode: giteaConfig.starredReposMode || "dedicated-org",
     starredLists: normalizeStarredLists(githubConfig.starredLists),
+    starredDuplicateStrategy: githubConfig.starredDuplicateStrategy ?? "suffix",
     
     // Mirror strategy
     mirrorStrategy: giteaConfig.mirrorStrategy || "preserve",
@@ -166,6 +167,7 @@ export function mapDbToUiConfig(dbConfig: any): {
     includeOrganizations: normalizeOrgList(dbConfig.githubConfig?.includeOrganizations),
     mirrorStarred: dbConfig.githubConfig?.includeStarred || false, // Map includeStarred to mirrorStarred
     starredLists: normalizeStarredLists(dbConfig.githubConfig?.starredLists),
+    starredDuplicateStrategy: dbConfig.githubConfig?.starredDuplicateStrategy ?? "suffix",
   };
 
   // Map from database Gitea config to UI fields


### PR DESCRIPTION
Fixes #326.

## Problem

The **Name collision strategy** dropdown (Configuration → GitHub Configuration → *Duplicate name handling*; field `starredDuplicateStrategy`) does not persist. Changing it from `repo-owner` to `owner-repo`, navigating away, and returning shows it reverted — and repos are still created with the `repo-owner` pattern.

## Root cause

The field was **absent from both directions of the UI↔DB config mapper** (`config-mapper.ts`):

- **Save** — `mapUiToDbConfig` never included `starredDuplicateStrategy`, so it was dropped before the DB write (the save API writes exactly what the mapper returns).
- **Load** — `mapDbToUiConfig` never read it, so the UI fell back to the `"suffix"` (`repo-owner`) default on every reload.
- **Mirror logic** — `gitea.ts` then read `undefined` and also defaulted to `suffix`, so the user's choice never took effect anywhere.

It has been broken since the field was introduced (`git log -S` shows it was never in the mapper). The schema/type/UI/mirror-logic all had it — only the persistence layer was missing. This matches the reporter's observation that *other* settings on the page save fine; only this one doesn't.

## Fix

- Map `starredDuplicateStrategy` in **both** `mapUiToDbConfig` and `mapDbToUiConfig` (defaulting to `suffix`, no migration — it lives in the `github_config` JSON blob).
- Add a `STARRED_DUPLICATE_STRATEGY` env var for parity (the reporter couldn't even work around it via compose because no env var existed) + docs.
- Round-trip tests covering save, load, save-default, and the missing-field read default.

## Verification

CI-equivalent on a clean checkout + this patch: `bun test` **343 pass / 0 fail**, `bun test:migrations` ✓, `astro build` ✓.

Real persistence round-trip through the actual SQLite JSON column:

```
mapUiToDbConfig -> github_config.starredDuplicateStrategy: prefix
read back from SQLite                                     : prefix
mapDbToUiConfig -> UI starredDuplicateStrategy            : prefix
legacy DB row (no field) -> defaults to                  : suffix
PERSISTENCE FIXED: "owner-repo" (prefix) survives save -> SQLite -> reload ✅
```

Note: the dropdown still intentionally exposes only `suffix`/`prefix` (the third schema value `owner-org` remains hidden) — out of scope here.