### PR TITLE
feat(github): reuse ETags across syncs via conditional requests

### DIFF
--- a/src/lib/github-conditional-requests.test.ts
+++ b/src/lib/github-conditional-requests.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { Octokit } from "@octokit/rest";
+import {
+  applyConditionalRequests,
+  conditionalRequestCacheKey,
+  InMemoryConditionalRequestStore,
+} from "@/lib/github-conditional-requests";
+
+function jsonResponse(
+  body: unknown,
+  init: { status: number; etag?: string; link?: string },
+): Response {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (init.etag) headers.etag = init.etag;
+  if (init.link) headers.link = init.link;
+  return new Response(init.status === 304 ? null : JSON.stringify(body), {
+    status: init.status,
+    headers,
+  });
+}
+
+function clientWithFetch(fetch: (url: string, init: any) => Promise<Response>) {
+  return new Octokit({
+    auth: "test-token",
+    request: { fetch: fetch as unknown as typeof globalThis.fetch },
+  });
+}
+
+describe("applyConditionalRequests", () => {
+  test("replays If-None-Match and serves the cached body on 304", async () => {
+    const etag = 'W/"abc123"';
+    const pulls = [{ number: 1, title: "one" }];
+    let calls = 0;
+    let secondRequestIfNoneMatch: string | undefined;
+
+    const octokit = clientWithFetch(async (_url, init) => {
+      calls += 1;
+      if (calls === 1) {
+        return jsonResponse(pulls, { status: 200, etag });
+      }
+      secondRequestIfNoneMatch = init?.headers?.["if-none-match"];
+      return jsonResponse(null, { status: 304, etag });
+    });
+    applyConditionalRequests(octokit, {
+      store: new InMemoryConditionalRequestStore(),
+      scope: "user-1",
+    });
+
+    const first = await octokit.request("GET /repos/{owner}/{repo}/pulls", {
+      owner: "o",
+      repo: "r",
+      state: "all",
+    });
+    const second = await octokit.request("GET /repos/{owner}/{repo}/pulls", {
+      owner: "o",
+      repo: "r",
+      state: "all",
+    });
+
+    expect(calls).toBe(2);
+    expect(secondRequestIfNoneMatch).toBe(etag);
+    // A 304 is transparently presented as a 200 carrying the cached body.
+    expect(second.status).toBe(200);
+    expect(second.data).toEqual(first.data);
+    expect(second.data).toEqual(pulls);
+  });
+
+  test("does not attach conditional headers to non-GET requests", async () => {
+    let sawIfNoneMatch = false;
+    const octokit = clientWithFetch(async (_url, init) => {
+      if (init?.headers?.["if-none-match"]) sawIfNoneMatch = true;
+      return jsonResponse({ ok: true }, { status: 201 });
+    });
+    applyConditionalRequests(octokit, {
+      store: new InMemoryConditionalRequestStore(),
+      scope: "user-1",
+    });
+
+    await octokit.request("POST /repos/{owner}/{repo}/pulls", {
+      owner: "o",
+      repo: "r",
+      title: "x",
+      head: "a",
+      base: "b",
+    });
+
+    expect(sawIfNoneMatch).toBe(false);
+  });
+
+  test("makes a full request again when the response carries no ETag", async () => {
+    let calls = 0;
+    let secondRequestIfNoneMatch: string | undefined;
+    const octokit = clientWithFetch(async (_url, init) => {
+      calls += 1;
+      if (calls >= 2) secondRequestIfNoneMatch = init?.headers?.["if-none-match"];
+      return jsonResponse([{ number: 1 }], { status: 200 }); // no etag
+    });
+    applyConditionalRequests(octokit, {
+      store: new InMemoryConditionalRequestStore(),
+      scope: "user-1",
+    });
+
+    await octokit.request("GET /repos/{owner}/{repo}/pulls", {
+      owner: "o",
+      repo: "r",
+    });
+    const second = await octokit.request("GET /repos/{owner}/{repo}/pulls", {
+      owner: "o",
+      repo: "r",
+    });
+
+    expect(calls).toBe(2);
+    expect(secondRequestIfNoneMatch).toBeUndefined();
+    expect(second.status).toBe(200);
+  });
+
+  test("isolates cached entries by scope", () => {
+    const store = new InMemoryConditionalRequestStore();
+    store.set(conditionalRequestCacheKey("user-1", "GET", "/x"), {
+      etag: "a",
+      data: 1,
+      status: 200,
+    });
+    expect(
+      store.get(conditionalRequestCacheKey("user-2", "GET", "/x")),
+    ).toBeUndefined();
+    expect(
+      store.get(conditionalRequestCacheKey("user-1", "GET", "/x"))?.etag,
+    ).toBe("a");
+  });
+});

