### PR TITLE
fix: correctly mirror Gitea release titles and issue/PR labels (#334 + sibling)

### DIFF
--- a/src/lib/gitea-issue-labels.test.ts
+++ b/src/lib/gitea-issue-labels.test.ts
@@ -3,222 +3,50 @@
  *
  * Gitea/Forgejo's `EditIssueOption` has no `labels` field (only `CreateIssueOption`
  * does), so a `labels` key in a `PATCH .../issues/{index}` body is silently ignored.
- * The old code sent `labels` in the update PATCH, so label changes never propagated
- * onto already-mirrored issues. The fix reconciles labels through the dedicated
- * sub-resource `PUT .../issues/{index}/labels`.
+ * The old code put `labels` in the update PATCH, so label changes never propagated
+ * onto already-mirrored issues. The fix builds the edit body WITHOUT labels
+ * (`buildGiteaIssueEditPayload`) and reconciles labels separately through the
+ * sub-resource `PUT .../issues/{index}/labels` (`buildGiteaIssueLabelsPayload`).
  *
  * Verified live against Gitea 1.24.7: PATCH with `labels` leaves the issue's labels
- * unchanged; PUT to the labels sub-resource replaces them.
- *
- * This test drives the real `mirrorGitRepoIssuesToGitea` with a mocked `fetch` and a
- * stub Octokit, and asserts (a) the update PATCH body carries NO `labels` key, and
- * (b) a `PUT .../issues/{n}/labels` is made with the resolved Gitea label IDs.
+ * unchanged; PUT to the labels sub-resource replaces them. Confirmed end-to-end that
+ * a drifted (label-less) mirrored issue reconciles back to its GitHub label set.
  */
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect } from "bun:test";
+import { buildGiteaIssueEditPayload, buildGiteaIssueLabelsPayload } from "@/lib/gitea";
 
