### PR TITLE
fix(releases): create releases only for tags present in Gitea; stop sending target (#331)

### DIFF
--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -2938,6 +2938,7 @@ export async function mirrorGitHubReleasesToGitea({
 
   let mirroredCount = 0;
   let skippedCount = 0;
+  let skippedMissingTagCount = 0;
   let totalAssetsUploaded = 0;
   let totalAssetsFailed = 0;
 
@@ -2996,7 +2997,8 @@ export async function mirrorGitHubReleasesToGitea({
             `${config.giteaConfig.url}/api/v1/repos/${repoOwner}/${repoName}/releases/${existingRelease.id}`,
             {
               tag_name: release.tag_name,
-              target: release.target_commitish,
+              // Omit `target` — the release already exists and is anchored to its tag;
+              // re-sending target_commitish risks the same "target not found" 404 (#331).
               title: release.name || release.tag_name,
               body: releaseNote,
               draft: release.draft,
@@ -3040,18 +3042,43 @@ export async function mirrorGitHubReleasesToGitea({
         continue;
       }
 
+      // The git tag must already exist in Gitea before we create a release for it.
+      // For a mirror, tags are synced from upstream by Gitea's own git mirror, which
+      // can lag behind this metadata sync (e.g. a large/slow initial clone). If the
+      // tag isn't present yet, skip and let a later sync pick it up — do NOT ask Gitea
+      // to create the release against a `target` branch:
+      //   - if the target can't be resolved Gitea returns 404 "The target couldn't be
+      //     found" and the release is lost (#331),
+      //   - if it can, Gitea would create a brand-new tag at the wrong commit.
+      const tagExists = await httpGet(
+        `${config.giteaConfig.url}/api/v1/repos/${repoOwner}/${repoName}/tags/${encodeURIComponent(release.tag_name)}`,
+        { Authorization: `token ${decryptedConfig.giteaConfig.token}` }
+      )
+        .then(() => true)
+        .catch(() => false);
+
+      if (!tagExists) {
+        console.warn(
+          `[Releases] Tag ${release.tag_name} is not present in Gitea yet — skipping release for now (the git mirror may still be syncing; it will be retried on the next sync)`
+        );
+        skippedMissingTagCount++;
+        continue;
+      }
+
       // Create new release with changelog/body content (includes GitHub date header)
       if (originalReleaseNote) {
         console.log(`[Releases] Including changelog for ${release.tag_name} (${originalReleaseNote.length} characters + GitHub date header)`);
       } else {
         console.log(`[Releases] Creating release ${release.tag_name} with GitHub date header (no changelog)`);
       }
-      
+
       const createReleaseResponse = await httpPost(
         `${config.giteaConfig.url}/api/v1/repos/${repoOwner}/${repoName}/releases`,
         {
           tag_name: release.tag_name,
-          target: release.target_commitish,
+          // Intentionally omit `target`: the tag already exists (verified above), so
+          // Gitea attaches the release to it. Sending target_commitish can 404 with
+          // "The target couldn't be found" on some Gitea/Forgejo versions (#331).
           title: release.name || release.tag_name,
           body: releaseNote,
           draft: release.draft,
@@ -3087,8 +3114,14 @@ export async function mirrorGitHubReleasesToGitea({
   }
 
   console.log(
-    `✅ Mirrored/Updated ${mirroredCount} releases to Gitea (${skippedCount} already up-to-date); assets uploaded: ${totalAssetsUploaded}, failed: ${totalAssetsFailed}`
+    `✅ Mirrored/Updated ${mirroredCount} releases to Gitea (${skippedCount} already up-to-date, ${skippedMissingTagCount} skipped: tag not synced yet); assets uploaded: ${totalAssetsUploaded}, failed: ${totalAssetsFailed}`
   );
+
+  if (skippedMissingTagCount > 0) {
+    console.warn(
+      `[Releases] ${skippedMissingTagCount} release(s) skipped because their git tag is not in Gitea yet for ${repository.fullName} — these will be created automatically once the git mirror finishes syncing the tags`
+    );
+  }
 
   if (totalAssetsFailed > 0) {
     console.error(


### PR DESCRIPTION
Follow-up to #332. That PR fixed idempotent **asset** reconciliation, but the reporter in #331 was actually blocked one step earlier: release **creation** itself was 404ing, so no release (and no assets) ever existed.

## Root cause
The create payload always sent `target: release.target_commitish` (e.g. `"main"`). When a release's git **tag isn't yet present** in the Gitea mirror — which happens when Gitea's own git-mirror clone lags behind this metadata sync — Gitea tries to *create* the tag from `target`:
- if the target ref can't be resolved → generic **`404 "The target couldn't be found"`** and the release is lost,
- if it can → it would create a **new tag at the wrong commit**.

`"The target couldn't be found."` is Gitea's generic `error.not_found` (a bare `ctx.NotFound()`), confirming the failure is at git/tag resolution time, not the request itself.

## Reproduction effort
I reproduced the reporter's **exact stack** on a test VM — Forgejo **15 rootless** + `read_only: true` + `cap_drop: ALL` + `user 99:100` — and also tested Gitea 1.20/1.21/1.23/1.24/1.25/1.26 and Forgejo 1.21/11/12. On a healthy repo **every version creates the release fine** (with `target`); the 404 only occurs when the **tag is absent at create time**. This matches the field symptom: all releases failing while issues/PRs (which need no git refs) succeed.

## Fix
- **Verify the git tag exists in Gitea before creating a release.** If it isn't synced yet, skip it (logged) and let a later sync create it once the mirror has the tag — never create a tag via `target`.
- **Drop `target` from the create and update payloads.** For a mirror the tag comes from upstream git, so Gitea attaches the release to the existing tag; `target` is unnecessary and is the thing that triggers the 404 (the documented workaround for the go-gitea/gitea#21681 / forgejo#1196 class).
- **Surface skipped-missing-tag releases** in the summary log.

## Verification (real mirror function on a Forgejo instance)
- Tag present → release created **without** `target` → 201, assets uploaded ✅
- Tag removed (simulating sync lag) → **skipped cleanly**, no 404, no bogus tag, retried next sync ✅
- `bun test src/lib/gitea-releases.test.ts` → 15/15 pass

Note: the underlying *why the tag was momentarily missing* on the reporter's box is still being confirmed via their Forgejo server logs, but this change removes the failure mode regardless (and is the correct behavior for a mirror).