--- a/src/lib/github-conditional-requests.test.ts
+++ b/src/lib/github-conditional-requests.test.ts
@@ -116,6 +116,50 @@ describe("applyConditionalRequests", () => {
     expect(second.status).toBe(200);
   });
 
+  test("keys cache entries per expanded URL so repos do not collide", async () => {
+    // Each resource gets its own ETag; the stub returns 304 only when the
+    // presented If-None-Match matches the ETag issued for that exact URL.
+    const etagByUrl = new Map<string, string>();
+    let notModifiedCount = 0;
+
+    const octokit = clientWithFetch(async (url, init) => {
+      const ifNoneMatch = init?.headers?.["if-none-match"] as
+        | string
+        | undefined;
+      let etag = etagByUrl.get(url);
+      if (!etag) {
+        etag = `W/"etag-${etagByUrl.size + 1}"`;
+        etagByUrl.set(url, etag);
+      }
+      if (ifNoneMatch && ifNoneMatch === etag) {
+        notModifiedCount += 1;
+        return jsonResponse(null, { status: 304, etag });
+      }
+      return jsonResponse([{ url }], { status: 200, etag });
+    });
+    applyConditionalRequests(octokit, {
+      store: new InMemoryConditionalRequestStore(),
+      scope: "user-1",
+    });
+
+    const get = (owner: string, repo: string) =>
+      octokit.request("GET /repos/{owner}/{repo}/pulls", {
+        owner,
+        repo,
+        state: "all",
+      });
+
+    const first = await get("alpha", "one");
+    await get("beta", "two");
+    const third = await get("alpha", "one");
+
+    // The repeated first request must revalidate against its OWN ETag and come
+    // back as a 304 cache hit, not be clobbered by the second repo's entry.
+    expect(notModifiedCount).toBe(1);
+    expect(third.status).toBe(200);
+    expect(third.data).toEqual(first.data);
+  });
+
   test("isolates cached entries by scope", () => {
     const store = new InMemoryConditionalRequestStore();
     store.set(conditionalRequestCacheKey("user-1", "GET", "/x"), {

--- a/src/lib/github-conditional-requests.ts
+++ b/src/lib/github-conditional-requests.ts
@@ -1,0 +1,128 @@
+import type { Octokit } from "@octokit/rest";
+
+/**
+ * A single cached GitHub response, retained so that a later conditional request
+ * which comes back `304 Not Modified` can be served from memory instead of
+ * downloading the full body again. Only the fields the mirror actually consumes
+ * are stored.
+ */
+export interface CachedResponse {
+  etag: string;
+  data: unknown;
+  status: number;
+  /** Preserved so `octokit.paginate` can keep following pages on a cache hit. */
+  link?: string;
+}
+
+export interface ConditionalRequestStore {
+  get(key: string): CachedResponse | undefined;
+  set(key: string, value: CachedResponse): void;
+}
+
+/**
+ * Process-lifetime, bounded in-memory store. Gitea Mirror runs as a long-lived
+ * server whose scheduler re-syncs on an interval, so keeping ETags in memory is
+ * enough to turn each repeated poll into a cheap `304`. The bound keeps memory
+ * predictable; evicting an entry only costs one full response on the next sync.
+ */
+export class InMemoryConditionalRequestStore implements ConditionalRequestStore {
+  private readonly entries = new Map<string, CachedResponse>();
+
+  constructor(private readonly maxEntries = 5000) {}
+
+  get(key: string): CachedResponse | undefined {
+    return this.entries.get(key);
+  }
+
+  set(key: string, value: CachedResponse): void {
+    // Delete-then-set so Map iteration order approximates LRU for eviction.
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+  }
+}
+
+/**
+ * Shared across every client so ETags survive the per-sync re-creation of the
+ * Octokit instance (a fresh client is built on each scheduled sync).
+ */
+export const defaultConditionalRequestStore =
+  new InMemoryConditionalRequestStore();
+
+export function conditionalRequestCacheKey(
+  scope: string,
+  method: string,
+  url: string,
+): string {
+  return `${scope} ${method.toUpperCase()} ${url}`;
+}
+
+/**
+ * Adds ETag-based conditional requests to an Octokit instance. For every GET it
+ * replays the previously stored `If-None-Match`; GitHub then answers `304 Not
+ * Modified` — which does not count against the token's primary rate limit —
+ * whenever nothing changed, and the cached body is returned in place of a full
+ * re-download. Non-GET requests are passed through untouched.
+ *
+ * The scope isolates cache entries per token/user so one account never reads
+ * another's cached data.
+ */
+export function applyConditionalRequests(
+  octokit: Octokit,
+  options: { store?: ConditionalRequestStore; scope?: string } = {},
+): void {
+  // Some tests stub Octokit without the hook system; skip wiring in that case.
+  if (typeof (octokit as any)?.hook?.wrap !== "function") return;
+
+  const store = options.store ?? defaultConditionalRequestStore;
+  const scope = options.scope ?? "default";
+
+  octokit.hook.wrap("request", async (request: any, requestOptions: any): Promise<any> => {
+    const method = String(requestOptions.method ?? "GET").toUpperCase();
+    if (method !== "GET") {
+      return request(requestOptions);
+    }
+
+    const key = conditionalRequestCacheKey(scope, method, requestOptions.url);
+    const cached = store.get(key);
+    if (cached?.etag) {
+      requestOptions.headers = {
+        ...requestOptions.headers,
+        "if-none-match": cached.etag,
+      };
+    }
+
+    try {
+      const response = await request(requestOptions);
+      const etag = response?.headers?.etag;
+      if (etag && response.status >= 200 && response.status < 300) {
+        store.set(key, {
+          etag,
+          data: response.data,
+          status: response.status,
+          link: response.headers?.link,
+        });
+      }
+      return response;
+    } catch (error: any) {
+      // GitHub answered "not modified": reuse the stored body, presented as a
+      // 200 so callers (including octokit.paginate) are unaffected.
+      if (error?.status === 304 && cached) {
+        return {
+          status: 200,
+          url: requestOptions.url,
+          headers: {
+            ...(error.response?.headers ?? {}),
+            etag: cached.etag,
+            ...(cached.link ? { link: cached.link } : {}),
+          },
+          data: cached.data,
+        } as any;
+      }
+      throw error;
+    }
+  });
+}

--- a/src/lib/github-conditional-requests.ts
+++ b/src/lib/github-conditional-requests.ts
@@ -86,7 +86,19 @@ export function applyConditionalRequests(
       return request(requestOptions);
     }
 
-    const key = conditionalRequestCacheKey(scope, method, requestOptions.url);
+    // Build the key from the expanded absolute URL, not the route template.
+    // Inside the hook `requestOptions.url` is still `/repos/{owner}/{repo}/...`,
+    // so keying on it would collapse every repo into a single entry per user +
+    // endpoint and stop the 304 path from firing once more than one repo syncs.
+    // `octokit.request.endpoint.parse` expands the route (owner/repo + query);
+    // the chained `request` argument has no `.endpoint`, so it must come from
+    // `octokit.request`.
+    const parseEndpoint = (octokit as any)?.request?.endpoint?.parse;
+    const expandedUrl =
+      typeof parseEndpoint === "function"
+        ? parseEndpoint(requestOptions).url
+        : requestOptions.url;
+    const key = conditionalRequestCacheKey(scope, method, expandedUrl);
     const cached = store.get(key);
     if (cached?.etag) {
       requestOptions.headers = {
@@ -113,7 +125,7 @@ export function applyConditionalRequests(
       if (error?.status === 304 && cached) {
         return {
           status: 200,
-          url: requestOptions.url,
+          url: expandedUrl,
           headers: {
             ...(error.response?.headers ?? {}),
             etag: cached.etag,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,6 +3,7 @@ import type { GitRepo, RepoStatus } from "@/types/Repository";
 import { Octokit } from "@octokit/rest";
 import { throttling } from "@octokit/plugin-throttling";
 import type { Config } from "@/types/config";
+import { applyConditionalRequests } from "@/lib/github-conditional-requests";
 // Conditionally import rate limit manager (not available in test environment)
 let RateLimitManager: any = null;
 let publishEvent: any = null;
@@ -201,6 +202,10 @@ export function createGitHubClient(
       throw error;
     });
   }
+
+  // Reuse ETags across syncs so unchanged lists (e.g. pull requests) come back
+  // as rate-limit-free 304s instead of full downloads on every scheduled poll.
+  applyConditionalRequests(octokit, { scope: userId ?? username });
 
   return octokit;
 }


### PR DESCRIPTION
## Summary

Fixes #355.

On each scheduled sync the mirror re-lists a repository's pull requests (`octokit.paginate(octokit.rest.pulls.list, { state: "all", per_page: 100, ... })`) and then fetches per-PR details. The Octokit client in `createGitHubClient` was built with the throttling plugin but no conditional-request/ETag layer, so unchanged pull request data was downloaded in full on every run and consumed full rate-limit budget.

This adds ETag-based conditional requests. For every GET the client now replays the previously stored `ETag` as `If-None-Match`; GitHub then returns `304 Not Modified` when nothing changed, which does **not** count against the token's primary rate limit, and the cached body is returned in its place. Sync results are unchanged — only redundant full downloads are removed.

## What changed

- New `src/lib/github-conditional-requests.ts`: an `octokit.hook.wrap("request", ...)` that attaches `If-None-Match` on GETs, caches `200` bodies keyed by user scope + method + URL, and serves the cached body (as a `200`) when GitHub replies `304`. The paginate `link` header is preserved on a cache hit so pagination still follows subsequent pages. Non-GET requests are passed through untouched.
- The cache store is an interface with a bounded in-memory implementation, wired into `createGitHubClient`. Gitea Mirror runs as a long-lived server whose scheduler re-syncs on an interval, so a process-lifetime store is enough to turn each repeated poll into a cheap `304`. No new dependencies and no schema/migration changes. The store is injectable, so a persistent (e.g. SQLite-backed) implementation could be added later for cross-restart reuse.
- Entries are scoped per user so one token never reads another's cached data.

## Testing

`src/lib/github-conditional-requests.test.ts` drives a real `Octokit` instance with a stubbed `fetch` and verifies: the second GET replays `If-None-Match`; a `304` is transparently served from cache as a `200` with the same body; responses without an `ETag` are re-fetched; non-GET requests are never made conditional; and cache entries are isolated by scope.

## Notes

- Value to self-hosted users: fewer full downloads and lower pressure on the token's hourly rate limit, so large mirror sets or short sync intervals are less likely to hit throttling.
- Optional follow-up (not included here to keep this focused): narrowing the list to `state: "open"` or an incremental `since` query where appropriate would further reduce redundant work.
