### PR TITLE
fix: honor destination overrides in bulk org mirroring and crash recovery

### DIFF
--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -1995,11 +1995,20 @@ export async function mirrorGitHubOrgToGitea({
     const mirrorStrategy = config.githubConfig?.mirrorStrategy ||
       (config.giteaConfig?.preserveOrgStructure ? "preserve" : "flat-user");
 
-    let giteaOrgId: number;
+    let giteaOrgId: number | undefined;
     let targetOrgName: string;
 
     // Determine the target organization based on strategy
-    if (mirrorStrategy === "single-org" && config.giteaConfig?.organization) {
+    if (organization.destinationOrg) {
+      // Organization-level override takes precedence over the strategy
+      targetOrgName = organization.destinationOrg;
+      giteaOrgId = await getOrCreateGiteaOrg({
+        orgId: organization.id,
+        orgName: targetOrgName,
+        config,
+      });
+      console.log(`Using organization override: ${organization.name} -> ${targetOrgName}`);
+    } else if (mirrorStrategy === "single-org" && config.giteaConfig?.organization) {
       // For single-org strategy, use the configured destination organization
       targetOrgName = config.giteaConfig.organization || config.giteaConfig.defaultOwner;
       giteaOrgId = await getOrCreateGiteaOrg({
@@ -2062,22 +2071,34 @@ export async function mirrorGitHubOrgToGitea({
             `Starting mirror for repository: ${repo.name} from GitHub org ${organization.name}`
           );
 
-          // Mirror the repository based on strategy
-          if (mirrorStrategy === "flat-user") {
-            // For flat-user strategy, mirror directly to user account
+          // Resolve per repo with the canonical precedence
+          const owner = await getGiteaRepoOwnerAsync({ config, repository: repoData });
+
+          if (owner === config.giteaConfig?.defaultOwner) {
             await mirrorGithubRepoToGitea({
               octokit,
               repository: repoData,
               config,
             });
-          } else {
-            // For preserve and single-org strategies, use organization
+          } else if (owner === targetOrgName && giteaOrgId !== undefined) {
             await mirrorGitHubRepoToGiteaOrg({
               octokit,
               config,
               repository: repoData,
-              giteaOrgId: giteaOrgId!,
+              giteaOrgId,
               orgName: targetOrgName,
+            });
+          } else {
+            const ownerOrgId = await getOrCreateGiteaOrg({
+              orgName: owner,
+              config,
+            });
+            await mirrorGitHubRepoToGiteaOrg({
+              octokit,
+              config,
+              repository: repoData,
+              giteaOrgId: ownerOrgId,
+              orgName: owner,
             });
           }
 

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -6,7 +6,7 @@
 import { findInterruptedJobs, resumeInterruptedJob } from './helpers';
 import { db, repositories, organizations, mirrorJobs, configs } from './db';
 import { eq, and, lt, inArray, sql } from 'drizzle-orm';
-import { mirrorGithubRepoToGitea, mirrorGitHubOrgRepoToGiteaOrg, syncGiteaRepo } from './gitea';
+import { mirrorGithubRepoToGitea, syncGiteaRepo } from './gitea';
 import { createGitHubClient } from './github';
 import { processWithResilience } from './utils/concurrency';
 import { repositoryVisibilityEnum, repoStatusEnum } from '@/types/Repository';
@@ -290,21 +290,11 @@ async function recoverMirrorJob(job: any, remainingItemIds: string[]) {
           mirroredLocation: repo.mirroredLocation || "",
         };
 
-        // Mirror the repository based on whether it's in an organization
-        if (repo.organization && config.giteaConfig.preserveOrgStructure) {
-          await mirrorGitHubOrgRepoToGiteaOrg({
-            config,
-            octokit,
-            orgName: repo.organization,
-            repository: repoData,
-          });
-        } else {
-          await mirrorGithubRepoToGitea({
-            octokit,
-            repository: repoData,
-            config,
-          });
-        }
+        await mirrorGithubRepoToGitea({
+          octokit,
+          repository: repoData,
+          config,
+        });
 
         return repo;
       },


### PR DESCRIPTION
## Summary

Fixes: #343

Destination Organization overrides (org-level and per-repo `destinationOrg`) only worked on the single-repo mirror path. Bulk **Mirror Organization** and crash recovery had their own destination logic instead of using the canonical resolver, causing the following

- Org/repo destination overrides silently ignored on bulk mirror. Repos landed in whatever target the strategy would normally pick, as if no override had been set

- `mixed` strategy falling into the flat-user fallback on bulk mirror, dumping org repos into the personal account.

- Starred repos in a bulk mirror not following starred-repo mode under `preserve`/`single-org` (routed into the org target) and `mixed` (personal account).

- Recovered jobs re-routing repos by GitHub org name via the legacy(?) `preserveOrgStructure` flag.

See #343 for the full root cause writeup.

## Changes

**`src/lib/gitea.ts`, `mirrorGitHubOrgToGitea()`**

- Apply the organization-level `destinationOrg` override before any strategy logic.
- Resolve each repo in the per-repo loop through `getGiteaRepoOwnerAsync()`, then route to the pre-created target org, the user account, or an on-demand org. This fixes overrides, `mixed`, and starred handling in one place, so the bulk path can no longer drift from the single-repo path.

**`src/lib/recovery.ts`**

- Recovered mirror jobs now always go through `mirrorGithubRepoToGitea()`, which resolves the destination itself, instead of pre-routing org repos by GitHub org name.

No schema, API, or UI changes.