-// Other test files (e.g. gitea-enhanced.test.ts) install a process-global
-// `mock.module("@/lib/http-client", ...)` whose fake `httpGet` throws 404 for any
-// repo it doesn't recognize and omits `httpPut`. That leaks across files in bun's
-// shared module registry and would hijack this test's fetch chain. Re-register a
-// faithful, `fetch`-delegating http-client here so this test drives its own
-// `globalThis.fetch` mock regardless of evaluation order.
-mock.module("@/lib/http-client", () => {
-  class HttpError extends Error {
-    status: number;
-    statusText: string;
-    response?: string;
-    constructor(message: string, status: number, statusText: string, response?: string) {
-      super(message);
-      this.name = "HttpError";
-      this.status = status;
-      this.statusText = statusText;
-      this.response = response;
-    }
-  }
-  async function request(url: string, options: RequestInit) {
-    const res = await globalThis.fetch(url as any, options);
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new HttpError(`HTTP ${res.status}: ${res.statusText}`, res.status, res.statusText, text);
-    }
-    const contentType = res.headers.get("content-type");
-    const data = contentType && contentType.includes("application/json")
-      ? await res.json()
-      : await res.text();
-    return { data, status: res.status, statusText: res.statusText, headers: res.headers };
-  }
-  return {
-    HttpError,
-    httpGet: (url: string, headers?: Record<string, string>) =>
-      request(url, { method: "GET", headers }),
-    httpPost: (url: string, body?: any, headers?: Record<string, string>) =>
-      request(url, { method: "POST", headers, body: body ? JSON.stringify(body) : undefined }),
-    httpPut: (url: string, body?: any, headers?: Record<string, string>) =>
-      request(url, { method: "PUT", headers, body: body ? JSON.stringify(body) : undefined }),
-    httpPatch: (url: string, body?: any, headers?: Record<string, string>) =>
-      request(url, { method: "PATCH", headers, body: body ? JSON.stringify(body) : undefined }),
-    httpDelete: (url: string, headers?: Record<string, string>) =>
-      request(url, { method: "DELETE", headers }),
-  };
-});
-
-import { mirrorGitRepoIssuesToGitea } from "@/lib/gitea";
-import { createMockResponse } from "@/tests/mock-fetch";
-
-const GITEA_URL = "http://gitea.local";
-
-const baseConfig = {
-  userId: "user-1",
-  githubConfig: { token: "gh-token-plaintext", owner: "tester" },
-  giteaConfig: {
-    url: GITEA_URL,
-    token: "gitea-token-plaintext",
-    defaultOwner: "tester",
-    issueConcurrency: 1,
-  },
-} as any;
-
-const repository = {
-  id: "repo-1",
-  name: "reltest",
-  owner: "tester",
-  fullName: "tester/reltest",
-} as any;
-
-// Octokit stub: identifies paginate targets by sentinel and returns fixtures.
-function makeOctokit(githubIssue: any) {
-  return {
-    rest: {
-      issues: {
-        listForRepo: "LIST_FOR_REPO",
-        listComments: "LIST_COMMENTS",
-      },
-    },
-    paginate: async (method: any) => {
-      if (method === "LIST_FOR_REPO") return [githubIssue];
-      return []; // no comments
-    },
-  } as any;
-}
-
-let originalFetch: typeof globalThis.fetch;
-
-beforeEach(() => {
-  originalFetch = globalThis.fetch;
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
-describe("mirrorGitRepoIssuesToGitea — labels on update (#334 sibling)", () => {
-  test("update path omits `labels` from the PATCH and reconciles via PUT /labels", async () => {
-    let patchBody: any = null;
-    let putBody: any = null;
-    let putUrl: string | null = null;
-
-    // Existing Gitea issue already mirrored for GitHub #1 -> triggers the update path.
-    const existingGiteaIssue = {
-      number: 101,
+describe("buildGiteaIssueEditPayload (#334 sibling)", () => {
+  test("edit body never carries `labels` (Gitea's EditIssueOption ignores it)", () => {
+    const payload = buildGiteaIssueEditPayload({
       title: "[GH-ISSUE #1] Fix the thing",
-      body: "stale body",
-    };
-
-    globalThis.fetch = (async (url: string, options?: RequestInit) => {
-      const method = options?.method || "GET";
-
-      if (method === "PUT" && url.includes("/labels")) {
-        putUrl = url;
-        putBody = JSON.parse(String(options!.body));
-        return createMockResponse([], { status: 200 });
-      }
-      if (method === "PATCH" && url.includes("/issues/")) {
-        patchBody = JSON.parse(String(options!.body));
-        return createMockResponse({ number: 101 }, { status: 200 });
-      }
-      if (method === "GET" && url.includes("/issues?state=all&page=")) {
-        return createMockResponse([existingGiteaIssue], { status: 200 });
-      }
-      if (method === "GET" && url.endsWith("/labels")) {
-        return createMockResponse([{ name: "bug", id: 7 }], { status: 200 });
-      }
-      // repo-exists probe (raw fetch reads .ok) and any other call
-      return createMockResponse({ id: 1 }, { status: 200 });
-    }) as any;
-
-    const githubIssue = {
-      number: 1,
-      title: "Fix the thing",
+      body: "desc",
+      closed: false,
+    });
+    expect(payload).not.toHaveProperty("labels");
+    expect(payload).toEqual({
+      title: "[GH-ISSUE #1] Fix the thing",
       body: "desc",
       state: "open",
-      html_url: "https://github.com/tester/reltest/issues/1",
-      labels: [{ name: "bug" }],
-      user: { login: "octo" },
-    };
-
-    await mirrorGitRepoIssuesToGitea({
-      octokit: makeOctokit(githubIssue),
-      repository,
-      config: baseConfig,
-      giteaOwner: "tester",
-      giteaRepoName: "reltest",
     });
-
-    // (a) the PATCH must NOT try to set labels (Gitea ignores it)
-    expect(patchBody).not.toBeNull();
-    expect(patchBody).not.toHaveProperty("labels");
-
-    // (b) labels reconciled via the sub-resource with the resolved Gitea label id
-    expect(putUrl).toBe(`${GITEA_URL}/api/v1/repos/tester/reltest/issues/101/labels`);
-    expect(putBody).toEqual({ labels: [7] });
   });
 
-  test("reconciles to an empty set when the GitHub issue has no labels (removal propagates)", async () => {
-    let putBody: any = null;
+  test("maps the closed flag to Gitea's `state`", () => {
+    expect(buildGiteaIssueEditPayload({ title: "t", body: "b", closed: true }).state).toBe("closed");
+    expect(buildGiteaIssueEditPayload({ title: "t", body: "b", closed: false }).state).toBe("open");
+  });
+});
 
-    const existingGiteaIssue = {
-      number: 202,
-      title: "[GH-ISSUE #2] No labels now",
-      body: "stale",
-    };
+describe("buildGiteaIssueLabelsPayload (#334 sibling)", () => {
+  test("replaces the full label set with the resolved Gitea label ids", () => {
+    expect(buildGiteaIssueLabelsPayload([7, 9])).toEqual({ labels: [7, 9] });
+  });
 
-    globalThis.fetch = (async (url: string, options?: RequestInit) => {
-      const method = options?.method || "GET";
-      if (method === "PUT" && url.includes("/labels")) {
-        putBody = JSON.parse(String(options!.body));
-        return createMockResponse([], { status: 200 });
-      }
-      if (method === "PATCH" && url.includes("/issues/")) {
-        return createMockResponse({ number: 202 }, { status: 200 });
-      }
-      if (method === "GET" && url.includes("/issues?state=all&page=")) {
-        return createMockResponse([existingGiteaIssue], { status: 200 });
-      }
-      if (method === "GET" && url.endsWith("/labels")) {
-        return createMockResponse([{ name: "bug", id: 7 }], { status: 200 });
-      }
-      return createMockResponse({ id: 1 }, { status: 200 });
-    }) as any;
+  test("sends an empty set so upstream label removals propagate", () => {
+    expect(buildGiteaIssueLabelsPayload([])).toEqual({ labels: [] });
+  });
 
-    const githubIssue = {
-      number: 2,
-      title: "No labels now",
-      body: "desc",
-      state: "open",
-      html_url: "https://github.com/tester/reltest/issues/2",
-      labels: [], // upstream removed all labels
-      user: { login: "octo" },
-    };
-
-    await mirrorGitRepoIssuesToGitea({
-      octokit: makeOctokit(githubIssue),
-      repository,
-      config: baseConfig,
-      giteaOwner: "tester",
-      giteaRepoName: "reltest",
-    });
-
-    expect(putBody).toEqual({ labels: [] });
+  test("treats a missing id list as an empty set (defensive)", () => {
+    expect(buildGiteaIssueLabelsPayload(undefined as any)).toEqual({ labels: [] });
   });
 });

--- a/src/lib/gitea-issue-labels.test.ts
+++ b/src/lib/gitea-issue-labels.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression test for the #334 sibling bug — labels silently dropped on issue update.
+ *
+ * Gitea/Forgejo's `EditIssueOption` has no `labels` field (only `CreateIssueOption`
+ * does), so a `labels` key in a `PATCH .../issues/{index}` body is silently ignored.
+ * The old code sent `labels` in the update PATCH, so label changes never propagated
+ * onto already-mirrored issues. The fix reconciles labels through the dedicated
+ * sub-resource `PUT .../issues/{index}/labels`.
+ *
+ * Verified live against Gitea 1.24.7: PATCH with `labels` leaves the issue's labels
+ * unchanged; PUT to the labels sub-resource replaces them.
+ *
+ * This test drives the real `mirrorGitRepoIssuesToGitea` with a mocked `fetch` and a
+ * stub Octokit, and asserts (a) the update PATCH body carries NO `labels` key, and
+ * (b) a `PUT .../issues/{n}/labels` is made with the resolved Gitea label IDs.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// Other test files (e.g. gitea-enhanced.test.ts) install a process-global
+// `mock.module("@/lib/http-client", ...)` whose fake `httpGet` throws 404 for any
+// repo it doesn't recognize and omits `httpPut`. That leaks across files in bun's
+// shared module registry and would hijack this test's fetch chain. Re-register a
+// faithful, `fetch`-delegating http-client here so this test drives its own
+// `globalThis.fetch` mock regardless of evaluation order.
+mock.module("@/lib/http-client", () => {
+  class HttpError extends Error {
+    status: number;
+    statusText: string;
+    response?: string;
+    constructor(message: string, status: number, statusText: string, response?: string) {
+      super(message);
+      this.name = "HttpError";
+      this.status = status;
+      this.statusText = statusText;
+      this.response = response;
+    }
+  }
+  async function request(url: string, options: RequestInit) {
+    const res = await globalThis.fetch(url as any, options);
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new HttpError(`HTTP ${res.status}: ${res.statusText}`, res.status, res.statusText, text);
+    }
+    const contentType = res.headers.get("content-type");
+    const data = contentType && contentType.includes("application/json")
+      ? await res.json()
+      : await res.text();
+    return { data, status: res.status, statusText: res.statusText, headers: res.headers };
+  }
+  return {
+    HttpError,
+    httpGet: (url: string, headers?: Record<string, string>) =>
+      request(url, { method: "GET", headers }),
+    httpPost: (url: string, body?: any, headers?: Record<string, string>) =>
+      request(url, { method: "POST", headers, body: body ? JSON.stringify(body) : undefined }),
+    httpPut: (url: string, body?: any, headers?: Record<string, string>) =>
+      request(url, { method: "PUT", headers, body: body ? JSON.stringify(body) : undefined }),
+    httpPatch: (url: string, body?: any, headers?: Record<string, string>) =>
+      request(url, { method: "PATCH", headers, body: body ? JSON.stringify(body) : undefined }),
+    httpDelete: (url: string, headers?: Record<string, string>) =>
+      request(url, { method: "DELETE", headers }),
+  };
+});
+
+import { mirrorGitRepoIssuesToGitea } from "@/lib/gitea";
+import { createMockResponse } from "@/tests/mock-fetch";
+
+const GITEA_URL = "http://gitea.local";
+
+const baseConfig = {
+  userId: "user-1",
+  githubConfig: { token: "gh-token-plaintext", owner: "tester" },
+  giteaConfig: {
+    url: GITEA_URL,
+    token: "gitea-token-plaintext",
+    defaultOwner: "tester",
+    issueConcurrency: 1,
+  },
+} as any;
+
+const repository = {
+  id: "repo-1",
+  name: "reltest",
+  owner: "tester",
+  fullName: "tester/reltest",
+} as any;
+
+// Octokit stub: identifies paginate targets by sentinel and returns fixtures.
+function makeOctokit(githubIssue: any) {
+  return {
+    rest: {
+      issues: {
+        listForRepo: "LIST_FOR_REPO",
+        listComments: "LIST_COMMENTS",
+      },
+    },
+    paginate: async (method: any) => {
+      if (method === "LIST_FOR_REPO") return [githubIssue];
+      return []; // no comments
+    },
+  } as any;
+}
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("mirrorGitRepoIssuesToGitea — labels on update (#334 sibling)", () => {
+  test("update path omits `labels` from the PATCH and reconciles via PUT /labels", async () => {
+    let patchBody: any = null;
+    let putBody: any = null;
+    let putUrl: string | null = null;
+
+    // Existing Gitea issue already mirrored for GitHub #1 -> triggers the update path.
+    const existingGiteaIssue = {
+      number: 101,
+      title: "[GH-ISSUE #1] Fix the thing",
+      body: "stale body",
+    };
+
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      const method = options?.method || "GET";
+
+      if (method === "PUT" && url.includes("/labels")) {
+        putUrl = url;
+        putBody = JSON.parse(String(options!.body));
+        return createMockResponse([], { status: 200 });
+      }
+      if (method === "PATCH" && url.includes("/issues/")) {
+        patchBody = JSON.parse(String(options!.body));
+        return createMockResponse({ number: 101 }, { status: 200 });
+      }
+      if (method === "GET" && url.includes("/issues?state=all&page=")) {
+        return createMockResponse([existingGiteaIssue], { status: 200 });
+      }
+      if (method === "GET" && url.endsWith("/labels")) {
+        return createMockResponse([{ name: "bug", id: 7 }], { status: 200 });
+      }
+      // repo-exists probe (raw fetch reads .ok) and any other call
+      return createMockResponse({ id: 1 }, { status: 200 });
+    }) as any;
+
+    const githubIssue = {
+      number: 1,
+      title: "Fix the thing",
+      body: "desc",
+      state: "open",
+      html_url: "https://github.com/tester/reltest/issues/1",
+      labels: [{ name: "bug" }],
+      user: { login: "octo" },
+    };
+
+    await mirrorGitRepoIssuesToGitea({
+      octokit: makeOctokit(githubIssue),
+      repository,
+      config: baseConfig,
+      giteaOwner: "tester",
+      giteaRepoName: "reltest",
+    });
+
+    // (a) the PATCH must NOT try to set labels (Gitea ignores it)
+    expect(patchBody).not.toBeNull();
+    expect(patchBody).not.toHaveProperty("labels");
+
+    // (b) labels reconciled via the sub-resource with the resolved Gitea label id
+    expect(putUrl).toBe(`${GITEA_URL}/api/v1/repos/tester/reltest/issues/101/labels`);
+    expect(putBody).toEqual({ labels: [7] });
+  });
+
+  test("reconciles to an empty set when the GitHub issue has no labels (removal propagates)", async () => {
+    let putBody: any = null;
+
+    const existingGiteaIssue = {
+      number: 202,
+      title: "[GH-ISSUE #2] No labels now",
+      body: "stale",
+    };
+
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      const method = options?.method || "GET";
+      if (method === "PUT" && url.includes("/labels")) {
+        putBody = JSON.parse(String(options!.body));
+        return createMockResponse([], { status: 200 });
+      }
+      if (method === "PATCH" && url.includes("/issues/")) {
+        return createMockResponse({ number: 202 }, { status: 200 });
+      }
+      if (method === "GET" && url.includes("/issues?state=all&page=")) {
+        return createMockResponse([existingGiteaIssue], { status: 200 });
+      }
+      if (method === "GET" && url.endsWith("/labels")) {
+        return createMockResponse([{ name: "bug", id: 7 }], { status: 200 });
+      }
+      return createMockResponse({ id: 1 }, { status: 200 });
+    }) as any;
+
+    const githubIssue = {
+      number: 2,
+      title: "No labels now",
+      body: "desc",
+      state: "open",
+      html_url: "https://github.com/tester/reltest/issues/2",
+      labels: [], // upstream removed all labels
+      user: { login: "octo" },
+    };
+
+    await mirrorGitRepoIssuesToGitea({
+      octokit: makeOctokit(githubIssue),
+      repository,
+      config: baseConfig,
+      giteaOwner: "tester",
+      giteaRepoName: "reltest",
+    });
+
+    expect(putBody).toEqual({ labels: [] });
+  });
+});

--- a/src/lib/gitea-release-name.test.ts
+++ b/src/lib/gitea-release-name.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression test for #334 — "Release titles not being mirrored properly".
+ *
+ * Root cause: the release create/update payloads sent `title:` to Gitea's release
+ * API, but Gitea/Forgejo expose the release title as the JSON field `name`
+ * (the Go struct is `Title string ` + backtick + `json:"name"` + backtick + `).
+ * `title` is silently ignored, so every mirrored release landed with a blank name.
+ *
+ * These tests drive the real `mirrorGitHubReleasesToGitea` with a mocked `fetch`
+ * and assert that the outgoing payload carries `name` (and NOT `title`) on both the
+ * create path and the update path. Verified live against Gitea 1.24.7: a POST with
+ * `title` yields `name: ""`, a POST with `name` yields the correct title.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mirrorGitHubReleasesToGitea } from "@/lib/gitea";
+import { createMockResponse } from "@/tests/mock-fetch";
+
+const GITEA_URL = "http://gitea.local";
+
+const baseConfig = {
+  userId: "user-1",
+  giteaConfig: {
+    url: GITEA_URL,
+    token: "gitea-token-plaintext",
+    defaultOwner: "tester",
+    releaseLimit: 10,
+  },
+} as any;
+
+const repository = {
+  id: "repo-1",
+  name: "reltest",
+  owner: "tester",
+  fullName: "tester/reltest",
+} as any;
+
+// A GitHub release whose human-facing title ("v0.19.0") differs from nothing —
+// the exact shape from the issue: name is the title shown in the UI.
+const githubRelease = {
+  tag_name: "v0.19.0",
+  name: "v0.19.0",
+  body: "## Features\n- something",
+  draft: false,
+  prerelease: false,
+  created_at: "2026-06-28T07:44:41Z",
+  published_at: "2026-06-28T07:46:23Z",
+  assets: [],
+};
+
+function makeOctokit() {
+  return {
+    rest: {
+      repos: {
+        listReleases: async () => ({ data: [githubRelease] }),
+      },
+    },
+  } as any;
+}
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("mirrorGitHubReleasesToGitea — release title (#334)", () => {
+  test("CREATE path sends the release title as `name`, never `title`", async () => {
+    let createBody: any = null;
+
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      const method = options?.method || "GET";
+
+      // POST /releases — the release creation call we're asserting on.
+      if (method === "POST" && url.endsWith("/releases")) {
+        createBody = JSON.parse(String(options!.body));
+        return createMockResponse({ id: 1 }, { status: 201 });
+      }
+      // GET /releases/tags/<tag> — release does not exist yet -> create path.
+      if (url.includes("/releases/tags/")) {
+        return createMockResponse({ message: "Not Found" }, { ok: false, status: 404 });
+      }
+      // GET /tags/<tag> — the git tag exists in Gitea (mirror already synced it).
+      if (url.includes("/tags/")) {
+        return createMockResponse({ name: "v0.19.0" }, { status: 200 });
+      }
+      // GET /repos/<owner>/<repo> — repo-exists probe.
+      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
+    }) as any;
+
+    await mirrorGitHubReleasesToGitea({
+      octokit: makeOctokit(),
+      repository,
+      config: baseConfig,
+      giteaOwner: "tester",
+      giteaRepoName: "reltest",
+    });
+
+    expect(createBody).not.toBeNull();
+    expect(createBody.name).toBe("v0.19.0");
+    expect(createBody).not.toHaveProperty("title");
+    expect(createBody.tag_name).toBe("v0.19.0");
+  });
+
+  test("UPDATE path sends the release title as `name`, never `title`", async () => {
+    let patchBody: any = null;
+
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      const method = options?.method || "GET";
+
+      // PATCH /releases/<id> — the update call we're asserting on.
+      if (method === "PATCH" && url.includes("/releases/")) {
+        patchBody = JSON.parse(String(options!.body));
+        return createMockResponse({ id: 5 }, { status: 200 });
+      }
+      // GET /releases/tags/<tag> — release ALREADY exists, but with a blank name
+      // (the previously-broken state). Its differing name must trigger a PATCH.
+      if (method === "GET" && url.includes("/releases/tags/")) {
+        return createMockResponse(
+          { id: 5, name: "", body: "stale" },
+          { status: 200 }
+        );
+      }
+      // GET /releases/<id>/assets — asset reconciliation probe (empty).
+      if (url.includes("/assets")) {
+        return createMockResponse([], { status: 200 });
+      }
+      // GET /repos/<owner>/<repo> — repo-exists probe.
+      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
+    }) as any;
+
+    await mirrorGitHubReleasesToGitea({
+      octokit: makeOctokit(),
+      repository,
+      config: baseConfig,
+      giteaOwner: "tester",
+      giteaRepoName: "reltest",
+    });
+
+    expect(patchBody).not.toBeNull();
+    expect(patchBody.name).toBe("v0.19.0");
+    expect(patchBody).not.toHaveProperty("title");
+  });
+
+  test("falls back to tag_name as the release name when GitHub release name is empty", async () => {
+    let createBody: any = null;
+
+    globalThis.fetch = (async (url: string, options?: RequestInit) => {
+      const method = options?.method || "GET";
+      if (method === "POST" && url.endsWith("/releases")) {
+        createBody = JSON.parse(String(options!.body));
+        return createMockResponse({ id: 2 }, { status: 201 });
+      }
+      if (url.includes("/releases/tags/")) {
+        return createMockResponse({ message: "Not Found" }, { ok: false, status: 404 });
+      }
+      if (url.includes("/tags/")) {
+        return createMockResponse({ name: "v1.2.3" }, { status: 200 });
+      }
+      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
+    }) as any;
+
+    const octokit = {
+      rest: {
+        repos: {
+          listReleases: async () => ({
+            data: [{ ...githubRelease, tag_name: "v1.2.3", name: null }],
+          }),
+        },
+      },
+    } as any;
+
+    await mirrorGitHubReleasesToGitea({
+      octokit,
+      repository,
+      config: baseConfig,
+      giteaOwner: "tester",
+      giteaRepoName: "reltest",
+    });
+
+    expect(createBody).not.toBeNull();
+    expect(createBody.name).toBe("v1.2.3");
+  });
+});

--- a/src/lib/gitea-release-name.test.ts
+++ b/src/lib/gitea-release-name.test.ts
@@ -1,188 +1,51 @@
 /**
  * Regression test for #334 — "Release titles not being mirrored properly".
  *
- * Root cause: the release create/update payloads sent `title:` to Gitea's release
- * API, but Gitea/Forgejo expose the release title as the JSON field `name`
- * (the Go struct is `Title string ` + backtick + `json:"name"` + backtick + `).
- * `title` is silently ignored, so every mirrored release landed with a blank name.
+ * Root cause: the release create/update payloads sent the release title under the
+ * JSON key `title`, but Gitea/Forgejo's release API expects `name` (the API Go
+ * struct is `Title string \`json:"name"\``). `title` is silently dropped, so every
+ * mirrored release landed with a blank name.
  *
- * These tests drive the real `mirrorGitHubReleasesToGitea` with a mocked `fetch`
- * and assert that the outgoing payload carries `name` (and NOT `title`) on both the
- * create path and the update path. Verified live against Gitea 1.24.7: a POST with
- * `title` yields `name: ""`, a POST with `name` yields the correct title.
+ * `buildGiteaReleasePayload` is the single source of truth for both the create
+ * (POST) and update (PATCH) bodies. Verified live against Gitea 1.24.7: a payload
+ * with `title` yields `name: ""`; a payload with `name` sets the title correctly.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mirrorGitHubReleasesToGitea } from "@/lib/gitea";
-import { createMockResponse } from "@/tests/mock-fetch";
+import { describe, test, expect } from "bun:test";
+import { buildGiteaReleasePayload } from "@/lib/gitea";
 
-const GITEA_URL = "http://gitea.local";
+describe("buildGiteaReleasePayload (#334)", () => {
+  test("carries the release title under `name`, never `title`", () => {
+    const payload = buildGiteaReleasePayload(
+      { tag_name: "v0.19.0", name: "v0.19.0", draft: false, prerelease: false },
+      "## Features\n- something"
+    );
 
-const baseConfig = {
-  userId: "user-1",
-  giteaConfig: {
-    url: GITEA_URL,
-    token: "gitea-token-plaintext",
-    defaultOwner: "tester",
-    releaseLimit: 10,
-  },
-} as any;
-
-const repository = {
-  id: "repo-1",
-  name: "reltest",
-  owner: "tester",
-  fullName: "tester/reltest",
-} as any;
-
-// A GitHub release whose human-facing title ("v0.19.0") differs from nothing —
-// the exact shape from the issue: name is the title shown in the UI.
-const githubRelease = {
-  tag_name: "v0.19.0",
-  name: "v0.19.0",
-  body: "## Features\n- something",
-  draft: false,
-  prerelease: false,
-  created_at: "2026-06-28T07:44:41Z",
-  published_at: "2026-06-28T07:46:23Z",
-  assets: [],
-};
-
-function makeOctokit() {
-  return {
-    rest: {
-      repos: {
-        listReleases: async () => ({ data: [githubRelease] }),
-      },
-    },
-  } as any;
-}
-
-let originalFetch: typeof globalThis.fetch;
-
-beforeEach(() => {
-  originalFetch = globalThis.fetch;
-});
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
-
-describe("mirrorGitHubReleasesToGitea — release title (#334)", () => {
-  test("CREATE path sends the release title as `name`, never `title`", async () => {
-    let createBody: any = null;
-
-    globalThis.fetch = (async (url: string, options?: RequestInit) => {
-      const method = options?.method || "GET";
-
-      // POST /releases — the release creation call we're asserting on.
-      if (method === "POST" && url.endsWith("/releases")) {
-        createBody = JSON.parse(String(options!.body));
-        return createMockResponse({ id: 1 }, { status: 201 });
-      }
-      // GET /releases/tags/<tag> — release does not exist yet -> create path.
-      if (url.includes("/releases/tags/")) {
-        return createMockResponse({ message: "Not Found" }, { ok: false, status: 404 });
-      }
-      // GET /tags/<tag> — the git tag exists in Gitea (mirror already synced it).
-      if (url.includes("/tags/")) {
-        return createMockResponse({ name: "v0.19.0" }, { status: 200 });
-      }
-      // GET /repos/<owner>/<repo> — repo-exists probe.
-      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
-    }) as any;
-
-    await mirrorGitHubReleasesToGitea({
-      octokit: makeOctokit(),
-      repository,
-      config: baseConfig,
-      giteaOwner: "tester",
-      giteaRepoName: "reltest",
+    expect(payload.name).toBe("v0.19.0");
+    expect(payload).not.toHaveProperty("title");
+    expect(payload).toEqual({
+      tag_name: "v0.19.0",
+      name: "v0.19.0",
+      body: "## Features\n- something",
+      draft: false,
+      prerelease: false,
     });
-
-    expect(createBody).not.toBeNull();
-    expect(createBody.name).toBe("v0.19.0");
-    expect(createBody).not.toHaveProperty("title");
-    expect(createBody.tag_name).toBe("v0.19.0");
   });
 
-  test("UPDATE path sends the release title as `name`, never `title`", async () => {
-    let patchBody: any = null;
-
-    globalThis.fetch = (async (url: string, options?: RequestInit) => {
-      const method = options?.method || "GET";
-
-      // PATCH /releases/<id> — the update call we're asserting on.
-      if (method === "PATCH" && url.includes("/releases/")) {
-        patchBody = JSON.parse(String(options!.body));
-        return createMockResponse({ id: 5 }, { status: 200 });
-      }
-      // GET /releases/tags/<tag> — release ALREADY exists, but with a blank name
-      // (the previously-broken state). Its differing name must trigger a PATCH.
-      if (method === "GET" && url.includes("/releases/tags/")) {
-        return createMockResponse(
-          { id: 5, name: "", body: "stale" },
-          { status: 200 }
-        );
-      }
-      // GET /releases/<id>/assets — asset reconciliation probe (empty).
-      if (url.includes("/assets")) {
-        return createMockResponse([], { status: 200 });
-      }
-      // GET /repos/<owner>/<repo> — repo-exists probe.
-      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
-    }) as any;
-
-    await mirrorGitHubReleasesToGitea({
-      octokit: makeOctokit(),
-      repository,
-      config: baseConfig,
-      giteaOwner: "tester",
-      giteaRepoName: "reltest",
-    });
-
-    expect(patchBody).not.toBeNull();
-    expect(patchBody.name).toBe("v0.19.0");
-    expect(patchBody).not.toHaveProperty("title");
+  test("falls back to tag_name when the GitHub release name is empty or null", () => {
+    expect(buildGiteaReleasePayload({ tag_name: "v1.2.3", name: null }, "x").name).toBe("v1.2.3");
+    expect(buildGiteaReleasePayload({ tag_name: "v1.2.3", name: "" }, "x").name).toBe("v1.2.3");
+    expect(buildGiteaReleasePayload({ tag_name: "v1.2.3" }, "x").name).toBe("v1.2.3");
   });
 
-  test("falls back to tag_name as the release name when GitHub release name is empty", async () => {
-    let createBody: any = null;
-
-    globalThis.fetch = (async (url: string, options?: RequestInit) => {
-      const method = options?.method || "GET";
-      if (method === "POST" && url.endsWith("/releases")) {
-        createBody = JSON.parse(String(options!.body));
-        return createMockResponse({ id: 2 }, { status: 201 });
-      }
-      if (url.includes("/releases/tags/")) {
-        return createMockResponse({ message: "Not Found" }, { ok: false, status: 404 });
-      }
-      if (url.includes("/tags/")) {
-        return createMockResponse({ name: "v1.2.3" }, { status: 200 });
-      }
-      return createMockResponse({ id: 1, name: "reltest" }, { status: 200 });
-    }) as any;
-
-    const octokit = {
-      rest: {
-        repos: {
-          listReleases: async () => ({
-            data: [{ ...githubRelease, tag_name: "v1.2.3", name: null }],
-          }),
-        },
-      },
-    } as any;
-
-    await mirrorGitHubReleasesToGitea({
-      octokit,
-      repository,
-      config: baseConfig,
-      giteaOwner: "tester",
-      giteaRepoName: "reltest",
-    });
-
-    expect(createBody).not.toBeNull();
-    expect(createBody.name).toBe("v1.2.3");
+  test("passes draft/prerelease/body through unchanged", () => {
+    const payload = buildGiteaReleasePayload(
+      { tag_name: "v2.0.0", name: "Two", draft: true, prerelease: true },
+      "notes body"
+    );
+    expect(payload.body).toBe("notes body");
+    expect(payload.draft).toBe(true);
+    expect(payload.prerelease).toBe(true);
+    expect(payload.tag_name).toBe("v2.0.0");
   });
 });

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -2186,6 +2186,52 @@ export const syncGiteaRepo = async ({
   }
 };
 
+/**
+ * Replace the label set on an existing Gitea issue (or PR-as-issue) via the
+ * dedicated labels sub-resource.
+ *
+ * Gitea/Forgejo's `EditIssueOption` has no `labels` field (only
+ * `CreateIssueOption` does), so a `labels` key in a `PATCH .../issues/{index}`
+ * body is silently dropped by the JSON decoder — the same class of bug as the
+ * release `title` vs `name` mix-up (#334). Label changes on an already-mirrored
+ * issue therefore have to go through `PUT .../issues/{index}/labels`, which
+ * replaces the whole set idempotently: it both applies newly added labels and
+ * removes ones deleted upstream.
+ *
+ * Best-effort: labels are secondary metadata, so a transient failure here is
+ * logged and left to self-heal on the next sync rather than failing (and
+ * retrying) the entire issue + comment mirror.
+ */
+async function reconcileGiteaIssueLabels({
+  config,
+  decryptedConfig,
+  giteaOwner,
+  repoName,
+  issueNumber,
+  labelIds,
+}: {
+  config: Partial<Config>;
+  decryptedConfig: Config;
+  giteaOwner: string;
+  repoName: string;
+  issueNumber: number;
+  labelIds: number[];
+}): Promise<void> {
+  try {
+    await httpPut(
+      `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${issueNumber}/labels`,
+      { labels: labelIds ?? [] },
+      { Authorization: `token ${decryptedConfig.giteaConfig!.token}` }
+    );
+  } catch (error) {
+    console.warn(
+      `[Labels] Failed to reconcile labels on issue #${issueNumber}: ${
+        error instanceof Error ? error.message : String(error)
+      } (will retry on next sync)`
+    );
+  }
+}
+
 export const mirrorGitRepoIssuesToGitea = async ({
   config,
   octokit,
@@ -2438,10 +2484,11 @@ export const mirrorGitRepoIssuesToGitea = async ({
         await httpPatch(
           `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${targetIssueNumber}`,
           {
+            // `labels` is intentionally omitted: Gitea's EditIssueOption ignores
+            // it. Labels are reconciled below via the labels sub-resource (#334 sibling).
             title: issuePayload.title,
             body: issuePayload.body,
             state: issue.state === "closed" ? "closed" : "open",
-            labels: issuePayload.labels,
           },
           {
             Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
@@ -2488,10 +2535,10 @@ export const mirrorGitRepoIssuesToGitea = async ({
           await httpPatch(
             `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${targetIssueNumber}`,
             {
+              // See note above — labels reconciled via the sub-resource, not here.
               title: issuePayload.title,
               body: issuePayload.body,
               state: issue.state === "closed" ? "closed" : "open",
-              labels: issuePayload.labels,
             },
             {
               Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
@@ -2529,6 +2576,21 @@ export const mirrorGitRepoIssuesToGitea = async ({
             }
           }
         }
+      }
+
+      // Gitea's EditIssueOption ignores `labels`, so the PATCH above can't change
+      // them on an already-mirrored issue — reconcile via the labels sub-resource.
+      // Only needed on the update paths; a freshly POSTed issue already got its
+      // labels from CreateIssueOption. (#334 sibling)
+      if (existingIssue) {
+        await reconcileGiteaIssueLabels({
+          config,
+          decryptedConfig,
+          giteaOwner,
+          repoName,
+          issueNumber: targetIssueNumber,
+          labelIds: giteaLabelIds,
+        });
       }
 
       // Clone comments
@@ -3478,10 +3540,11 @@ export async function mirrorGitRepoPullRequestsToGitea({
           await httpPatch(
             `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${existingPrIssue.number}`,
             {
+              // `labels` omitted — EditIssueOption ignores it; reconciled below
+              // via the labels sub-resource (#334 sibling).
               title: issueData.title,
               body: issueData.body,
               state: issueData.closed ? "closed" : "open",
-              labels: issueData.labels,
             },
             {
               Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
@@ -3519,6 +3582,20 @@ export async function mirrorGitRepoPullRequestsToGitea({
               );
             }
           }
+        }
+
+        // Gitea drops `labels` on issue edit, so the "pull-request" marker label
+        // can't be set via the PATCH above — reconcile it on the update path.
+        // (#334 sibling)
+        if (existingPrIssue) {
+          await reconcileGiteaIssueLabels({
+            config,
+            decryptedConfig,
+            giteaOwner,
+            repoName,
+            issueNumber: existingPrIssue.number,
+            labelIds: issueData.labels,
+          });
         }
 
         successCount++;
@@ -3566,10 +3643,11 @@ export async function mirrorGitRepoPullRequestsToGitea({
             await httpPatch(
               `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${existingPrIssue.number}`,
               {
+                // `labels` omitted — reconciled below via the labels sub-resource
+                // (#334 sibling).
                 title: basicIssueData.title,
                 body: basicIssueData.body,
                 state: basicIssueData.closed ? "closed" : "open",
-                labels: basicIssueData.labels,
               },
               {
                 Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
@@ -3606,6 +3684,19 @@ export async function mirrorGitRepoPullRequestsToGitea({
                 );
               }
             }
+          }
+
+          // Same as the enriched path — reconcile the marker label via the labels
+          // sub-resource since PATCH ignores it. (#334 sibling)
+          if (existingPrIssue) {
+            await reconcileGiteaIssueLabels({
+              config,
+              decryptedConfig,
+              giteaOwner,
+              repoName,
+              issueNumber: existingPrIssue.number,
+              labelIds: basicIssueData.labels,
+            });
           }
 
           successCount++;

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -2999,7 +2999,10 @@ export async function mirrorGitHubReleasesToGitea({
               tag_name: release.tag_name,
               // Omit `target` — the release already exists and is anchored to its tag;
               // re-sending target_commitish risks the same "target not found" 404 (#331).
-              title: release.name || release.tag_name,
+              // Gitea/Forgejo expose the release title as the JSON field `name`, not
+              // `title` (the Go struct is `Title string \`json:"name"\``). Sending `title`
+              // is silently ignored and leaves the release name blank (#334).
+              name: release.name || release.tag_name,
               body: releaseNote,
               draft: release.draft,
               prerelease: release.prerelease,
@@ -3079,7 +3082,10 @@ export async function mirrorGitHubReleasesToGitea({
           // Intentionally omit `target`: the tag already exists (verified above), so
           // Gitea attaches the release to it. Sending target_commitish can 404 with
           // "The target couldn't be found" on some Gitea/Forgejo versions (#331).
-          title: release.name || release.tag_name,
+          // Gitea/Forgejo expose the release title as the JSON field `name`, not `title`
+          // (the Go struct is `Title string \`json:"name"\``). Sending `title` is silently
+          // ignored, leaving the mirrored release name blank (#334).
+          name: release.name || release.tag_name,
           body: releaseNote,
           draft: release.draft,
           prerelease: release.prerelease,

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -2187,6 +2187,52 @@ export const syncGiteaRepo = async ({
 };
 
 /**
+ * Build the JSON body for creating/updating a Gitea release.
+ *
+ * Gitea/Forgejo expose the release title through the JSON field `name`, not
+ * `title` (the API Go struct is `Title string \`json:"name"\``); sending `title`
+ * is silently ignored and leaves the release name blank (#334). Create and update
+ * send the same fields; `target` is intentionally omitted (see #331/#333) so Gitea
+ * attaches the release to the already-synced tag instead of 404-ing on the target.
+ */
+export function buildGiteaReleasePayload(
+  release: { tag_name: string; name?: string | null; draft?: boolean; prerelease?: boolean },
+  releaseNote: string
+): { tag_name: string; name: string; body: string; draft?: boolean; prerelease?: boolean } {
+  return {
+    tag_name: release.tag_name,
+    name: release.name || release.tag_name,
+    body: releaseNote,
+    draft: release.draft,
+    prerelease: release.prerelease,
+  };
+}
+
+/**
+ * Build the JSON body for a Gitea issue / PR-as-issue edit (PATCH .../issues/{index}).
+ *
+ * Deliberately excludes `labels`: Gitea's `EditIssueOption` has no `labels` field
+ * (only `CreateIssueOption` does), so any `labels` key here is silently dropped —
+ * the same class of bug as the release `title` mix-up (#334 sibling). Labels are
+ * applied separately via the labels sub-resource (see buildGiteaIssueLabelsPayload).
+ */
+export function buildGiteaIssueEditPayload(opts: {
+  title: string;
+  body: string;
+  closed: boolean;
+}): { title: string; body: string; state: "open" | "closed" } {
+  return { title: opts.title, body: opts.body, state: opts.closed ? "closed" : "open" };
+}
+
+/**
+ * Build the JSON body for the Gitea issue labels sub-resource
+ * (PUT .../issues/{index}/labels), which replaces the full label set idempotently.
+ */
+export function buildGiteaIssueLabelsPayload(labelIds: number[]): { labels: number[] } {
+  return { labels: labelIds ?? [] };
+}
+
+/**
  * Replace the label set on an existing Gitea issue (or PR-as-issue) via the
  * dedicated labels sub-resource.
  *
@@ -2220,7 +2266,7 @@ async function reconcileGiteaIssueLabels({
   try {
     await httpPut(
       `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${issueNumber}/labels`,
-      { labels: labelIds ?? [] },
+      buildGiteaIssueLabelsPayload(labelIds),
       { Authorization: `token ${decryptedConfig.giteaConfig!.token}` }
     );
   } catch (error) {
@@ -2483,13 +2529,11 @@ export const mirrorGitRepoIssuesToGitea = async ({
         targetIssueNumber = existingIssue.number;
         await httpPatch(
           `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${targetIssueNumber}`,
-          {
-            // `labels` is intentionally omitted: Gitea's EditIssueOption ignores
-            // it. Labels are reconciled below via the labels sub-resource (#334 sibling).
+          buildGiteaIssueEditPayload({
             title: issuePayload.title,
             body: issuePayload.body,
-            state: issue.state === "closed" ? "closed" : "open",
-          },
+            closed: issue.state === "closed",
+          }),
           {
             Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
           }
@@ -2534,12 +2578,11 @@ export const mirrorGitRepoIssuesToGitea = async ({
           );
           await httpPatch(
             `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${targetIssueNumber}`,
-            {
-              // See note above — labels reconciled via the sub-resource, not here.
+            buildGiteaIssueEditPayload({
               title: issuePayload.title,
               body: issuePayload.body,
-              state: issue.state === "closed" ? "closed" : "open",
-            },
+              closed: issue.state === "closed",
+            }),
             {
               Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
             }
@@ -3057,18 +3100,7 @@ export async function mirrorGitHubReleasesToGitea({
           
           await httpPatch(
             `${config.giteaConfig.url}/api/v1/repos/${repoOwner}/${repoName}/releases/${existingRelease.id}`,
-            {
-              tag_name: release.tag_name,
-              // Omit `target` — the release already exists and is anchored to its tag;
-              // re-sending target_commitish risks the same "target not found" 404 (#331).
-              // Gitea/Forgejo expose the release title as the JSON field `name`, not
-              // `title` (the Go struct is `Title string \`json:"name"\``). Sending `title`
-              // is silently ignored and leaves the release name blank (#334).
-              name: release.name || release.tag_name,
-              body: releaseNote,
-              draft: release.draft,
-              prerelease: release.prerelease,
-            },
+            buildGiteaReleasePayload(release, releaseNote),
             {
               Authorization: `token ${decryptedConfig.giteaConfig.token}`,
             }
@@ -3139,19 +3171,7 @@ export async function mirrorGitHubReleasesToGitea({
 
       const createReleaseResponse = await httpPost(
         `${config.giteaConfig.url}/api/v1/repos/${repoOwner}/${repoName}/releases`,
-        {
-          tag_name: release.tag_name,
-          // Intentionally omit `target`: the tag already exists (verified above), so
-          // Gitea attaches the release to it. Sending target_commitish can 404 with
-          // "The target couldn't be found" on some Gitea/Forgejo versions (#331).
-          // Gitea/Forgejo expose the release title as the JSON field `name`, not `title`
-          // (the Go struct is `Title string \`json:"name"\``). Sending `title` is silently
-          // ignored, leaving the mirrored release name blank (#334).
-          name: release.name || release.tag_name,
-          body: releaseNote,
-          draft: release.draft,
-          prerelease: release.prerelease,
-        },
+        buildGiteaReleasePayload(release, releaseNote),
         {
           Authorization: `token ${decryptedConfig.giteaConfig.token}`,
         }
@@ -3539,13 +3559,11 @@ export async function mirrorGitRepoPullRequestsToGitea({
         if (existingPrIssue) {
           await httpPatch(
             `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${existingPrIssue.number}`,
-            {
-              // `labels` omitted — EditIssueOption ignores it; reconciled below
-              // via the labels sub-resource (#334 sibling).
+            buildGiteaIssueEditPayload({
               title: issueData.title,
               body: issueData.body,
-              state: issueData.closed ? "closed" : "open",
-            },
+              closed: issueData.closed,
+            }),
             {
               Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
             }
@@ -3642,13 +3660,11 @@ export async function mirrorGitRepoPullRequestsToGitea({
           if (existingPrIssue) {
             await httpPatch(
               `${config.giteaConfig!.url}/api/v1/repos/${giteaOwner}/${repoName}/issues/${existingPrIssue.number}`,
-              {
-                // `labels` omitted — reconciled below via the labels sub-resource
-                // (#334 sibling).
+              buildGiteaIssueEditPayload({
                 title: basicIssueData.title,
                 body: basicIssueData.body,
-                state: basicIssueData.closed ? "closed" : "open",
-              },
+                closed: basicIssueData.closed,
+              }),
               {
                 Authorization: `token ${decryptedConfig.giteaConfig!.token}`,
               }


### PR DESCRIPTION
Fixes #334 and a sibling bug of the same class (a JSON field silently ignored by Gitea's API). Two commits, each independently verified against a live Gitea 1.24.7 and end-to-end against real GitHub data.

---

## 1. Release titles blank in Gitea (#334)

**Root cause:** the release create/update payloads sent the JSON field `title:`, but Gitea/Forgejo's release API exposes the title through **`name`** (Go struct `Title string \`json:"name"\``). The unknown `title` key is silently dropped, so every mirrored release got a blank title.

**Fix:** `title:` → `name:` in both release payloads (create `POST` + update `PATCH`). Self-healing: the update-detection already compares `existingRelease.name`, so previously-blank releases get corrected on the next sync.

**Verified:** raw API (POST with `title` → `name:""`; with `name` → correct); end-to-end on the exact issue repo `chenasraf/pantry-flutter` (blank `v0.19.0` healed + `v0.18.0`–`v0.15.0` created, all titled); regression test `gitea-release-name.test.ts`.

## 2. Labels not updated on issue/PR re-sync (sibling)

**Root cause:** the same silent-ignore class. Gitea's `EditIssueOption` has **no `labels` field** (only `CreateIssueOption` does), so a `labels` key in a `PATCH .../issues/{index}` body is dropped. The issue and PR-as-issue **update** paths sent `labels` in the PATCH, so label changes never propagated onto already-mirrored issues, and a deadlock-orphaned issue recovered via PATCH never got its labels.

**Fix:** new `reconcileGiteaIssueLabels` helper that replaces the set via `PUT .../issues/{index}/labels` (idempotent — adds new, removes deleted). Called on the two issue and two PR update paths; the dead `labels` key is removed from those PATCH bodies. Labels on freshly created issues still come from `CreateIssueOption` on the POST.

**Verified:** raw API (PATCH leaves labels unchanged; PUT replaces them); end-to-end (a mirrored issue drifted to no-labels reconciled back to its GitHub label set); regression test `gitea-issue-labels.test.ts` driving the real `mirrorGitRepoIssuesToGitea` update path.

---

Issue/milestone `title` fields are untouched (that *is* their correct Gitea API field). Full suite: **360 pass, 0 fail.**