### PR TITLE
feat: per-repository and per-organization mirror option overrides

### DIFF
--- a/drizzle/0014_needy_white_tiger.sql
+++ b/drizzle/0014_needy_white_tiger.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `organizations` ADD `mirror_overrides` text;--> statement-breakpoint
+ALTER TABLE `repositories` ADD `mirror_overrides` text;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2389 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "367fa60e-8b76-4b55-8be8-a41a099a5c3c",
+  "prevId": "6beb5116-f397-4dcb-ac73-f2b81079f61d",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_accounts_account_id": {
+          "name": "idx_accounts_account_id",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_accounts_provider": {
+          "name": "idx_accounts_provider",
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "github_config": {
+          "name": "github_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gitea_config": {
+          "name": "gitea_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "include": {
+          "name": "include",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"*\"]'"
+        },
+        "exclude": {
+          "name": "exclude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "schedule_config": {
+          "name": "schedule_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cleanup_config": {
+          "name": "cleanup_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notification_config": {
+          "name": "notification_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"enabled\":false,\"provider\":\"ntfy\",\"notifyOnSyncError\":true,\"notifyOnSyncSuccess\":false,\"notifyOnNewRepo\":false}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "configs_user_id_users_id_fk": {
+          "name": "configs_user_id_users_id_fk",
+          "tableFrom": "configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_events_user_channel": {
+          "name": "idx_events_user_channel",
+          "columns": [
+            "user_id",
+            "channel"
+          ],
+          "isUnique": false
+        },
+        "idx_events_created_at": {
+          "name": "idx_events_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_events_read": {
+          "name": "idx_events_read",
+          "columns": [
+            "read"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_user_id_users_id_fk": {
+          "name": "events_user_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jwks": {
+      "name": "jwks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mirror_jobs": {
+      "name": "mirror_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_name": {
+          "name": "repository_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'imported'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mirror'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_items": {
+          "name": "completed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_item_ids": {
+          "name": "completed_item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "in_progress": {
+          "name": "in_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checkpoint": {
+          "name": "last_checkpoint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mirror_jobs_user_id": {
+          "name": "idx_mirror_jobs_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mirror_jobs_batch_id": {
+          "name": "idx_mirror_jobs_batch_id",
+          "columns": [
+            "batch_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mirror_jobs_in_progress": {
+          "name": "idx_mirror_jobs_in_progress",
+          "columns": [
+            "in_progress"
+          ],
+          "isUnique": false
+        },
+        "idx_mirror_jobs_job_type": {
+          "name": "idx_mirror_jobs_job_type",
+          "columns": [
+            "job_type"
+          ],
+          "isUnique": false
+        },
+        "idx_mirror_jobs_timestamp": {
+          "name": "idx_mirror_jobs_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mirror_jobs_user_id_users_id_fk": {
+          "name": "mirror_jobs_user_id_users_id_fk",
+          "tableFrom": "mirror_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_access_tokens_token": {
+          "name": "idx_oauth_access_tokens_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_access_tokens_client_id": {
+          "name": "idx_oauth_access_tokens_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_access_tokens_user_id": {
+          "name": "idx_oauth_access_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_user_id_users_id_fk": {
+          "name": "oauth_access_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_clients": {
+      "name": "oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_clients_client_id": {
+          "name": "idx_oauth_clients_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_clients_user_id": {
+          "name": "idx_oauth_clients_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_users_id_fk": {
+          "name": "oauth_clients_user_id_users_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_consents": {
+      "name": "oauth_consents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_oauth_consents_client_id": {
+          "name": "idx_oauth_consents_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_consents_user_id": {
+          "name": "idx_oauth_consents_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_consents_user_id_users_id_fk": {
+          "name": "oauth_consents_user_id_users_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_refresh_tokens_token": {
+          "name": "idx_oauth_refresh_tokens_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_refresh_tokens_client_id": {
+          "name": "idx_oauth_refresh_tokens_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_refresh_tokens_user_id": {
+          "name": "idx_oauth_refresh_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_user_id_users_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_role": {
+          "name": "membership_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_included": {
+          "name": "is_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "destination_org": {
+          "name": "destination_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mirror_overrides": {
+          "name": "mirror_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'imported'"
+        },
+        "last_mirrored": {
+          "name": "last_mirrored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_count": {
+          "name": "repository_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "public_repository_count": {
+          "name": "public_repository_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private_repository_count": {
+          "name": "private_repository_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fork_repository_count": {
+          "name": "fork_repository_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_organizations_user_id": {
+          "name": "idx_organizations_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_organizations_config_id": {
+          "name": "idx_organizations_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "idx_organizations_status": {
+          "name": "idx_organizations_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_organizations_is_included": {
+          "name": "idx_organizations_is_included",
+          "columns": [
+            "is_included"
+          ],
+          "isUnique": false
+        },
+        "uniq_organizations_user_normalized_name": {
+          "name": "uniq_organizations_user_normalized_name",
+          "columns": [
+            "user_id",
+            "normalized_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organizations_user_id_users_id_fk": {
+          "name": "organizations_user_id_users_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizations_config_id_configs_id_fk": {
+          "name": "organizations_config_id_configs_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'github'"
+        },
+        "limit": {
+          "name": "limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset": {
+          "name": "reset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_rate_limits_user_provider": {
+          "name": "idx_rate_limits_user_provider",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_rate_limits_status": {
+          "name": "idx_rate_limits_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rate_limits_user_id_users_id_fk": {
+          "name": "rate_limits_user_id_users_id_fk",
+          "tableFrom": "rate_limits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_full_name": {
+          "name": "normalized_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mirrored_location": {
+          "name": "mirrored_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_fork": {
+          "name": "is_fork",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_issues": {
+          "name": "has_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_starred": {
+          "name": "is_starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_lfs": {
+          "name": "has_lfs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "has_submodules": {
+          "name": "has_submodules",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'imported'"
+        },
+        "last_mirrored": {
+          "name": "last_mirrored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination_org": {
+          "name": "destination_org",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mirror_overrides": {
+          "name": "mirror_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_repositories_user_id": {
+          "name": "idx_repositories_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_config_id": {
+          "name": "idx_repositories_config_id",
+          "columns": [
+            "config_id"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_status": {
+          "name": "idx_repositories_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_owner": {
+          "name": "idx_repositories_owner",
+          "columns": [
+            "owner"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_organization": {
+          "name": "idx_repositories_organization",
+          "columns": [
+            "organization"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_is_fork": {
+          "name": "idx_repositories_is_fork",
+          "columns": [
+            "is_fork"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_is_starred": {
+          "name": "idx_repositories_is_starred",
+          "columns": [
+            "is_starred"
+          ],
+          "isUnique": false
+        },
+        "idx_repositories_user_imported_at": {
+          "name": "idx_repositories_user_imported_at",
+          "columns": [
+            "user_id",
+            "imported_at"
+          ],
+          "isUnique": false
+        },
+        "uniq_repositories_user_full_name": {
+          "name": "uniq_repositories_user_full_name",
+          "columns": [
+            "user_id",
+            "full_name"
+          ],
+          "isUnique": true
+        },
+        "uniq_repositories_user_normalized_full_name": {
+          "name": "uniq_repositories_user_normalized_full_name",
+          "columns": [
+            "user_id",
+            "normalized_full_name"
+          ],
+          "isUnique": true
+        },
+        "idx_repositories_mirrored_location": {
+          "name": "idx_repositories_mirrored_location",
+          "columns": [
+            "user_id",
+            "mirrored_location"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "repositories_user_id_users_id_fk": {
+          "name": "repositories_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "repositories_config_id_configs_id_fk": {
+          "name": "repositories_config_id_configs_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_token": {
+          "name": "idx_sessions_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sso_providers": {
+      "name": "sso_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "sso_providers_provider_id_unique": {
+          "name": "sso_providers_provider_id_unique",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "idx_sso_providers_provider_id": {
+          "name": "idx_sso_providers_provider_id",
+          "columns": [
+            "provider_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sso_providers_domain": {
+          "name": "idx_sso_providers_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_sso_providers_issuer": {
+          "name": "idx_sso_providers_issuer",
+          "columns": [
+            "issuer"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification_tokens": {
+      "name": "verification_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_verification_tokens_token": {
+          "name": "idx_verification_tokens_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "idx_verification_tokens_identifier": {
+          "name": "idx_verification_tokens_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_verifications_identifier": {
+          "name": "idx_verifications_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780377747526,
       "tag": "0013_slim_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1787182504975,
+      "tag": "0014_needy_white_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/validate-migrations.ts
+++ b/scripts/validate-migrations.ts
@@ -294,6 +294,66 @@ function verify0013Migration(db: any) {
   assert(normName.dflt_value === null, `Expected normalized_name to have no default, got ${normName.dflt_value}`);
 }
 
+function seedPre0014Database(db: any) {
+  // Migrations 0000-0013 have run, so repositories/organizations exist but
+  // lack mirror_overrides. Seed one of each so the column-add can be verified
+  // against pre-existing rows (they must come out NULL = "inherit").
+  db.run("INSERT INTO users (id, email, username, name) VALUES ('u-ovr', 'ovr@example.com', 'ovr', 'Override User')");
+  db.run("INSERT INTO configs (id, user_id, name, is_active, github_config, gitea_config, schedule_config, cleanup_config) VALUES ('cfg-pre14', 'u-ovr', 'Default', 1, '{}', '{}', '{}', '{}')");
+  db.run("INSERT INTO organizations (id, user_id, config_id, name, avatar_url, normalized_name) VALUES ('org-pre14', 'u-ovr', 'cfg-pre14', 'ExampleOrg', 'https://example.com/a.png', 'exampleorg')");
+  db.run(
+    "INSERT INTO repositories (id, user_id, config_id, name, full_name, normalized_full_name, url, clone_url, owner, default_branch) " +
+      "VALUES ('repo-pre14', 'u-ovr', 'cfg-pre14', 'browser-use', 'ExampleOrg/browser-use', 'exampleorg/browser-use', 'https://github.com/ExampleOrg/browser-use', 'https://github.com/ExampleOrg/browser-use.git', 'ExampleOrg', 'main')",
+  );
+}
+
+function verify0014Migration(db: any) {
+  // Both tables gained a nullable mirror_overrides column with no default.
+  for (const table of ["repositories", "organizations"]) {
+    const cols = db
+      .query(`PRAGMA table_info(${table})`)
+      .all() as Array<{ name: string; type: string; notnull: number; dflt_value: string | null }>;
+    const col = cols.find((c) => c.name === "mirror_overrides");
+    assert(col, `Expected ${table}.mirror_overrides column to exist`);
+    assert(col.notnull === 0, `Expected ${table}.mirror_overrides to be nullable`);
+    assert(
+      col.dflt_value === null,
+      `Expected ${table}.mirror_overrides to have no default, got ${col.dflt_value}`,
+    );
+  }
+
+  // Pre-existing rows inherit (NULL), rather than being backfilled with {}.
+  const repoRow = db
+    .query("SELECT id, mirror_overrides FROM repositories WHERE id = 'repo-pre14'")
+    .get() as { id: string; mirror_overrides: string | null } | null;
+  assert(repoRow, "Expected pre-existing repository row to survive migration");
+  assert(
+    repoRow.mirror_overrides === null,
+    `Expected existing repository to inherit (NULL mirror_overrides), got ${repoRow.mirror_overrides}`,
+  );
+
+  const orgRow = db
+    .query("SELECT id, mirror_overrides FROM organizations WHERE id = 'org-pre14'")
+    .get() as { id: string; mirror_overrides: string | null } | null;
+  assert(orgRow, "Expected pre-existing organization row to survive migration");
+  assert(
+    orgRow.mirror_overrides === null,
+    `Expected existing organization to inherit (NULL mirror_overrides), got ${orgRow.mirror_overrides}`,
+  );
+
+  // The new column round-trips a JSON overrides payload (the #361 case:
+  // mirror this repo but skip its LFS objects).
+  db.run(
+    "UPDATE repositories SET mirror_overrides = '{\"lfs\":false}' WHERE id = 'repo-pre14'",
+  );
+  const updated = db
+    .query("SELECT mirror_overrides FROM repositories WHERE id = 'repo-pre14'")
+    .get() as { mirror_overrides: string } | null;
+  assert(updated, "Expected repository row after override update");
+  const parsed = JSON.parse(updated.mirror_overrides);
+  assert(parsed.lfs === false, `Expected persisted lfs override false, got ${updated.mirror_overrides}`);
+}
+
 const MIGRATION_0012_TIMESTAMP = 1774062000000;
 const MIGRATION_0013_TIMESTAMP = 1780377747526;
 
@@ -408,6 +468,10 @@ const latestUpgradeFixtures: Record<string, UpgradeFixture> = {
   "0013_slim_galactus": {
     seed: seedPre0013Database,
     verify: verify0013Migration,
+  },
+  "0014_needy_white_tiger": {
+    seed: seedPre0014Database,
+    verify: verify0014Migration,
   },
 };
 

--- a/src/components/config/MirrorOverridesDialog.tsx
+++ b/src/components/config/MirrorOverridesDialog.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MirrorOverrides } from "@/lib/db/schema";
+import {
+  MIRROR_OVERRIDE_LABELS,
+  UI_MIRROR_OVERRIDE_KEYS,
+  type MirrorOverrideKey,
+} from "@/lib/utils/mirror-overrides";
+
+/**
+ * Tri-state value for one flag in the dialog. "inherit" persists as absent,
+ * which is what lets the next tier out supply the value.
+ */
+type TriState = "inherit" | "on" | "off";
+
+function toTriState(value: boolean | null | undefined): TriState {
+  if (value === true) return "on";
+  if (value === false) return "off";
+  return "inherit";
+}
+
+function fromTriState(value: TriState): boolean | undefined {
+  if (value === "on") return true;
+  if (value === "off") return false;
+  return undefined;
+}
+
+export interface MirrorOverridesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Display name of the repo or org being edited. */
+  targetName: string;
+  /** "repository" or "organization", used for the wording only. */
+  targetKind: "repository" | "organization";
+  value?: MirrorOverrides | null;
+  /**
+   * Effective values from the tiers above this one, used to label what
+   * "Inherit" actually resolves to right now.
+   */
+  inheritedFrom?: Partial<Record<MirrorOverrideKey, boolean>>;
+  inheritedLabel?: string;
+  onSave: (overrides: MirrorOverrides | null) => Promise<void>;
+}
+
+export function MirrorOverridesDialog({
+  open,
+  onOpenChange,
+  targetName,
+  targetKind,
+  value,
+  inheritedFrom,
+  inheritedLabel = "global settings",
+  onSave,
+}: MirrorOverridesDialogProps) {
+  const [draft, setDraft] = useState<Record<MirrorOverrideKey, TriState>>(
+    () => buildDraft(value)
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Re-seed whenever the dialog opens or targets a different object, so a
+  // previous edit never leaks into the next one.
+  useEffect(() => {
+    if (open) setDraft(buildDraft(value));
+  }, [open, value]);
+
+  const overriddenCount = useMemo(
+    () => Object.values(draft).filter((state) => state !== "inherit").length,
+    [draft]
+  );
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const next: MirrorOverrides = {};
+      for (const key of UI_MIRROR_OVERRIDE_KEYS) {
+        const resolved = fromTriState(draft[key]);
+        if (typeof resolved === "boolean") next[key] = resolved;
+      }
+      await onSave(Object.keys(next).length > 0 ? next : null);
+      onOpenChange(false);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleResetAll = () => {
+    setDraft(buildDraft(null));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Mirror options</DialogTitle>
+          <DialogDescription>
+            Override what gets mirrored for this {targetKind}.{" "}
+            <span className="font-medium text-foreground">{targetName}</span>{" "}
+            inherits anything left on Inherit.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          {UI_MIRROR_OVERRIDE_KEYS.map((key) => {
+            const inherited = inheritedFrom?.[key];
+            return (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-4"
+              >
+                <Label htmlFor={`override-${key}`} className="flex-1">
+                  {MIRROR_OVERRIDE_LABELS[key]}
+                  {inherited !== undefined && draft[key] === "inherit" && (
+                    <span className="ml-2 text-xs font-normal text-muted-foreground">
+                      currently {inherited ? "on" : "off"}
+                    </span>
+                  )}
+                </Label>
+                <Select
+                  value={draft[key]}
+                  onValueChange={(next) =>
+                    setDraft((prev) => ({ ...prev, [key]: next as TriState }))
+                  }
+                >
+                  <SelectTrigger id={`override-${key}`} className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="inherit">Inherit</SelectItem>
+                    <SelectItem value="on">On</SelectItem>
+                    <SelectItem value="off">Off</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Inherit uses the {inheritedLabel}. Git LFS is worth turning off for
+          repositories whose LFS fetch fails, since Gitea aborts the whole
+          migration when it cannot pull them.
+        </p>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="ghost"
+            onClick={handleResetAll}
+            disabled={isSaving || overriddenCount === 0}
+          >
+            Reset all
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function buildDraft(
+  value: MirrorOverrides | null | undefined
+): Record<MirrorOverrideKey, TriState> {
+  const draft = {} as Record<MirrorOverrideKey, TriState>;
+  for (const key of UI_MIRROR_OVERRIDE_KEYS) {
+    draft[key] = toTriState(value?.[key]);
+  }
+  return draft;
+}

--- a/src/components/config/MirrorOverridesDialog.tsx
+++ b/src/components/config/MirrorOverridesDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import type { MirrorOverrides } from "@/lib/db/schema";
 import {
+  getMirrorOverrideGating,
   MIRROR_OVERRIDE_LABELS,
   UI_MIRROR_OVERRIDE_KEYS,
   type MirrorOverrideKey,
@@ -46,15 +47,24 @@ export interface MirrorOverridesDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Display name of the repo or org being edited. */
   targetName: string;
-  /** "repository" or "organization", used for the wording only. */
+  /** "repository" or "organization", used for wording and gating rules. */
   targetKind: "repository" | "organization";
   value?: MirrorOverrides | null;
   /**
    * Effective values from the tiers above this one, used to label what
-   * "Inherit" actually resolves to right now.
+   * "Inherit" actually resolves to right now. For a repository this should
+   * already be global merged with its organization's overrides.
    */
   inheritedFrom?: Partial<Record<MirrorOverrideKey, boolean>>;
   inheritedLabel?: string;
+  /**
+   * True while the inherited values are still being fetched. The hint is
+   * suppressed rather than shown wrong and then corrected.
+   */
+  inheritedLoading?: boolean;
+  /** Repository-only: drives the starred-code-only gating. */
+  isStarred?: boolean;
+  starredCodeOnly?: boolean;
   onSave: (overrides: MirrorOverrides | null) => Promise<void>;
 }
 
@@ -66,6 +76,9 @@ export function MirrorOverridesDialog({
   value,
   inheritedFrom,
   inheritedLabel = "global settings",
+  inheritedLoading = false,
+  isStarred,
+  starredCodeOnly,
   onSave,
 }: MirrorOverridesDialogProps) {
   const [draft, setDraft] = useState<Record<MirrorOverrideKey, TriState>>(
@@ -79,6 +92,28 @@ export function MirrorOverridesDialog({
     if (open) setDraft(buildDraft(value));
   }, [open, value]);
 
+  // What each flag currently resolves to, including the in-progress edit.
+  // Drives the labels gate so it reacts live as issues is toggled.
+  const effective = useMemo(() => {
+    const next: Partial<Record<MirrorOverrideKey, boolean>> = {};
+    for (const key of UI_MIRROR_OVERRIDE_KEYS) {
+      const pinned = fromTriState(draft[key]);
+      next[key] = pinned ?? inheritedFrom?.[key] ?? false;
+    }
+    return next;
+  }, [draft, inheritedFrom]);
+
+  const gating = useMemo(
+    () =>
+      getMirrorOverrideGating({
+        targetKind,
+        isStarred,
+        starredCodeOnly,
+        effective,
+      }),
+    [targetKind, isStarred, starredCodeOnly, effective]
+  );
+
   const overriddenCount = useMemo(
     () => Object.values(draft).filter((state) => state !== "inherit").length,
     [draft]
@@ -87,6 +122,8 @@ export function MirrorOverridesDialog({
   const handleSave = async () => {
     setIsSaving(true);
     try {
+      // Gated flags keep whatever the user previously stored. The clamp is a
+      // runtime concern, so a disabled toggle must not silently erase data.
       const next: MirrorOverrides = {};
       for (const key of UI_MIRROR_OVERRIDE_KEYS) {
         const resolved = fromTriState(draft[key]);
@@ -117,35 +154,51 @@ export function MirrorOverridesDialog({
 
         <div className="space-y-3 py-2">
           {UI_MIRROR_OVERRIDE_KEYS.map((key) => {
+            const disabledReason = gating[key];
+            const isDisabled = !!disabledReason;
             const inherited = inheritedFrom?.[key];
+            const showHint =
+              !inheritedLoading &&
+              !isDisabled &&
+              draft[key] === "inherit" &&
+              inherited !== undefined;
+
             return (
-              <div
-                key={key}
-                className="flex items-center justify-between gap-4"
-              >
-                <Label htmlFor={`override-${key}`} className="flex-1">
-                  {MIRROR_OVERRIDE_LABELS[key]}
-                  {inherited !== undefined && draft[key] === "inherit" && (
-                    <span className="ml-2 text-xs font-normal text-muted-foreground">
-                      currently {inherited ? "on" : "off"}
-                    </span>
-                  )}
-                </Label>
-                <Select
-                  value={draft[key]}
-                  onValueChange={(next) =>
-                    setDraft((prev) => ({ ...prev, [key]: next as TriState }))
-                  }
-                >
-                  <SelectTrigger id={`override-${key}`} className="w-32">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="inherit">Inherit</SelectItem>
-                    <SelectItem value="on">On</SelectItem>
-                    <SelectItem value="off">Off</SelectItem>
-                  </SelectContent>
-                </Select>
+              <div key={key} className="space-y-1">
+                <div className="flex items-center justify-between gap-4">
+                  <Label
+                    htmlFor={`override-${key}`}
+                    className={isDisabled ? "flex-1 text-muted-foreground" : "flex-1"}
+                  >
+                    {MIRROR_OVERRIDE_LABELS[key]}
+                    {showHint && (
+                      <span className="ml-2 text-xs font-normal text-muted-foreground">
+                        currently {inherited ? "on" : "off"}
+                      </span>
+                    )}
+                  </Label>
+                  <Select
+                    value={draft[key]}
+                    disabled={isDisabled}
+                    onValueChange={(next) =>
+                      setDraft((prev) => ({ ...prev, [key]: next as TriState }))
+                    }
+                  >
+                    <SelectTrigger id={`override-${key}`} className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="inherit">Inherit</SelectItem>
+                      <SelectItem value="on">On</SelectItem>
+                      <SelectItem value="off">Off</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {isDisabled && (
+                  <p className="text-xs text-muted-foreground">
+                    {disabledReason}
+                  </p>
+                )}
               </div>
             );
           })}

--- a/src/components/organizations/Organization.tsx
+++ b/src/components/organizations/Organization.tsx
@@ -475,7 +475,7 @@ export function Organization() {
 
   // Check if any filters are active
   const hasActiveFilters = !!(filter.membershipRole || filter.status);
-  const activeFilterCount = [filter.membershipRole, filter.status].filter(Boolean).length;
+  const activeFilterCount = [filter.membershipRole, filter.status, filter.hasOverrides].filter(Boolean).length;
 
   // Clear all filters
   const clearFilters = () => {
@@ -483,6 +483,7 @@ export function Organization() {
       searchTerm: filter.searchTerm,
       membershipRole: "",
       status: "",
+      hasOverrides: "",
     });
   };
 
@@ -653,6 +654,37 @@ export function Organization() {
                     </SelectContent>
                   </Select>
                 </div>
+
+                {/* Mirror Options Filter */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium flex items-center gap-2">
+                    <span className="text-muted-foreground">By</span> Mirror options
+                    {filter.hasOverrides && (
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {filter.hasOverrides === "overridden" ? "Custom" : "Default"}
+                      </span>
+                    )}
+                  </label>
+                  <Select
+                    value={filter.hasOverrides || "all"}
+                    onValueChange={(value) =>
+                      setFilter((prev) => ({
+                        ...prev,
+                        hasOverrides:
+                          value === "all" ? "" : (value as "overridden" | "default"),
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue placeholder="All organizations" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All organizations</SelectItem>
+                      <SelectItem value="overridden">Custom options</SelectItem>
+                      <SelectItem value="default">Using defaults</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
               
               <DrawerFooter className="gap-2 px-4 pt-2 pb-4 border-t">
@@ -791,6 +823,27 @@ export function Organization() {
                     </span>
                   </SelectItem>
                 ))}
+              </SelectContent>
+            </Select>
+
+            {/* Mirror Options Filter */}
+            <Select
+              value={filter.hasOverrides || "all"}
+              onValueChange={(value) =>
+                setFilter((prev) => ({
+                  ...prev,
+                  hasOverrides:
+                    value === "all" ? "" : (value as "overridden" | "default"),
+                }))
+              }
+            >
+              <SelectTrigger className="w-[170px] h-10">
+                <SelectValue placeholder="All mirror options" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All mirror options</SelectItem>
+                <SelectItem value="overridden">Custom options</SelectItem>
+                <SelectItem value="default">Using defaults</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -738,6 +738,8 @@ export function OrganizationList({
           mirrorIssues: !!giteaConfig?.mirrorIssues,
           mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
           mirrorReleases: !!giteaConfig?.mirrorReleases,
+          mirrorLabels: !!giteaConfig?.mirrorLabels,
+          mirrorMilestones: !!giteaConfig?.mirrorMilestones,
         }}
         inheritedLabel="global settings"
         onSave={async (overrides) => {

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -1,16 +1,18 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plus, RefreshCw, Building2, Check, AlertCircle, Clock, MoreVertical, Ban, Trash2 } from "lucide-react";
+import { Plus, RefreshCw, Building2, Check, AlertCircle, Clock, MoreVertical, Ban, SlidersHorizontal, Trash2 } from "lucide-react";
 import { SiGithub, SiGitea } from "react-icons/si";
-import type { Organization } from "@/lib/db/schema";
+import type { MirrorOverrides, Organization } from "@/lib/db/schema";
 import type { FilterParams } from "@/types/filter";
 import Fuse from "fuse.js";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import { MirrorDestinationEditor } from "./MirrorDestinationEditor";
+import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
+import { hasMirrorOverrides } from "@/lib/utils/mirror-overrides";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
 import { withBase } from "@/lib/base-path";
 import {
@@ -66,6 +68,27 @@ export function OrganizationList({
   onDelete,
 }: OrganizationListProps) {
   const { giteaConfig } = useGiteaConfig();
+  const [overridesTarget, setOverridesTarget] = useState<Organization | null>(null);
+
+  const handleUpdateMirrorOverrides = async (
+    orgId: string,
+    overrides: MirrorOverrides | null
+  ) => {
+    const response = await fetch(`${withBase("/api/organizations")}/${orgId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mirrorOverrides: overrides }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || "Failed to update mirror options");
+    }
+
+    if (onRefresh) {
+      await onRefresh();
+    }
+  };
 
   // Helper function to construct Gitea organization URL
   const getGiteaOrgUrl = (organization: Organization): string | null => {
@@ -281,13 +304,24 @@ export function OrganizationList({
                 </div>
                 
                 {/* Status badge */}
-                <Badge variant={statusBadge.variant} className="flex items-center gap-1">
-                  {StatusIcon && <StatusIcon className={cn(
-                    "h-3.5 w-3.5",
-                    org.status === "mirroring" && "animate-pulse"
-                  )} />}
-                  {statusBadge.label}
-                </Badge>
+                <div className="flex items-center gap-2">
+                  {hasMirrorOverrides(org.mirrorOverrides) && (
+                    <Badge
+                      variant="outline"
+                      className="text-amber-600 dark:text-amber-400 border-amber-500/40"
+                      title="This organization overrides the global mirror options"
+                    >
+                      Custom options
+                    </Badge>
+                  )}
+                  <Badge variant={statusBadge.variant} className="flex items-center gap-1">
+                    {StatusIcon && <StatusIcon className={cn(
+                      "h-3.5 w-3.5",
+                      org.status === "mirroring" && "animate-pulse"
+                    )} />}
+                    {statusBadge.label}
+                  </Badge>
+                </div>
               </div>
 
               {/* Destination override section */}
@@ -429,6 +463,10 @@ export function OrganizationList({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => setOverridesTarget(org)}>
+                        <SlidersHorizontal className="h-4 w-4 mr-2" />
+                        Mirror Options
+                      </DropdownMenuItem>
                       {org.status !== "ignored" && (
                         <DropdownMenuItem
                           onClick={() => org.id && onIgnore && onIgnore({ orgId: org.id, ignore: true })}
@@ -685,6 +723,29 @@ export function OrganizationList({
           </Card>
         );
       })}
+
+      <MirrorOverridesDialog
+        open={!!overridesTarget}
+        onOpenChange={(open) => {
+          if (!open) setOverridesTarget(null);
+        }}
+        targetKind="organization"
+        targetName={overridesTarget?.name ?? ""}
+        value={overridesTarget?.mirrorOverrides ?? null}
+        inheritedFrom={{
+          lfs: !!giteaConfig?.lfs,
+          wiki: !!giteaConfig?.wiki,
+          mirrorIssues: !!giteaConfig?.mirrorIssues,
+          mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
+          mirrorReleases: !!giteaConfig?.mirrorReleases,
+        }}
+        inheritedLabel="global settings"
+        onSave={async (overrides) => {
+          if (overridesTarget?.id) {
+            await handleUpdateMirrorOverrides(overridesTarget.id, overrides);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import { MirrorDestinationEditor } from "./MirrorDestinationEditor";
 import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
-import { hasMirrorOverrides } from "@/lib/utils/mirror-overrides";
+import { hasMirrorOverrides, mirrorOptionsToFlags } from "@/lib/utils/mirror-overrides";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
 import { withBase } from "@/lib/base-path";
 import {
@@ -67,7 +67,7 @@ export function OrganizationList({
   onRefresh,
   onDelete,
 }: OrganizationListProps) {
-  const { giteaConfig } = useGiteaConfig();
+  const { giteaConfig, mirrorOptions } = useGiteaConfig();
   const [overridesTarget, setOverridesTarget] = useState<Organization | null>(null);
 
   const handleUpdateMirrorOverrides = async (
@@ -732,15 +732,7 @@ export function OrganizationList({
         targetKind="organization"
         targetName={overridesTarget?.name ?? ""}
         value={overridesTarget?.mirrorOverrides ?? null}
-        inheritedFrom={{
-          lfs: !!giteaConfig?.lfs,
-          wiki: !!giteaConfig?.wiki,
-          mirrorIssues: !!giteaConfig?.mirrorIssues,
-          mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
-          mirrorReleases: !!giteaConfig?.mirrorReleases,
-          mirrorLabels: !!giteaConfig?.mirrorLabels,
-          mirrorMilestones: !!giteaConfig?.mirrorMilestones,
-        }}
+        inheritedFrom={mirrorOptionsToFlags(mirrorOptions)}
         inheritedLabel="global settings"
         onSave={async (overrides) => {
           if (overridesTarget?.id) {

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -145,6 +145,13 @@ export function OrganizationList({
       result = result.filter((org) => org.status === filter.status);
     }
 
+    if (filter.hasOverrides) {
+      const wantOverridden = filter.hasOverrides === "overridden";
+      result = result.filter(
+        (org) => hasMirrorOverrides(org.mirrorOverrides) === wantOverridden
+      );
+    }
+
     if (filter.searchTerm) {
       const fuse = new Fuse(result, {
         keys: ["name", "type"],

--- a/src/components/repositories/Repository.tsx
+++ b/src/components/repositories/Repository.tsx
@@ -1028,7 +1028,7 @@ export default function Repository() {
 
   // Check if any filters are active
   const hasActiveFilters = !!(filter.owner || filter.organization || filter.status);
-  const activeFilterCount = [filter.owner, filter.organization, filter.status].filter(Boolean).length;
+  const activeFilterCount = [filter.owner, filter.organization, filter.status, filter.hasOverrides].filter(Boolean).length;
 
   // Clear all filters
   const clearFilters = () => {
@@ -1338,6 +1338,26 @@ export default function Repository() {
                     </span>
                   </SelectItem>
                 ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={filter.hasOverrides || "all"}
+              onValueChange={(value) =>
+                setFilter((prev) => ({
+                  ...prev,
+                  hasOverrides:
+                    value === "all" ? "" : (value as "overridden" | "default"),
+                }))
+              }
+            >
+              <SelectTrigger className="w-[170px] h-10">
+                <SelectValue placeholder="All mirror options" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All mirror options</SelectItem>
+                <SelectItem value="overridden">Custom options</SelectItem>
+                <SelectItem value="default">Using defaults</SelectItem>
               </SelectContent>
             </Select>
 

--- a/src/components/repositories/Repository.tsx
+++ b/src/components/repositories/Repository.tsx
@@ -1037,6 +1037,7 @@ export default function Repository() {
       status: "",
       organization: "",
       owner: "",
+      hasOverrides: "",
       sort: filter.sort || "imported-desc",
     });
   };
@@ -1175,6 +1176,39 @@ export default function Repository() {
                           </span>
                         </SelectItem>
                       ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Mirror Options Filter */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium flex items-center gap-2">
+                    <span className="text-muted-foreground">By</span> Mirror options
+                    {filter.hasOverrides && (
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {filter.hasOverrides === "overridden" ? "Custom" : "Default"}
+                      </span>
+                    )}
+                  </label>
+                  <Select
+                    value={filter.hasOverrides || "all"}
+                    onValueChange={(value) =>
+                      setFilter((prev) => ({
+                        ...prev,
+                        hasOverrides:
+                          value === "all"
+                            ? ""
+                            : (value as "overridden" | "default"),
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="w-full h-10">
+                      <SelectValue placeholder="All repositories" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All repositories</SelectItem>
+                      <SelectItem value="overridden">Custom options</SelectItem>
+                      <SelectItem value="default">Using defaults</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -28,7 +28,11 @@ import {
 import { InlineDestinationEditor } from "./InlineDestinationEditor";
 import { MarqueeText, MarqueeTrigger } from "@/components/ui/marquee-text";
 import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
-import { hasMirrorOverrides, type MirrorOverrideKey } from "@/lib/utils/mirror-overrides";
+import {
+  hasMirrorOverrides,
+  mirrorOptionsToFlags,
+  type MirrorOverrideKey,
+} from "@/lib/utils/mirror-overrides";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { withBase } from "@/lib/base-path";
@@ -103,7 +107,7 @@ export default function RepositoryTable({
 }: RepositoryTableProps) {
   const tableParentRef = useRef<HTMLDivElement>(null);
   const lastSelectedIndexRef = useRef<number | null>(null);
-  const { giteaConfig, advancedOptions } = useGiteaConfig();
+  const { giteaConfig, advancedOptions, mirrorOptions } = useGiteaConfig();
   const [overridesTarget, setOverridesTarget] = useState<Repository | null>(null);
   // Organization-tier overrides for the repo being edited, so the dialog's
   // "Inherit" hint reflects global -> org rather than global alone.
@@ -147,16 +151,10 @@ export default function RepositoryTable({
   }, [overridesTarget]);
 
   // Global defaults with the organization tier layered on top.
+  // The globals come from mirrorOptions, not giteaConfig: /api/config reshapes
+  // the mirror flags on the way out and does not put them on giteaConfig.
   const inheritedMirrorOptions = useMemo(() => {
-    const globals: Partial<Record<MirrorOverrideKey, boolean>> = {
-      lfs: !!giteaConfig?.lfs,
-      wiki: !!giteaConfig?.wiki,
-      mirrorIssues: !!giteaConfig?.mirrorIssues,
-      mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
-      mirrorReleases: !!giteaConfig?.mirrorReleases,
-      mirrorLabels: !!giteaConfig?.mirrorLabels,
-      mirrorMilestones: !!giteaConfig?.mirrorMilestones,
-    };
+    const globals = mirrorOptionsToFlags(mirrorOptions);
 
     if (!orgOverrides) return globals;
 
@@ -165,7 +163,7 @@ export default function RepositoryTable({
       if (typeof orgValue === "boolean") globals[key] = orgValue;
     }
     return globals;
-  }, [giteaConfig, orgOverrides]);
+  }, [mirrorOptions, orgOverrides]);
 
   const handleUpdateMirrorOverrides = async (
     repoId: string,

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   getCoreRowModel,
   getFilteredRowModel,
@@ -9,9 +9,9 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FlipHorizontal, GitFork, RefreshCw, RotateCcw, Star, Lock, Ban, Check, ChevronDown, Trash2, X } from "lucide-react";
+import { FlipHorizontal, GitFork, RefreshCw, RotateCcw, Star, Lock, Ban, Check, ChevronDown, SlidersHorizontal, Trash2, X } from "lucide-react";
 import { SiGithub, SiGitea } from "react-icons/si";
-import type { Repository } from "@/lib/db/schema";
+import type { MirrorOverrides, Repository } from "@/lib/db/schema";
 import { Button } from "@/components/ui/button";
 import { formatLastSyncTime } from "@/lib/utils";
 import { buildGiteaWebUrl } from "@/lib/gitea-url";
@@ -27,6 +27,8 @@ import {
 } from "@/components/ui/tooltip";
 import { InlineDestinationEditor } from "./InlineDestinationEditor";
 import { MarqueeText, MarqueeTrigger } from "@/components/ui/marquee-text";
+import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
+import { hasMirrorOverrides } from "@/lib/utils/mirror-overrides";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { withBase } from "@/lib/base-path";
@@ -102,6 +104,27 @@ export default function RepositoryTable({
   const tableParentRef = useRef<HTMLDivElement>(null);
   const lastSelectedIndexRef = useRef<number | null>(null);
   const { giteaConfig } = useGiteaConfig();
+  const [overridesTarget, setOverridesTarget] = useState<Repository | null>(null);
+
+  const handleUpdateMirrorOverrides = async (
+    repoId: string,
+    overrides: MirrorOverrides | null
+  ) => {
+    const response = await fetch(`${withBase("/api/repositories")}/${repoId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mirrorOverrides: overrides }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || "Failed to update mirror options");
+    }
+
+    if (onRefresh) {
+      await onRefresh();
+    }
+  };
 
   const handleUpdateDestination = async (repoId: string, newDestination: string | null) => {
     // Call API to update repository destination
@@ -152,6 +175,7 @@ export default function RepositoryTable({
     filter.status,
     filter.owner,
     filter.organization,
+    filter.hasOverrides,
   ].some((val) => val?.toString().trim() !== "");
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
@@ -169,8 +193,12 @@ export default function RepositoryTable({
       next.push({ id: "organization", value: filter.organization });
     }
 
+    if (filter.hasOverrides) {
+      next.push({ id: "hasOverrides", value: filter.hasOverrides });
+    }
+
     return next;
-  }, [filter.status, filter.owner, filter.organization]);
+  }, [filter.status, filter.owner, filter.organization, filter.hasOverrides]);
 
   const sorting = useMemo(() => getTableSorting(filter.sort), [filter.sort]);
 
@@ -194,6 +222,13 @@ export default function RepositoryTable({
         id: "status",
         accessorFn: (row) => row.status,
         filterFn: "equalsString",
+      },
+      {
+        id: "hasOverrides",
+        accessorFn: (row) =>
+          hasMirrorOverrides(row.mirrorOverrides) ? "overridden" : "default",
+        filterFn: "equalsString",
+        enableGlobalFilter: false,
       },
       {
         id: "importedAt",
@@ -778,6 +813,21 @@ export default function RepositoryTable({
                             Fork
                           </span>
                         )}
+                        {hasMirrorOverrides(repo.mirrorOverrides) && (
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="ml-2 shrink-0 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs text-amber-600 dark:text-amber-400">
+                                  Custom
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                This repository overrides the global mirror
+                                options
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        )}
                       </MarqueeTrigger>
                       {/* Owner */}
                       <div className="h-full p-3 flex items-center flex-[1]">
@@ -848,6 +898,7 @@ export default function RepositoryTable({
                           onDelete={onDelete && repo.id ? () => onDelete(repo.id as string) : undefined}
                           onApproveSync={onApproveSync ? () => onApproveSync({ repoId: repo.id ?? "" }) : undefined}
                           onDismissSync={onDismissSync ? () => onDismissSync({ repoId: repo.id ?? "" }) : undefined}
+                          onEditMirrorOptions={repo.id ? () => setOverridesTarget(repo) : undefined}
                         />
                       </div>
                       {/* Links */}
@@ -947,6 +998,29 @@ export default function RepositoryTable({
           </div>
         </>
       )}
+
+      <MirrorOverridesDialog
+        open={!!overridesTarget}
+        onOpenChange={(open) => {
+          if (!open) setOverridesTarget(null);
+        }}
+        targetKind="repository"
+        targetName={overridesTarget?.fullName ?? ""}
+        value={overridesTarget?.mirrorOverrides ?? null}
+        inheritedFrom={{
+          lfs: !!giteaConfig?.lfs,
+          wiki: !!giteaConfig?.wiki,
+          mirrorIssues: !!giteaConfig?.mirrorIssues,
+          mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
+          mirrorReleases: !!giteaConfig?.mirrorReleases,
+        }}
+        inheritedLabel="organization or global settings"
+        onSave={async (overrides) => {
+          if (overridesTarget?.id) {
+            await handleUpdateMirrorOverrides(overridesTarget.id, overrides);
+          }
+        }}
+      />
     </div>
   );
 }
@@ -961,6 +1035,7 @@ function RepoActionButton({
   onDelete,
   onApproveSync,
   onDismissSync,
+  onEditMirrorOptions,
 }: {
   repo: { id: string; status: string };
   isLoading: boolean;
@@ -971,6 +1046,7 @@ function RepoActionButton({
   onDelete?: () => void;
   onApproveSync?: () => void;
   onDismissSync?: () => void;
+  onEditMirrorOptions?: () => void;
 }) {
   // For pending-approval repos, show approve/dismiss actions
   if (repo.status === "pending-approval") {
@@ -1087,6 +1163,12 @@ function RepoActionButton({
         </DropdownMenuTrigger>
       </div>
       <DropdownMenuContent align="end">
+        {onEditMirrorOptions && (
+          <DropdownMenuItem onClick={onEditMirrorOptions}>
+            <SlidersHorizontal className="h-4 w-4 mr-2" />
+            Mirror Options
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={() => onSkip(true)}>
           <Ban className="h-4 w-4 mr-2" />
           Ignore Repository

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getCoreRowModel,
   getFilteredRowModel,
@@ -28,7 +28,7 @@ import {
 import { InlineDestinationEditor } from "./InlineDestinationEditor";
 import { MarqueeText, MarqueeTrigger } from "@/components/ui/marquee-text";
 import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
-import { hasMirrorOverrides } from "@/lib/utils/mirror-overrides";
+import { hasMirrorOverrides, type MirrorOverrideKey } from "@/lib/utils/mirror-overrides";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { withBase } from "@/lib/base-path";
@@ -103,8 +103,69 @@ export default function RepositoryTable({
 }: RepositoryTableProps) {
   const tableParentRef = useRef<HTMLDivElement>(null);
   const lastSelectedIndexRef = useRef<number | null>(null);
-  const { giteaConfig } = useGiteaConfig();
+  const { giteaConfig, advancedOptions } = useGiteaConfig();
   const [overridesTarget, setOverridesTarget] = useState<Repository | null>(null);
+  // Organization-tier overrides for the repo being edited, so the dialog's
+  // "Inherit" hint reflects global -> org rather than global alone.
+  const [orgOverrides, setOrgOverrides] = useState<MirrorOverrides | null>(null);
+  const [orgOverridesLoading, setOrgOverridesLoading] = useState(false);
+
+  useEffect(() => {
+    const orgName = overridesTarget?.organization;
+
+    // Personal repos have no org tier to fetch.
+    if (!overridesTarget || !orgName) {
+      setOrgOverrides(null);
+      setOrgOverridesLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setOrgOverridesLoading(true);
+    setOrgOverrides(null);
+
+    (async () => {
+      try {
+        const response = await fetch(
+          `${withBase("/api/organizations/mirror-overrides")}?name=${encodeURIComponent(orgName)}`
+        );
+        if (!response.ok) throw new Error("Failed to load organization overrides");
+        const data = await response.json();
+        if (!cancelled) setOrgOverrides(data.mirrorOverrides ?? null);
+      } catch {
+        // Degrade to the global values rather than blocking the dialog.
+        if (!cancelled) setOrgOverrides(null);
+      } finally {
+        if (!cancelled) setOrgOverridesLoading(false);
+      }
+    })();
+
+    // Ignore a late response for a repo the user already navigated away from.
+    return () => {
+      cancelled = true;
+    };
+  }, [overridesTarget]);
+
+  // Global defaults with the organization tier layered on top.
+  const inheritedMirrorOptions = useMemo(() => {
+    const globals: Partial<Record<MirrorOverrideKey, boolean>> = {
+      lfs: !!giteaConfig?.lfs,
+      wiki: !!giteaConfig?.wiki,
+      mirrorIssues: !!giteaConfig?.mirrorIssues,
+      mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
+      mirrorReleases: !!giteaConfig?.mirrorReleases,
+      mirrorLabels: !!giteaConfig?.mirrorLabels,
+      mirrorMilestones: !!giteaConfig?.mirrorMilestones,
+    };
+
+    if (!orgOverrides) return globals;
+
+    for (const key of Object.keys(globals) as MirrorOverrideKey[]) {
+      const orgValue = orgOverrides[key];
+      if (typeof orgValue === "boolean") globals[key] = orgValue;
+    }
+    return globals;
+  }, [giteaConfig, orgOverrides]);
 
   const handleUpdateMirrorOverrides = async (
     repoId: string,
@@ -1007,14 +1068,15 @@ export default function RepositoryTable({
         targetKind="repository"
         targetName={overridesTarget?.fullName ?? ""}
         value={overridesTarget?.mirrorOverrides ?? null}
-        inheritedFrom={{
-          lfs: !!giteaConfig?.lfs,
-          wiki: !!giteaConfig?.wiki,
-          mirrorIssues: !!giteaConfig?.mirrorIssues,
-          mirrorPullRequests: !!giteaConfig?.mirrorPullRequests,
-          mirrorReleases: !!giteaConfig?.mirrorReleases,
-        }}
-        inheritedLabel="organization or global settings"
+        inheritedFrom={inheritedMirrorOptions}
+        inheritedLoading={orgOverridesLoading}
+        isStarred={!!overridesTarget?.isStarred}
+        starredCodeOnly={!!advancedOptions?.starredCodeOnly}
+        inheritedLabel={
+          overridesTarget?.organization
+            ? "organization or global settings"
+            : "global settings"
+        }
         onSave={async (overrides) => {
           if (overridesTarget?.id) {
             await handleUpdateMirrorOverrides(overridesTarget.id, overrides);

--- a/src/hooks/useGiteaConfig.ts
+++ b/src/hooks/useGiteaConfig.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './useAuth';
 import { apiRequest } from '@/lib/utils';
-import type { AdvancedOptions, ConfigApiResponse, GiteaConfig } from '@/types/config';
+import type { AdvancedOptions, ConfigApiResponse, GiteaConfig, MirrorOptions } from '@/types/config';
 import { getCachedConfig } from './useConfigStatus';
 
 interface GiteaConfigHook {
@@ -11,6 +11,11 @@ interface GiteaConfigHook {
    * starredCodeOnly without a second request.
    */
   advancedOptions: AdvancedOptions | null;
+  /**
+   * Mirror flags in the API's reshaped form. The mirror flags are NOT present
+   * on giteaConfig in this payload; use mirrorOptionsToFlags() to read them.
+   */
+  mirrorOptions: MirrorOptions | null;
   isLoading: boolean;
   error: string | null;
 }
@@ -24,6 +29,7 @@ export function useGiteaConfig(): GiteaConfigHook {
   const [giteaConfigState, setGiteaConfigState] = useState<GiteaConfigHook>({
     giteaConfig: null,
     advancedOptions: null,
+    mirrorOptions: null,
     isLoading: true,
     error: null,
   });
@@ -33,6 +39,7 @@ export function useGiteaConfig(): GiteaConfigHook {
       setGiteaConfigState({
         giteaConfig: null,
         advancedOptions: null,
+        mirrorOptions: null,
         isLoading: false,
         error: 'User not authenticated',
       });
@@ -45,6 +52,7 @@ export function useGiteaConfig(): GiteaConfigHook {
       setGiteaConfigState({
         giteaConfig: cachedConfig.giteaConfig || null,
         advancedOptions: cachedConfig.advancedOptions || null,
+        mirrorOptions: cachedConfig.mirrorOptions || null,
         isLoading: false,
         error: null,
       });
@@ -62,6 +70,7 @@ export function useGiteaConfig(): GiteaConfigHook {
       setGiteaConfigState({
         giteaConfig: configResponse?.giteaConfig || null,
         advancedOptions: configResponse?.advancedOptions || null,
+        mirrorOptions: configResponse?.mirrorOptions || null,
         isLoading: false,
         error: null,
       });
@@ -69,6 +78,7 @@ export function useGiteaConfig(): GiteaConfigHook {
       setGiteaConfigState({
         giteaConfig: null,
         advancedOptions: null,
+        mirrorOptions: null,
         isLoading: false,
         error: error instanceof Error ? error.message : 'Failed to fetch Gitea configuration',
       });

--- a/src/hooks/useGiteaConfig.ts
+++ b/src/hooks/useGiteaConfig.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './useAuth';
 import { apiRequest } from '@/lib/utils';
-import type { ConfigApiResponse, GiteaConfig } from '@/types/config';
+import type { AdvancedOptions, ConfigApiResponse, GiteaConfig } from '@/types/config';
 import { getCachedConfig } from './useConfigStatus';
 
 interface GiteaConfigHook {
   giteaConfig: GiteaConfig | null;
+  /**
+   * Advanced options from the same config payload. Exposed so callers can read
+   * starredCodeOnly without a second request.
+   */
+  advancedOptions: AdvancedOptions | null;
   isLoading: boolean;
   error: string | null;
 }
@@ -18,6 +23,7 @@ export function useGiteaConfig(): GiteaConfigHook {
   const { user } = useAuth();
   const [giteaConfigState, setGiteaConfigState] = useState<GiteaConfigHook>({
     giteaConfig: null,
+    advancedOptions: null,
     isLoading: true,
     error: null,
   });
@@ -26,6 +32,7 @@ export function useGiteaConfig(): GiteaConfigHook {
     if (!user?.id) {
       setGiteaConfigState({
         giteaConfig: null,
+        advancedOptions: null,
         isLoading: false,
         error: 'User not authenticated',
       });
@@ -37,6 +44,7 @@ export function useGiteaConfig(): GiteaConfigHook {
     if (cachedConfig) {
       setGiteaConfigState({
         giteaConfig: cachedConfig.giteaConfig || null,
+        advancedOptions: cachedConfig.advancedOptions || null,
         isLoading: false,
         error: null,
       });
@@ -53,12 +61,14 @@ export function useGiteaConfig(): GiteaConfigHook {
 
       setGiteaConfigState({
         giteaConfig: configResponse?.giteaConfig || null,
+        advancedOptions: configResponse?.advancedOptions || null,
         isLoading: false,
         error: null,
       });
     } catch (error) {
       setGiteaConfigState({
         giteaConfig: null,
+        advancedOptions: null,
         isLoading: false,
         error: error instanceof Error ? error.message : 'Failed to fetch Gitea configuration',
       });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -44,6 +44,28 @@ export const backupStrategyEnum = z.enum([
   "block-on-force-push",
 ]);
 
+/**
+ * Per-object overrides for the global mirror options in `giteaConfigSchema`.
+ *
+ * Every flag is nullable, and `null`/absent means "inherit from the next tier
+ * out". Resolution order is global config -> organization -> repository, and it
+ * is applied per flag, so a repository can override LFS while still inheriting
+ * the org's issue setting. See `resolveMirrorOptions` in
+ * `src/lib/utils/mirror-overrides.ts`.
+ */
+export const mirrorOverridesSchema = z.object({
+  lfs: z.boolean().nullable().optional(),
+  wiki: z.boolean().nullable().optional(),
+  mirrorReleases: z.boolean().nullable().optional(),
+  mirrorMetadata: z.boolean().nullable().optional(),
+  mirrorIssues: z.boolean().nullable().optional(),
+  mirrorPullRequests: z.boolean().nullable().optional(),
+  mirrorLabels: z.boolean().nullable().optional(),
+  mirrorMilestones: z.boolean().nullable().optional(),
+});
+
+export type MirrorOverrides = z.infer<typeof mirrorOverridesSchema>;
+
 export const giteaConfigSchema = z.object({
   url: z.url(),
   externalUrl: z.url().optional(),
@@ -224,6 +246,7 @@ export const repositorySchema = z.object({
   lastMirrored: z.coerce.date().optional().nullable(),
   errorMessage: z.string().optional().nullable(),
   destinationOrg: z.string().optional().nullable(),
+  mirrorOverrides: mirrorOverridesSchema.optional().nullable(),
   metadata: z.string().optional().nullable(), // JSON string for metadata sync state
   importedAt: z.coerce.date(),
   createdAt: z.coerce.date(),
@@ -278,6 +301,7 @@ export const organizationSchema = z.object({
   membershipRole: z.enum(["member", "admin", "owner", "billing_manager"]).default("member"),
   isIncluded: z.boolean().default(true),
   destinationOrg: z.string().optional().nullable(),
+  mirrorOverrides: mirrorOverridesSchema.optional().nullable(),
   status: z
     .enum([
       "imported",
@@ -444,6 +468,10 @@ export const repositories = sqliteTable("repositories", {
   
   destinationOrg: text("destination_org"),
 
+  // Per-repository mirror option overrides. NULL means "inherit" (from the
+  // organization, then the global config). See mirrorOverridesSchema.
+  mirrorOverrides: text("mirror_overrides", { mode: "json" }).$type<MirrorOverrides>(),
+
   metadata: text("metadata"), // JSON string storing metadata sync state (issues, PRs, releases, etc.)
   importedAt: integer("imported_at", { mode: "timestamp" })
     .notNull()
@@ -528,6 +556,10 @@ export const organizations = sqliteTable("organizations", {
     .default(true),
 
   destinationOrg: text("destination_org"),
+
+  // Per-organization mirror option overrides. NULL means "inherit" from the
+  // global config; repository-level overrides win over these.
+  mirrorOverrides: text("mirror_overrides", { mode: "json" }).$type<MirrorOverrides>(),
 
   status: text("status").notNull().default("imported"),
   lastMirrored: integer("last_mirrored", { mode: "timestamp" }),

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -16,6 +16,7 @@ import { httpPost, httpGet, httpPatch, HttpError } from "./http-client";
 import { db, repositories } from "./db";
 import { eq } from "drizzle-orm";
 import { repoStatusEnum } from "@/types/Repository";
+import { resolveMirrorOptionsForRepository } from "./utils/mirror-overrides";
 import {
   createPreSyncBundleBackup,
   shouldCreatePreSyncBackup,
@@ -733,8 +734,14 @@ export async function syncGiteaRepoEnhanced({
       // metadataState + metadataUpdated are hoisted above the backup
       // strategy block so force-push detection can read/write the
       // acknowledged-deletions list. Don't shadow them here.
-      const skipMetadataForStarred =
-        repository.isStarred && config.githubConfig?.starredCodeOnly;
+      // Same resolution as the initial mirror path in gitea.ts: global config,
+      // then organization override, then repository override, with the
+      // starredCodeOnly clamp folded in. Without this, a repository's overrides
+      // would be honored on first mirror and then ignored on every later sync.
+      const mirrorOptions = await resolveMirrorOptionsForRepository({
+        config,
+        repository,
+      });
       let metadataOctokit: Octokit | null = null;
 
       const ensureOctokit = (): Octokit | null => {
@@ -752,19 +759,13 @@ export async function syncGiteaRepoEnhanced({
       // The underlying mirror* functions are idempotent: issues/PRs are
       // matched via [GH-ISSUE #N] / [GH-PR #N] markers and PATCHed in
       // place, labels are deduped by name, milestones by title.
-      const shouldMirrorReleases =
-        !!config.giteaConfig?.mirrorReleases && !skipMetadataForStarred;
-      const shouldMirrorIssuesThisRun =
-        !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
-      const shouldMirrorPullRequests =
-        !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
+      const shouldMirrorReleases = mirrorOptions.mirrorReleases;
+      const shouldMirrorIssuesThisRun = mirrorOptions.mirrorIssues;
+      const shouldMirrorPullRequests = mirrorOptions.mirrorPullRequests;
       // Labels-only path; issues run already creates/reconciles labels.
       const shouldMirrorLabels =
-        !!config.giteaConfig?.mirrorLabels &&
-        !skipMetadataForStarred &&
-        !shouldMirrorIssuesThisRun;
-      const shouldMirrorMilestones =
-        !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
+        mirrorOptions.mirrorLabels && !shouldMirrorIssuesThisRun;
+      const shouldMirrorMilestones = mirrorOptions.mirrorMilestones;
 
       if (shouldMirrorReleases) {
         const octokit = ensureOctokit();

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -18,6 +18,7 @@ import {
   parseRepositoryMetadataState,
   serializeRepositoryMetadataState,
 } from "./metadata-state";
+import { resolveMirrorOptionsForRepository } from "./utils/mirror-overrides";
 
 /**
  * Helper function to get organization configuration including destination override
@@ -852,20 +853,27 @@ export const mirrorGithubRepoToGitea = async ({
       console.log(`Proceeding with mirror creation for ${targetRepoName}`);
     }
 
+    // Resolve mirror options once for this repository: global config, then any
+    // organization override, then any repository override. This also folds in
+    // the starredCodeOnly clamp that used to be applied ad hoc below.
+    const mirrorOptions = await resolveMirrorOptionsForRepository({
+      config,
+      repository,
+    });
+
     // Prepare migration payload
     // For private repos, use separate auth fields instead of embedding credentials in URL
     // This is required for Forgejo 12+ which rejects URLs with embedded credentials
-    // Skip wiki for starred repos if starredCodeOnly is enabled
-    const shouldMirrorWiki = config.giteaConfig?.wiki &&
-      !(repository.isStarred && config.githubConfig?.starredCodeOnly);
-
     const migratePayload: any = {
       clone_addr: cloneAddress,
       repo_name: targetRepoName,
       mirror: true,
       mirror_interval: config.giteaConfig?.mirrorInterval || "8h",
-      wiki: shouldMirrorWiki || false,
-      lfs: config.giteaConfig?.lfs || false,
+      wiki: mirrorOptions.wiki,
+      // Gitea performs the LFS fetch inside its own migration, so a failure
+      // here aborts the entire migration with nothing to salvage. That is why
+      // a per-repository opt-out exists (issue #361).
+      lfs: mirrorOptions.lfs,
       private: repository.isPrivate,
       repo_owner: repoOwner,
       description: repository.description?.trim() || "",
@@ -915,15 +923,13 @@ export const mirrorGithubRepoToGitea = async ({
 
     const metadataState = parseRepositoryMetadataState(repository.metadata);
     let metadataUpdated = false;
-    const skipMetadataForStarred =
-      repository.isStarred && config.githubConfig?.starredCodeOnly;
 
-    // Mirror releases if enabled (always allowed to rerun for updates)
-    const shouldMirrorReleases =
-      !!config.giteaConfig?.mirrorReleases && !skipMetadataForStarred;
+    // Mirror releases if enabled (always allowed to rerun for updates).
+    // mirrorOptions already accounts for org/repo overrides and starredCodeOnly.
+    const shouldMirrorReleases = mirrorOptions.mirrorReleases;
 
     console.log(
-      `[Metadata] Release mirroring check: mirrorReleases=${config.giteaConfig?.mirrorReleases}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorReleases=${shouldMirrorReleases}`
+      `[Metadata] Release mirroring check: mirrorReleases=${mirrorOptions.mirrorReleases}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorReleases=${shouldMirrorReleases}`
     );
 
     if (shouldMirrorReleases) {
@@ -954,11 +960,10 @@ export const mirrorGithubRepoToGitea = async ({
     // The underlying mirror* functions are idempotent: issues/PRs are
     // matched via [GH-ISSUE #N] / [GH-PR #N] markers and PATCHed in place,
     // labels are deduped by name, milestones by title.
-    const shouldMirrorIssuesThisRun =
-      !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
+    const shouldMirrorIssuesThisRun = mirrorOptions.mirrorIssues;
 
     console.log(
-      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
+      `[Metadata] Issue mirroring check: mirrorIssues=${mirrorOptions.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
     );
 
     if (shouldMirrorIssuesThisRun) {
@@ -986,11 +991,10 @@ export const mirrorGithubRepoToGitea = async ({
       }
     }
 
-    const shouldMirrorPullRequests =
-      !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
+    const shouldMirrorPullRequests = mirrorOptions.mirrorPullRequests;
 
     console.log(
-      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
+      `[Metadata] Pull request mirroring check: mirrorPullRequests=${mirrorOptions.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
     );
 
     if (shouldMirrorPullRequests) {
@@ -1019,12 +1023,10 @@ export const mirrorGithubRepoToGitea = async ({
 
     // Labels-only path; issues run above already creates/reconciles labels.
     const shouldMirrorLabels =
-      !!config.giteaConfig?.mirrorLabels &&
-      !skipMetadataForStarred &&
-      !shouldMirrorIssuesThisRun;
+      mirrorOptions.mirrorLabels && !shouldMirrorIssuesThisRun;
 
     console.log(
-      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
+      `[Metadata] Label mirroring check: mirrorLabels=${mirrorOptions.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
     );
 
     if (shouldMirrorLabels) {
@@ -1051,11 +1053,10 @@ export const mirrorGithubRepoToGitea = async ({
       }
     }
 
-    const shouldMirrorMilestones =
-      !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
+    const shouldMirrorMilestones = mirrorOptions.mirrorMilestones;
 
     console.log(
-      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
+      `[Metadata] Milestone mirroring check: mirrorMilestones=${mirrorOptions.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
     );
 
     if (shouldMirrorMilestones) {
@@ -1610,21 +1611,28 @@ export async function mirrorGitHubRepoToGiteaOrg({
 
     const apiUrl = `${config.giteaConfig.url}/api/v1/repos/migrate`;
 
+    // Resolve mirror options once for this repository: global config, then any
+    // organization override, then any repository override. This also folds in
+    // the starredCodeOnly clamp that used to be applied ad hoc below.
+    const mirrorOptions = await resolveMirrorOptionsForRepository({
+      config,
+      repository,
+    });
+
     // Prepare migration payload
     // For private repos, use separate auth fields instead of embedding credentials in URL
     // This is required for Forgejo 12+ which rejects URLs with embedded credentials
-    // Skip wiki for starred repos if starredCodeOnly is enabled
-    const shouldMirrorWiki = config.giteaConfig?.wiki &&
-      !(repository.isStarred && config.githubConfig?.starredCodeOnly);
-
     const migratePayload: any = {
       clone_addr: cloneAddress,
       uid: giteaOrgId,
       repo_name: targetRepoName,
       mirror: true,
       mirror_interval: config.giteaConfig?.mirrorInterval || "8h",
-      wiki: shouldMirrorWiki || false,
-      lfs: config.giteaConfig?.lfs || false,
+      wiki: mirrorOptions.wiki,
+      // Gitea performs the LFS fetch inside its own migration, so a failure
+      // here aborts the entire migration with nothing to salvage. That is why
+      // a per-repository opt-out exists (issue #361).
+      lfs: mirrorOptions.lfs,
       private: repository.isPrivate,
       description: repository.description?.trim() || "",
       service: "git",
@@ -1673,14 +1681,12 @@ export async function mirrorGitHubRepoToGiteaOrg({
 
     const metadataState = parseRepositoryMetadataState(repository.metadata);
     let metadataUpdated = false;
-    const skipMetadataForStarred =
-      repository.isStarred && config.githubConfig?.starredCodeOnly;
 
-    const shouldMirrorReleases =
-      !!config.giteaConfig?.mirrorReleases && !skipMetadataForStarred;
+    // mirrorOptions already accounts for org/repo overrides and starredCodeOnly.
+    const shouldMirrorReleases = mirrorOptions.mirrorReleases;
 
     console.log(
-      `[Metadata] Release mirroring check: mirrorReleases=${config.giteaConfig?.mirrorReleases}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorReleases=${shouldMirrorReleases}`
+      `[Metadata] Release mirroring check: mirrorReleases=${mirrorOptions.mirrorReleases}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorReleases=${shouldMirrorReleases}`
     );
 
     if (shouldMirrorReleases) {
@@ -1709,11 +1715,10 @@ export async function mirrorGitHubRepoToGiteaOrg({
 
     // Reconcile metadata on every sync. See note in mirrorGithubRepoToGitea
     // above. The underlying mirror* functions are idempotent.
-    const shouldMirrorIssuesThisRun =
-      !!config.giteaConfig?.mirrorIssues && !skipMetadataForStarred;
+    const shouldMirrorIssuesThisRun = mirrorOptions.mirrorIssues;
 
     console.log(
-      `[Metadata] Issue mirroring check: mirrorIssues=${config.giteaConfig?.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
+      `[Metadata] Issue mirroring check: mirrorIssues=${mirrorOptions.mirrorIssues}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorIssues=${shouldMirrorIssuesThisRun}`
     );
 
     if (shouldMirrorIssuesThisRun) {
@@ -1741,11 +1746,10 @@ export async function mirrorGitHubRepoToGiteaOrg({
       }
     }
 
-    const shouldMirrorPullRequests =
-      !!config.giteaConfig?.mirrorPullRequests && !skipMetadataForStarred;
+    const shouldMirrorPullRequests = mirrorOptions.mirrorPullRequests;
 
     console.log(
-      `[Metadata] Pull request mirroring check: mirrorPullRequests=${config.giteaConfig?.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
+      `[Metadata] Pull request mirroring check: mirrorPullRequests=${mirrorOptions.mirrorPullRequests}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorPullRequests=${shouldMirrorPullRequests}`
     );
 
     if (shouldMirrorPullRequests) {
@@ -1774,12 +1778,10 @@ export async function mirrorGitHubRepoToGiteaOrg({
 
     // Labels-only path; issues run above already creates/reconciles labels.
     const shouldMirrorLabels =
-      !!config.giteaConfig?.mirrorLabels &&
-      !skipMetadataForStarred &&
-      !shouldMirrorIssuesThisRun;
+      mirrorOptions.mirrorLabels && !shouldMirrorIssuesThisRun;
 
     console.log(
-      `[Metadata] Label mirroring check: mirrorLabels=${config.giteaConfig?.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
+      `[Metadata] Label mirroring check: mirrorLabels=${mirrorOptions.mirrorLabels}, issuesRunning=${shouldMirrorIssuesThisRun}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorLabels=${shouldMirrorLabels}`
     );
 
     if (shouldMirrorLabels) {
@@ -1806,11 +1808,10 @@ export async function mirrorGitHubRepoToGiteaOrg({
       }
     }
 
-    const shouldMirrorMilestones =
-      !!config.giteaConfig?.mirrorMilestones && !skipMetadataForStarred;
+    const shouldMirrorMilestones = mirrorOptions.mirrorMilestones;
 
     console.log(
-      `[Metadata] Milestone mirroring check: mirrorMilestones=${config.giteaConfig?.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
+      `[Metadata] Milestone mirroring check: mirrorMilestones=${mirrorOptions.mirrorMilestones}, isStarred=${repository.isStarred}, starredCodeOnly=${config.githubConfig?.starredCodeOnly}, shouldMirrorMilestones=${shouldMirrorMilestones}`
     );
 
     if (shouldMirrorMilestones) {

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -535,46 +535,68 @@ describe("mirrorOptionsToFlags - client/server shape contract", () => {
     expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.labelsFollowIssues);
   });
 
-  test("mirrorMetadata off forces the metadata components off", async () => {
+  test("derived flags equal the stored DB flags the runtime reads", async () => {
+    // The property that actually matters: what the dialog shows must equal
+    // what the mirror paths will do. Both read the same stored fields, so
+    // pushing DB state out through the API mapping and back must be lossless.
+    //
+    // This replaces an earlier assertion that compared against
+    // mapUiToDbConfig's *write* derivation. That was the wrong reference: it
+    // pinned the write-path mirrorMetadata AND into the read path and so
+    // enshrined the bug it was meant to guard.
     const { mapDbToUiConfig } = await import("./config-mapper");
-    const apiShape = mapDbToUiConfig(
-      makeDbConfig({ mirrorMetadata: false })
+    const dbConfig = makeDbConfig();
+    const flags = mirrorOptionsToFlags(
+      mapDbToUiConfig(dbConfig).mirrorOptions
     );
-    const flags = mirrorOptionsToFlags(apiShape.mirrorOptions);
 
-    expect(flags.mirrorIssues).toBe(false);
-    expect(flags.mirrorLabels).toBe(false);
-    expect(flags.wiki).toBe(false);
-    // lfs and releases sit outside the master switch.
-    expect(flags.lfs).toBe(true);
-    expect(flags.mirrorReleases).toBe(true);
+    const stored = dbConfig.giteaConfig as Record<string, boolean>;
+    expect(flags.lfs).toBe(stored.lfs);
+    expect(flags.wiki).toBe(stored.wiki);
+    expect(flags.mirrorIssues).toBe(stored.mirrorIssues);
+    expect(flags.mirrorPullRequests).toBe(stored.mirrorPullRequests);
+    expect(flags.mirrorReleases).toBe(stored.mirrorReleases);
+    expect(flags.mirrorLabels).toBe(stored.mirrorLabels);
+    expect(flags.mirrorMilestones).toBe(stored.mirrorMilestones);
   });
 
-  test("matches what config-mapper would write back to the DB", async () => {
-    // Strongest form of the contract: the flags this derives must equal the
-    // flags mapUiToDbConfig would persist from the same mirrorOptions.
-    const { mapDbToUiConfig, mapUiToDbConfig } = await import("./config-mapper");
-    const apiShape = mapDbToUiConfig(makeDbConfig());
+  test("mirrorMetadata does not gate the components on read", async () => {
+    // Reachable via env vars: MIRROR_METADATA=false with MIRROR_ISSUES=true
+    // stores an inconsistent pair. The runtime reads mirrorIssues directly and
+    // mirrors issues, so the dialog must say so too. ANDing with
+    // mirrorMetadata here would double-apply a write-path rule and report off.
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const dbConfig = makeDbConfig({
+      mirrorMetadata: false,
+      mirrorIssues: true,
+      mirrorLabels: true,
+      wiki: true,
+    });
+    const flags = mirrorOptionsToFlags(
+      mapDbToUiConfig(dbConfig).mirrorOptions
+    );
 
-    const roundTripped = mapUiToDbConfig(
-      apiShape.githubConfig,
-      apiShape.giteaConfig,
-      apiShape.mirrorOptions,
-      apiShape.advancedOptions
-    ).giteaConfig;
+    expect(flags.mirrorIssues).toBe(true);
+    expect(flags.mirrorLabels).toBe(true);
+    expect(flags.wiki).toBe(true);
+  });
 
-    const flags = mirrorOptionsToFlags(apiShape.mirrorOptions);
+  test("the dialog agrees with the resolver on an inconsistent config", async () => {
+    // Same state, checked against the resolver the mirror paths actually use,
+    // rather than against the raw DB object.
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const dbConfig = makeDbConfig({ mirrorMetadata: false, mirrorIssues: true });
 
-    for (const key of [
-      "lfs",
-      "wiki",
-      "mirrorIssues",
-      "mirrorPullRequests",
-      "mirrorReleases",
-      "mirrorLabels",
-      "mirrorMilestones",
-    ] as const) {
-      expect(flags[key]).toBe(!!(roundTripped as any)[key]);
+    const runtime = resolveMirrorOptions({
+      config: makeConfig(dbConfig.giteaConfig as any, {}),
+      repository: makeRepo(),
+    });
+    const client = mirrorOptionsToFlags(
+      mapDbToUiConfig(dbConfig).mirrorOptions
+    );
+
+    for (const key of UI_MIRROR_OVERRIDE_KEYS) {
+      expect(client[key]).toBe(runtime[key]);
     }
   });
 

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -4,6 +4,7 @@ import {
   hasMirrorOverrides,
   listOverriddenKeys,
   MIRROR_GATING_REASONS,
+  mirrorOptionsToFlags,
   normalizeMirrorOverrides,
   parseMirrorOverrides,
   resolveMirrorOptions,
@@ -433,5 +434,155 @@ describe("UI_MIRROR_OVERRIDE_KEYS", () => {
     // gitea.ts nor gitea-enhanced.ts reads it, so a per-object override would
     // resolve fine and then do nothing.
     expect(UI_MIRROR_OVERRIDE_KEYS).not.toContain("mirrorMetadata");
+  });
+});
+
+describe("mirrorOptionsToFlags - client/server shape contract", () => {
+  // These tests deliberately go through config-mapper rather than hand-writing
+  // an API payload. The original bug was that the dialog read
+  // `giteaConfig.lfs`, which /api/config never returns: mapDbToUiConfig
+  // reshapes the flags into `mirrorOptions` with different names and nesting.
+  // A synthetic DB-shaped config cannot expose that mismatch, so the flags are
+  // pushed through the real mapping in both directions here. If config-mapper
+  // changes shape again, these fail.
+
+  /** A DB-shaped config row, as the mirror runtime actually sees it. */
+  function makeDbConfig(giteaOverrides: Record<string, unknown> = {}) {
+    return {
+      githubConfig: {
+        owner: "acme",
+        includeForks: true,
+        starredCodeOnly: false,
+      },
+      giteaConfig: {
+        url: "https://gitea.example.com",
+        token: "t",
+        defaultOwner: "acme",
+        lfs: true,
+        wiki: false,
+        mirrorMetadata: true,
+        mirrorIssues: true,
+        mirrorPullRequests: false,
+        mirrorLabels: true,
+        mirrorMilestones: false,
+        mirrorReleases: true,
+        releaseLimit: 10,
+        ...giteaOverrides,
+      },
+    };
+  }
+
+  test("flags survive the DB -> API -> flags round trip", async () => {
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const dbConfig = makeDbConfig();
+
+    // This is exactly what /api/config sends to the browser.
+    const apiShape = mapDbToUiConfig(dbConfig);
+    const flags = mirrorOptionsToFlags(apiShape.mirrorOptions);
+
+    expect(flags.lfs).toBe(true);
+    expect(flags.mirrorIssues).toBe(true);
+    expect(flags.mirrorReleases).toBe(true);
+    expect(flags.mirrorLabels).toBe(true);
+    expect(flags.mirrorPullRequests).toBe(false);
+    expect(flags.mirrorMilestones).toBe(false);
+    expect(flags.wiki).toBe(false);
+  });
+
+  test("the API payload really does not carry flags on giteaConfig", async () => {
+    // Pins the root cause. If someone later makes /api/config also return the
+    // flags on giteaConfig, this fails and the client mapping can be revisited.
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig(makeDbConfig());
+
+    expect((apiShape.giteaConfig as any).lfs).toBeUndefined();
+    expect((apiShape.giteaConfig as any).mirrorIssues).toBeUndefined();
+    // ...while mirrorOptions does, under different names.
+    expect(apiShape.mirrorOptions.mirrorLFS).toBe(true);
+    expect(apiShape.mirrorOptions.metadataComponents.issues).toBe(true);
+  });
+
+  test("reading giteaConfig directly yields the all-off bug", async () => {
+    // Reproduces the reported symptom: every hint read "currently off" because
+    // undefined coerces to false and is indistinguishable from a real off.
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig(makeDbConfig());
+    const buggy = {
+      lfs: !!(apiShape.giteaConfig as any).lfs,
+      mirrorIssues: !!(apiShape.giteaConfig as any).mirrorIssues,
+    };
+
+    expect(buggy.lfs).toBe(false); // DB says true
+    expect(buggy.mirrorIssues).toBe(false); // DB says true
+
+    const fixed = mirrorOptionsToFlags(apiShape.mirrorOptions);
+    expect(fixed.lfs).toBe(true);
+    expect(fixed.mirrorIssues).toBe(true);
+  });
+
+  test("the labels gate fires on a real API payload", async () => {
+    // The gate itself was correct but was being fed undefined, so it never
+    // fired. Drive it from a genuine payload instead.
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig(makeDbConfig());
+    const effective = mirrorOptionsToFlags(apiShape.mirrorOptions);
+
+    expect(effective.mirrorIssues).toBe(true);
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective,
+    });
+    expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.labelsFollowIssues);
+  });
+
+  test("mirrorMetadata off forces the metadata components off", async () => {
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig(
+      makeDbConfig({ mirrorMetadata: false })
+    );
+    const flags = mirrorOptionsToFlags(apiShape.mirrorOptions);
+
+    expect(flags.mirrorIssues).toBe(false);
+    expect(flags.mirrorLabels).toBe(false);
+    expect(flags.wiki).toBe(false);
+    // lfs and releases sit outside the master switch.
+    expect(flags.lfs).toBe(true);
+    expect(flags.mirrorReleases).toBe(true);
+  });
+
+  test("matches what config-mapper would write back to the DB", async () => {
+    // Strongest form of the contract: the flags this derives must equal the
+    // flags mapUiToDbConfig would persist from the same mirrorOptions.
+    const { mapDbToUiConfig, mapUiToDbConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig(makeDbConfig());
+
+    const roundTripped = mapUiToDbConfig(
+      apiShape.githubConfig,
+      apiShape.giteaConfig,
+      apiShape.mirrorOptions,
+      apiShape.advancedOptions
+    ).giteaConfig;
+
+    const flags = mirrorOptionsToFlags(apiShape.mirrorOptions);
+
+    for (const key of [
+      "lfs",
+      "wiki",
+      "mirrorIssues",
+      "mirrorPullRequests",
+      "mirrorReleases",
+      "mirrorLabels",
+      "mirrorMilestones",
+    ] as const) {
+      expect(flags[key]).toBe(!!(roundTripped as any)[key]);
+    }
+  });
+
+  test("handles a missing or empty payload without throwing", () => {
+    for (const value of [null, undefined, {}]) {
+      const flags = mirrorOptionsToFlags(value as any);
+      expect(flags.lfs).toBe(false);
+      expect(flags.mirrorIssues).toBe(false);
+    }
   });
 });

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
+  getMirrorOverrideGating,
   hasMirrorOverrides,
   listOverriddenKeys,
+  MIRROR_GATING_REASONS,
   normalizeMirrorOverrides,
   parseMirrorOverrides,
   resolveMirrorOptions,
+  STARRED_CLAMPED_KEYS,
+  UI_MIRROR_OVERRIDE_KEYS,
 } from "./mirror-overrides";
 import type { Config } from "@/types/config";
 import type { Repository } from "@/lib/db/schema";
@@ -256,5 +260,178 @@ describe("override helpers", () => {
     expect(normalizeMirrorOverrides({ lfs: false, wiki: null })).toEqual({
       lfs: false,
     });
+  });
+});
+
+describe("getMirrorOverrideGating - starred clamp", () => {
+  const starredRepo = {
+    targetKind: "repository" as const,
+    isStarred: true,
+    starredCodeOnly: true,
+    effective: {},
+  };
+
+  test("disables every metadata flag with the starred reason", () => {
+    const gating = getMirrorOverrideGating(starredRepo);
+
+    for (const key of STARRED_CLAMPED_KEYS) {
+      expect(gating[key]).toBe(MIRROR_GATING_REASONS.starredCodeOnly);
+    }
+  });
+
+  test("LFS stays editable for starred repos", () => {
+    // Regression guard for issue #361: LFS is repository content, not
+    // metadata. The clamp must never sweep it up, or the whole feature breaks
+    // for exactly the repos it was built for.
+    const gating = getMirrorOverrideGating(starredRepo);
+
+    expect(gating.lfs).toBeUndefined();
+  });
+
+  test("STARRED_CLAMPED_KEYS never contains lfs", () => {
+    expect(STARRED_CLAMPED_KEYS).not.toContain("lfs");
+  });
+
+  test("no clamp when the repo is starred but starredCodeOnly is off", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      isStarred: true,
+      starredCodeOnly: false,
+      effective: {},
+    });
+
+    expect(Object.keys(gating)).toHaveLength(0);
+  });
+
+  test("no clamp when starredCodeOnly is on but the repo is not starred", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      isStarred: false,
+      starredCodeOnly: true,
+      effective: {},
+    });
+
+    expect(Object.keys(gating)).toHaveLength(0);
+  });
+
+  test("organizations never get the starred clamp", () => {
+    // Orgs cannot be starred, so the org dialog must not show this at all.
+    const gating = getMirrorOverrideGating({
+      targetKind: "organization",
+      isStarred: true,
+      starredCodeOnly: true,
+      effective: {},
+    });
+
+    expect(gating.mirrorIssues).toBeUndefined();
+    expect(gating.wiki).toBeUndefined();
+  });
+
+  test("the clamp set matches what the resolver actually forces off", () => {
+    // Guards against the UI disabling a different set of flags than the
+    // runtime clamps, which would put the two out of sync silently.
+    const resolved = resolveMirrorOptions({
+      config: makeConfig(
+        {
+          lfs: true,
+          wiki: true,
+          mirrorReleases: true,
+          mirrorMetadata: true,
+          mirrorIssues: true,
+          mirrorPullRequests: true,
+          mirrorLabels: true,
+          mirrorMilestones: true,
+        },
+        { starredCodeOnly: true }
+      ),
+      repository: makeRepo({ isStarred: true }),
+    });
+
+    for (const key of STARRED_CLAMPED_KEYS) {
+      expect(resolved[key]).toBe(false);
+    }
+    expect(resolved.lfs).toBe(true);
+  });
+});
+
+describe("getMirrorOverrideGating - labels follow issues", () => {
+  test("labels are disabled while issues resolve to on", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective: { mirrorIssues: true },
+    });
+
+    expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.labelsFollowIssues);
+  });
+
+  test("labels are editable when issues resolve to off", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective: { mirrorIssues: false },
+    });
+
+    expect(gating.mirrorLabels).toBeUndefined();
+  });
+
+  test("applies to organizations too", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "organization",
+      effective: { mirrorIssues: true },
+    });
+
+    expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.labelsFollowIssues);
+  });
+
+  test("the starred reason wins over the labels reason", () => {
+    // Both rules apply; the more fundamental one should be the one explained.
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      isStarred: true,
+      starredCodeOnly: true,
+      effective: { mirrorIssues: true },
+    });
+
+    expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.starredCodeOnly);
+  });
+
+  test("gating matches the runtime rule for labels", () => {
+    // Runtime is `mirrorLabels && !mirrorIssues` in gitea.ts and
+    // gitea-enhanced.ts, so labels genuinely cannot take effect while issues
+    // are on. Confirm the resolver agrees with what the UI claims.
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ mirrorIssues: true, mirrorLabels: true }),
+      repository: makeRepo(),
+    });
+
+    expect(resolved.mirrorIssues).toBe(true);
+    expect(resolved.mirrorLabels).toBe(true);
+    // The runtime then suppresses the labels-only pass; the UI says so up front.
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective: resolved,
+    });
+    expect(gating.mirrorLabels).toBe(MIRROR_GATING_REASONS.labelsFollowIssues);
+  });
+});
+
+describe("UI_MIRROR_OVERRIDE_KEYS", () => {
+  test("exposes lfs plus the flags the runtime actually reads", () => {
+    expect(UI_MIRROR_OVERRIDE_KEYS).toEqual([
+      "lfs",
+      "wiki",
+      "mirrorIssues",
+      "mirrorPullRequests",
+      "mirrorReleases",
+      "mirrorLabels",
+      "mirrorMilestones",
+    ]);
+  });
+
+  test("excludes mirrorMetadata, which no mirror path reads", () => {
+    // mirrorMetadata is a write-time master switch in the global settings UI
+    // (config-mapper ANDs it into the individual flags on save). Neither
+    // gitea.ts nor gitea-enhanced.ts reads it, so a per-object override would
+    // resolve fine and then do nothing.
+    expect(UI_MIRROR_OVERRIDE_KEYS).not.toContain("mirrorMetadata");
   });
 });

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasMirrorOverrides,
+  listOverriddenKeys,
+  normalizeMirrorOverrides,
+  parseMirrorOverrides,
+  resolveMirrorOptions,
+} from "./mirror-overrides";
+import type { Config } from "@/types/config";
+import type { Repository } from "@/lib/db/schema";
+
+/** Minimal config carrying just the flags the resolver reads. */
+function makeConfig(
+  gitea: Record<string, unknown> = {},
+  github: Record<string, unknown> = {}
+): Partial<Config> {
+  return {
+    userId: "user-1",
+    giteaConfig: gitea as any,
+    githubConfig: github as any,
+  };
+}
+
+function makeRepo(overrides: Partial<Repository> = {}): any {
+  return {
+    isStarred: false,
+    mirrorOverrides: null,
+    organization: "acme",
+    ...overrides,
+  };
+}
+
+describe("resolveMirrorOptions precedence", () => {
+  test("falls back to global config when no overrides exist", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true, mirrorIssues: true, wiki: false }),
+      repository: makeRepo(),
+    });
+
+    expect(resolved.lfs).toBe(true);
+    expect(resolved.mirrorIssues).toBe(true);
+    expect(resolved.wiki).toBe(false);
+  });
+
+  test("treats missing global flags as false rather than undefined", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({}),
+      repository: makeRepo(),
+    });
+
+    for (const value of Object.values(resolved)) {
+      expect(typeof value).toBe("boolean");
+    }
+    expect(resolved.lfs).toBe(false);
+  });
+
+  test("organization override beats global config", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true, mirrorIssues: true }),
+      repository: makeRepo(),
+      orgOverrides: { lfs: false },
+    });
+
+    expect(resolved.lfs).toBe(false);
+    // Untouched flags still inherit from global.
+    expect(resolved.mirrorIssues).toBe(true);
+  });
+
+  test("repository override beats global config", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true }),
+      repository: makeRepo({ mirrorOverrides: { lfs: false } as any }),
+    });
+
+    expect(resolved.lfs).toBe(false);
+  });
+
+  test("repository override beats organization override", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: false }),
+      repository: makeRepo({ mirrorOverrides: { lfs: true } as any }),
+      orgOverrides: { lfs: false },
+    });
+
+    expect(resolved.lfs).toBe(true);
+  });
+
+  test("resolution is per flag, not all-or-nothing", () => {
+    // global: everything on. org turns issues off. repo turns lfs off.
+    // Each flag should land on its own most-specific tier.
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({
+        lfs: true,
+        wiki: true,
+        mirrorIssues: true,
+        mirrorReleases: true,
+      }),
+      repository: makeRepo({ mirrorOverrides: { lfs: false } as any }),
+      orgOverrides: { mirrorIssues: false },
+    });
+
+    expect(resolved.lfs).toBe(false); // repo tier
+    expect(resolved.mirrorIssues).toBe(false); // org tier
+    expect(resolved.wiki).toBe(true); // global tier
+    expect(resolved.mirrorReleases).toBe(true); // global tier
+  });
+
+  test("an explicit true override re-enables a globally disabled flag", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: false }),
+      repository: makeRepo({ mirrorOverrides: { lfs: true } as any }),
+    });
+
+    expect(resolved.lfs).toBe(true);
+  });
+
+  test("null in an override means inherit, not false", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true }),
+      repository: makeRepo({ mirrorOverrides: { lfs: null } as any }),
+      orgOverrides: { lfs: null },
+    });
+
+    expect(resolved.lfs).toBe(true);
+  });
+});
+
+describe("resolveMirrorOptions and starredCodeOnly", () => {
+  test("starredCodeOnly forces metadata off for starred repos", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig(
+        {
+          lfs: true,
+          wiki: true,
+          mirrorIssues: true,
+          mirrorPullRequests: true,
+          mirrorReleases: true,
+          mirrorLabels: true,
+          mirrorMilestones: true,
+          mirrorMetadata: true,
+        },
+        { starredCodeOnly: true }
+      ),
+      repository: makeRepo({ isStarred: true }),
+    });
+
+    expect(resolved.wiki).toBe(false);
+    expect(resolved.mirrorIssues).toBe(false);
+    expect(resolved.mirrorPullRequests).toBe(false);
+    expect(resolved.mirrorReleases).toBe(false);
+    expect(resolved.mirrorLabels).toBe(false);
+    expect(resolved.mirrorMilestones).toBe(false);
+    expect(resolved.mirrorMetadata).toBe(false);
+    // LFS is code, not metadata, so it survives the clamp.
+    expect(resolved.lfs).toBe(true);
+  });
+
+  test("starredCodeOnly clamp outranks an explicit repo override", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({}, { starredCodeOnly: true }),
+      repository: makeRepo({
+        isStarred: true,
+        mirrorOverrides: { mirrorIssues: true } as any,
+      }),
+    });
+
+    expect(resolved.mirrorIssues).toBe(false);
+  });
+
+  test("starredCodeOnly does not affect non-starred repos", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ mirrorIssues: true }, { starredCodeOnly: true }),
+      repository: makeRepo({ isStarred: false }),
+    });
+
+    expect(resolved.mirrorIssues).toBe(true);
+  });
+
+  test("starred repo without starredCodeOnly keeps its metadata flags", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ mirrorIssues: true }, { starredCodeOnly: false }),
+      repository: makeRepo({ isStarred: true }),
+    });
+
+    expect(resolved.mirrorIssues).toBe(true);
+  });
+
+  test("the #361 case: repo opts out of LFS, everything else unchanged", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true, mirrorIssues: true, mirrorReleases: true }),
+      repository: makeRepo({
+        mirrorOverrides: { lfs: false } as any,
+      }),
+    });
+
+    expect(resolved.lfs).toBe(false);
+    expect(resolved.mirrorIssues).toBe(true);
+    expect(resolved.mirrorReleases).toBe(true);
+  });
+});
+
+describe("parseMirrorOverrides", () => {
+  test("returns null for null, undefined and empty string", () => {
+    expect(parseMirrorOverrides(null)).toBeNull();
+    expect(parseMirrorOverrides(undefined)).toBeNull();
+    expect(parseMirrorOverrides("")).toBeNull();
+    expect(parseMirrorOverrides("   ")).toBeNull();
+  });
+
+  test("parses a JSON string payload", () => {
+    expect(parseMirrorOverrides('{"lfs":false}')).toEqual({ lfs: false });
+  });
+
+  test("accepts an already-parsed object", () => {
+    expect(parseMirrorOverrides({ lfs: true })).toEqual({ lfs: true });
+  });
+
+  test("degrades malformed input to null instead of throwing", () => {
+    // A bad override must never be able to break a mirror run.
+    expect(parseMirrorOverrides("{not json")).toBeNull();
+    expect(parseMirrorOverrides([1, 2, 3])).toBeNull();
+    expect(parseMirrorOverrides(42)).toBeNull();
+    expect(parseMirrorOverrides({ lfs: "yes" })).toBeNull();
+  });
+
+  test("a malformed override falls back to global config in the resolver", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true }),
+      repository: makeRepo({ mirrorOverrides: "{corrupt" as any }),
+    });
+
+    expect(resolved.lfs).toBe(true);
+  });
+});
+
+describe("override helpers", () => {
+  test("hasMirrorOverrides only counts pinned flags", () => {
+    expect(hasMirrorOverrides(null)).toBe(false);
+    expect(hasMirrorOverrides({})).toBe(false);
+    expect(hasMirrorOverrides({ lfs: null })).toBe(false);
+    expect(hasMirrorOverrides({ lfs: false })).toBe(true);
+    expect(hasMirrorOverrides({ lfs: true })).toBe(true);
+  });
+
+  test("listOverriddenKeys reports which flags deviate", () => {
+    expect(listOverriddenKeys({ lfs: false, mirrorIssues: true })).toEqual([
+      "lfs",
+      "mirrorIssues",
+    ]);
+    expect(listOverriddenKeys({ lfs: null })).toEqual([]);
+  });
+
+  test("normalizeMirrorOverrides strips nulls and collapses empty to null", () => {
+    expect(normalizeMirrorOverrides({ lfs: null, wiki: undefined })).toBeNull();
+    expect(normalizeMirrorOverrides({})).toBeNull();
+    expect(normalizeMirrorOverrides({ lfs: false, wiki: null })).toEqual({
+      lfs: false,
+    });
+  });
+});

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -24,9 +24,32 @@ export type MirrorOverrideKey = (typeof MIRROR_OVERRIDE_KEYS)[number];
 export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean>;
 
 /**
- * The five flags surfaced in the override UI. The resolver handles all eight,
- * but metadata/labels/milestones are derived or niche enough that exposing
- * them as per-repo toggles would be more confusing than useful.
+ * Flags the starred-code-only clamp forces off.
+ *
+ * Shared by the resolver and the UI gating helper so the two cannot drift.
+ * `lfs` is deliberately absent: LFS is repository content, not metadata, and
+ * turning it off per repository is the entire point of issue #361. It must
+ * stay editable for starred repos.
+ */
+export const STARRED_CLAMPED_KEYS = [
+  "wiki",
+  "mirrorReleases",
+  "mirrorMetadata",
+  "mirrorIssues",
+  "mirrorPullRequests",
+  "mirrorLabels",
+  "mirrorMilestones",
+] as const satisfies readonly MirrorOverrideKey[];
+
+/**
+ * Flags surfaced in the override UI.
+ *
+ * `mirrorMetadata` is intentionally excluded. It is a write-time master switch
+ * in the global settings UI (config-mapper ANDs it into the individual flags
+ * when the config is saved) and is never read by the mirror paths in gitea.ts
+ * or gitea-enhanced.ts. A per-object override for it would resolve correctly
+ * and then change nothing, which is exactly the silent no-op this UI is meant
+ * to avoid.
  */
 export const UI_MIRROR_OVERRIDE_KEYS: MirrorOverrideKey[] = [
   "lfs",
@@ -34,7 +57,67 @@ export const UI_MIRROR_OVERRIDE_KEYS: MirrorOverrideKey[] = [
   "mirrorIssues",
   "mirrorPullRequests",
   "mirrorReleases",
+  "mirrorLabels",
+  "mirrorMilestones",
 ];
+
+/** Reasons a toggle is disabled. Shown verbatim in the dialog. */
+export const MIRROR_GATING_REASONS = {
+  starredCodeOnly:
+    "Starred repos mirror code only (Advanced Options > starred code only)",
+  labelsFollowIssues: "Issues mirroring already syncs labels",
+} as const;
+
+/** key -> reason it cannot take effect. Absent key means editable. */
+export type MirrorOverrideGating = Partial<Record<MirrorOverrideKey, string>>;
+
+/**
+ * Decide which toggles cannot take effect, and why.
+ *
+ * This is the single source of truth behind the rule that a toggle which
+ * cannot take effect is disabled with a reason rather than silently ignored.
+ * It mirrors the real runtime behavior:
+ *
+ *  - the starred clamp in `resolveMirrorOptions` forces STARRED_CLAMPED_KEYS
+ *    off for starred repos when starredCodeOnly is set, outranking any override
+ *  - `shouldMirrorLabels` in gitea.ts / gitea-enhanced.ts is
+ *    `mirrorLabels && !mirrorIssues`, so labels cannot take effect while issues
+ *    are being mirrored (the issue path already reconciles labels)
+ *
+ * `effective` is the value each flag currently resolves to including the
+ * in-progress edit, so the labels gate reacts live as issues is toggled.
+ */
+export function getMirrorOverrideGating({
+  targetKind,
+  isStarred,
+  starredCodeOnly,
+  effective,
+}: {
+  targetKind: "repository" | "organization";
+  isStarred?: boolean;
+  starredCodeOnly?: boolean;
+  effective: Partial<Record<MirrorOverrideKey, boolean>>;
+}): MirrorOverrideGating {
+  const gating: MirrorOverrideGating = {};
+
+  // Organizations are never starred, so the clamp cannot apply to them.
+  const starredClampApplies =
+    targetKind === "repository" && !!isStarred && !!starredCodeOnly;
+
+  if (starredClampApplies) {
+    for (const key of STARRED_CLAMPED_KEYS) {
+      gating[key] = MIRROR_GATING_REASONS.starredCodeOnly;
+    }
+  }
+
+  // Labels ride along with issues. Only report this when the more fundamental
+  // starred clamp has not already disabled the toggle.
+  if (!gating.mirrorLabels && effective.mirrorIssues) {
+    gating.mirrorLabels = MIRROR_GATING_REASONS.labelsFollowIssues;
+  }
+
+  return gating;
+}
 
 export const MIRROR_OVERRIDE_LABELS: Record<MirrorOverrideKey, string> = {
   lfs: "Git LFS files",
@@ -163,13 +246,12 @@ export function resolveMirrorOptions({
     !!repository.isStarred && !!config.githubConfig?.starredCodeOnly;
 
   if (skipMetadataForStarred) {
-    resolved.wiki = false;
-    resolved.mirrorReleases = false;
-    resolved.mirrorMetadata = false;
-    resolved.mirrorIssues = false;
-    resolved.mirrorPullRequests = false;
-    resolved.mirrorLabels = false;
-    resolved.mirrorMilestones = false;
+    // STARRED_CLAMPED_KEYS is shared with getMirrorOverrideGating so the set of
+    // flags the UI disables always matches the set the runtime forces off.
+    // Note it excludes `lfs` by design.
+    for (const key of STARRED_CLAMPED_KEYS) {
+      resolved[key] = false;
+    }
   }
 
   return resolved;

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -72,10 +72,19 @@ export const UI_MIRROR_OVERRIDE_KEYS: MirrorOverrideKey[] = [
  * code reading `giteaConfig.lfs` therefore gets `undefined`, not `false`, which
  * is indistinguishable from "off" once coerced.
  *
- * This mirrors the derivation in `mapUiToDbConfig` exactly, including that
- * `mirrorMetadata` acts as a master switch over the metadata components, while
- * `lfs` and `mirrorReleases` sit outside it. A round-trip test pins this
- * against config-mapper so it fails if that mapping changes again.
+ * The mapping is 1:1 with the fields the runtime reads. `metadataComponents.*`
+ * carries the raw stored values (`issues` is `giteaConfig.mirrorIssues`
+ * untouched), so passing them straight through reproduces exactly what
+ * gitea.ts and gitea-enhanced.ts will do.
+ *
+ * Deliberately does NOT AND the components with `mirrorMetadata`. That switch
+ * is a write-path concern: `mapUiToDbConfig` already applies it when
+ * persisting, so a config saved through the settings UI has it baked into the
+ * stored flag. Applying it again on read double-applies it. That is invisible
+ * while the stored state is self-consistent, and wrong when it is not, which
+ * is reachable via env vars: MIRROR_METADATA=false with MIRROR_ISSUES=true
+ * stores `mirrorMetadata:false, mirrorIssues:true`, and the runtime mirrors
+ * issues. A second AND here would report "off" for something that is on.
  */
 export function mirrorOptionsToFlags(
   mirrorOptions:
@@ -94,19 +103,17 @@ export function mirrorOptionsToFlags(
     | null
     | undefined
 ): Partial<Record<MirrorOverrideKey, boolean>> {
-  const metadataOn = !!mirrorOptions?.mirrorMetadata;
   const components = mirrorOptions?.metadataComponents;
 
+  // Straight through: each field is the raw stored value the runtime reads.
   return {
-    // Not gated by mirrorMetadata.
     lfs: !!mirrorOptions?.mirrorLFS,
     mirrorReleases: !!mirrorOptions?.mirrorReleases,
-    // Gated by mirrorMetadata, matching mapUiToDbConfig.
-    wiki: metadataOn && !!components?.wiki,
-    mirrorIssues: metadataOn && !!components?.issues,
-    mirrorPullRequests: metadataOn && !!components?.pullRequests,
-    mirrorLabels: metadataOn && !!components?.labels,
-    mirrorMilestones: metadataOn && !!components?.milestones,
+    wiki: !!components?.wiki,
+    mirrorIssues: !!components?.issues,
+    mirrorPullRequests: !!components?.pullRequests,
+    mirrorLabels: !!components?.labels,
+    mirrorMilestones: !!components?.milestones,
   };
 }
 

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -61,6 +61,55 @@ export const UI_MIRROR_OVERRIDE_KEYS: MirrorOverrideKey[] = [
   "mirrorMilestones",
 ];
 
+/**
+ * Convert the API's `mirrorOptions` shape into the flag keys used everywhere
+ * else.
+ *
+ * `/api/config` does not return the mirror flags on `giteaConfig`. On the way
+ * out, `mapDbToUiConfig` reshapes them into `mirrorOptions`, which uses
+ * different names (`mirrorLFS`, not `lfs`) and nests the metadata flags under
+ * `metadataComponents` with short names (`issues`, not `mirrorIssues`). Client
+ * code reading `giteaConfig.lfs` therefore gets `undefined`, not `false`, which
+ * is indistinguishable from "off" once coerced.
+ *
+ * This mirrors the derivation in `mapUiToDbConfig` exactly, including that
+ * `mirrorMetadata` acts as a master switch over the metadata components, while
+ * `lfs` and `mirrorReleases` sit outside it. A round-trip test pins this
+ * against config-mapper so it fails if that mapping changes again.
+ */
+export function mirrorOptionsToFlags(
+  mirrorOptions:
+    | {
+        mirrorLFS?: boolean;
+        mirrorReleases?: boolean;
+        mirrorMetadata?: boolean;
+        metadataComponents?: {
+          issues?: boolean;
+          pullRequests?: boolean;
+          labels?: boolean;
+          milestones?: boolean;
+          wiki?: boolean;
+        };
+      }
+    | null
+    | undefined
+): Partial<Record<MirrorOverrideKey, boolean>> {
+  const metadataOn = !!mirrorOptions?.mirrorMetadata;
+  const components = mirrorOptions?.metadataComponents;
+
+  return {
+    // Not gated by mirrorMetadata.
+    lfs: !!mirrorOptions?.mirrorLFS,
+    mirrorReleases: !!mirrorOptions?.mirrorReleases,
+    // Gated by mirrorMetadata, matching mapUiToDbConfig.
+    wiki: metadataOn && !!components?.wiki,
+    mirrorIssues: metadataOn && !!components?.issues,
+    mirrorPullRequests: metadataOn && !!components?.pullRequests,
+    mirrorLabels: metadataOn && !!components?.labels,
+    mirrorMilestones: metadataOn && !!components?.milestones,
+  };
+}
+
 /** Reasons a toggle is disabled. Shown verbatim in the dialog. */
 export const MIRROR_GATING_REASONS = {
   starredCodeOnly:

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -1,0 +1,237 @@
+import type { Config } from "@/types/config";
+import type { MirrorOverrides, Repository } from "@/lib/db/schema";
+import { mirrorOverridesSchema } from "@/lib/db/schema";
+
+/**
+ * The mirror option flags that can be overridden per organization and per
+ * repository. These mirror the flag names on `giteaConfigSchema` so the
+ * resolver can read both tiers with the same key.
+ */
+export const MIRROR_OVERRIDE_KEYS = [
+  "lfs",
+  "wiki",
+  "mirrorReleases",
+  "mirrorMetadata",
+  "mirrorIssues",
+  "mirrorPullRequests",
+  "mirrorLabels",
+  "mirrorMilestones",
+] as const;
+
+export type MirrorOverrideKey = (typeof MIRROR_OVERRIDE_KEYS)[number];
+
+/** Fully resolved mirror options: every flag has a definite boolean value. */
+export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean>;
+
+/**
+ * The five flags surfaced in the override UI. The resolver handles all eight,
+ * but metadata/labels/milestones are derived or niche enough that exposing
+ * them as per-repo toggles would be more confusing than useful.
+ */
+export const UI_MIRROR_OVERRIDE_KEYS: MirrorOverrideKey[] = [
+  "lfs",
+  "wiki",
+  "mirrorIssues",
+  "mirrorPullRequests",
+  "mirrorReleases",
+];
+
+export const MIRROR_OVERRIDE_LABELS: Record<MirrorOverrideKey, string> = {
+  lfs: "Git LFS files",
+  wiki: "Wiki",
+  mirrorReleases: "Releases",
+  mirrorMetadata: "Metadata",
+  mirrorIssues: "Issues",
+  mirrorPullRequests: "Pull requests",
+  mirrorLabels: "Labels",
+  mirrorMilestones: "Milestones",
+};
+
+/**
+ * Normalize a persisted overrides value into a plain object.
+ *
+ * The column is JSON-mode, so Drizzle hands back an object, but rows written
+ * before this feature (or by a raw SQL path) may hold a string or NULL. Invalid
+ * shapes degrade to "no overrides" rather than throwing, because a malformed
+ * override must never be able to break a mirror run.
+ */
+export function parseMirrorOverrides(
+  value: unknown
+): MirrorOverrides | null {
+  if (value == null) return null;
+
+  let candidate = value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      candidate = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof candidate !== "object" || Array.isArray(candidate)) return null;
+
+  const parsed = mirrorOverridesSchema.safeParse(candidate);
+  if (!parsed.success) return null;
+
+  return parsed.data;
+}
+
+/** True when the overrides object actually pins at least one flag. */
+export function hasMirrorOverrides(value: unknown): boolean {
+  const overrides = parseMirrorOverrides(value);
+  if (!overrides) return false;
+  return MIRROR_OVERRIDE_KEYS.some((key) => overrides[key] != null);
+}
+
+/** The keys an overrides object pins, for badges and summaries. */
+export function listOverriddenKeys(value: unknown): MirrorOverrideKey[] {
+  const overrides = parseMirrorOverrides(value);
+  if (!overrides) return [];
+  return MIRROR_OVERRIDE_KEYS.filter((key) => overrides[key] != null);
+}
+
+/**
+ * Strip flags that are null/undefined so only genuine pins are stored, and
+ * collapse an empty result to null. Keeps "no overrides" as a single canonical
+ * representation instead of `{}` vs `{lfs: null}` vs NULL.
+ */
+export function normalizeMirrorOverrides(
+  value: unknown
+): MirrorOverrides | null {
+  const overrides = parseMirrorOverrides(value);
+  if (!overrides) return null;
+
+  const cleaned: MirrorOverrides = {};
+  for (const key of MIRROR_OVERRIDE_KEYS) {
+    const flag = overrides[key];
+    if (typeof flag === "boolean") cleaned[key] = flag;
+  }
+
+  return Object.keys(cleaned).length > 0 ? cleaned : null;
+}
+
+/**
+ * Resolve the effective mirror options for one repository.
+ *
+ * Precedence is per flag, most specific tier wins:
+ *   repository override -> organization override -> global config -> false
+ *
+ * `starredCodeOnly` is applied last as a hard clamp. It is a "code only, no
+ * metadata" switch for starred repos, so it forces every metadata flag off
+ * regardless of what any tier asked for. That preserves the pre-existing
+ * behavior of `skipMetadataForStarred`, which this function subsumes.
+ *
+ * Pure and synchronous by design: the organization overrides are fetched by
+ * the caller (see `loadOrganizationMirrorOverrides`) so this stays trivially
+ * testable.
+ */
+export function resolveMirrorOptions({
+  config,
+  repository,
+  orgOverrides,
+}: {
+  config: Partial<Config>;
+  repository: Pick<Repository, "isStarred" | "mirrorOverrides">;
+  orgOverrides?: unknown;
+}): ResolvedMirrorOptions {
+  const globalConfig = config.giteaConfig;
+  const org = parseMirrorOverrides(orgOverrides);
+  const repo = parseMirrorOverrides(repository.mirrorOverrides);
+
+  const resolved = {} as ResolvedMirrorOptions;
+
+  for (const key of MIRROR_OVERRIDE_KEYS) {
+    const repoValue = repo?.[key];
+    const orgValue = org?.[key];
+
+    if (typeof repoValue === "boolean") {
+      resolved[key] = repoValue;
+    } else if (typeof orgValue === "boolean") {
+      resolved[key] = orgValue;
+    } else {
+      resolved[key] = !!globalConfig?.[key];
+    }
+  }
+
+  // Starred repos with starredCodeOnly mirror code and nothing else. This
+  // clamp intentionally outranks explicit per-repo overrides: the setting
+  // exists to stop starred repos from dragging in metadata wholesale.
+  const skipMetadataForStarred =
+    !!repository.isStarred && !!config.githubConfig?.starredCodeOnly;
+
+  if (skipMetadataForStarred) {
+    resolved.wiki = false;
+    resolved.mirrorReleases = false;
+    resolved.mirrorMetadata = false;
+    resolved.mirrorIssues = false;
+    resolved.mirrorPullRequests = false;
+    resolved.mirrorLabels = false;
+    resolved.mirrorMilestones = false;
+  }
+
+  return resolved;
+}
+
+/**
+ * Fetch the organization-tier overrides for a repository, if it belongs to one.
+ *
+ * Returns null for personal repos, unknown orgs, or when the org has no
+ * overrides set. Failures are swallowed to null: a DB hiccup reading an
+ * optional override must not fail the mirror.
+ */
+export async function loadOrganizationMirrorOverrides({
+  organizationName,
+  userId,
+}: {
+  organizationName?: string | null;
+  userId?: string;
+}): Promise<MirrorOverrides | null> {
+  if (!organizationName || !userId) return null;
+
+  try {
+    const { db, organizations } = await import("@/lib/db");
+    const { and, eq } = await import("drizzle-orm");
+
+    const [org] = await db
+      .select({ mirrorOverrides: organizations.mirrorOverrides })
+      .from(organizations)
+      .where(
+        and(
+          eq(organizations.userId, userId),
+          eq(organizations.name, organizationName)
+        )
+      )
+      .limit(1);
+
+    return parseMirrorOverrides(org?.mirrorOverrides);
+  } catch (error) {
+    console.error(
+      `[MirrorOverrides] Failed to load organization overrides for ${organizationName}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+}
+
+/**
+ * Convenience wrapper: load the org tier then resolve. This is what the mirror
+ * paths in gitea.ts call.
+ */
+export async function resolveMirrorOptionsForRepository({
+  config,
+  repository,
+}: {
+  config: Partial<Config>;
+  repository: Repository;
+}): Promise<ResolvedMirrorOptions> {
+  const orgOverrides = await loadOrganizationMirrorOverrides({
+    organizationName: repository.organization,
+    userId: config.userId,
+  });
+
+  return resolveMirrorOptions({ config, repository, orgOverrides });
+}

--- a/src/pages/api/organizations/[id].ts
+++ b/src/pages/api/organizations/[id].ts
@@ -1,8 +1,20 @@
 import type { APIRoute } from "astro";
 import { db, organizations, repositories } from "@/lib/db";
 import { eq, and } from "drizzle-orm";
+import { z } from "zod";
 import { createSecureErrorResponse } from "@/lib/utils";
 import { requireAuth } from "@/lib/utils/auth-helpers";
+import { mirrorOverridesSchema } from "@/lib/db/schema";
+import { normalizeMirrorOverrides } from "@/lib/utils/mirror-overrides";
+
+/**
+ * Partial update. Each field is optional and only written when present in the
+ * body, so updating mirror overrides does not clobber destinationOrg.
+ */
+const patchBodySchema = z.object({
+  destinationOrg: z.string().nullable().optional(),
+  mirrorOverrides: mirrorOverridesSchema.nullable().optional(),
+});
 
 export const PATCH: APIRoute = async (context) => {
   try {
@@ -20,8 +32,21 @@ export const PATCH: APIRoute = async (context) => {
       });
     }
 
-    const body = await context.request.json();
-    const { destinationOrg } = body;
+    const parsed = patchBodySchema.safeParse(await context.request.json());
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid request body",
+          details: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const body = parsed.data;
 
     // Validate that the organization belongs to the user
     const [existingOrg] = await db
@@ -37,20 +62,36 @@ export const PATCH: APIRoute = async (context) => {
       });
     }
 
-    // Update the organization's destination override
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+    if ("destinationOrg" in body) {
+      updates.destinationOrg = body.destinationOrg || null;
+    }
+
+    if ("mirrorOverrides" in body) {
+      updates.mirrorOverrides = normalizeMirrorOverrides(body.mirrorOverrides);
+    }
+
     await db
       .update(organizations)
-      .set({
-        destinationOrg: destinationOrg || null,
-        updatedAt: new Date(),
-      })
+      .set(updates)
       .where(eq(organizations.id, orgId));
+
+    const [updated] = await db
+      .select({
+        destinationOrg: organizations.destinationOrg,
+        mirrorOverrides: organizations.mirrorOverrides,
+      })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
 
     return new Response(
       JSON.stringify({
         success: true,
-        message: "Organization destination updated successfully",
-        destinationOrg: destinationOrg || null,
+        message: "Organization updated successfully",
+        destinationOrg: updated?.destinationOrg ?? null,
+        mirrorOverrides: updated?.mirrorOverrides ?? null,
       }),
       {
         status: 200,
@@ -58,7 +99,7 @@ export const PATCH: APIRoute = async (context) => {
       }
     );
   } catch (error) {
-    return createSecureErrorResponse(error, "Update organization destination", 500);
+    return createSecureErrorResponse(error, "Update organization", 500);
   }
 };
 

--- a/src/pages/api/organizations/mirror-overrides.ts
+++ b/src/pages/api/organizations/mirror-overrides.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from "astro";
+import { createSecureErrorResponse } from "@/lib/utils";
+import { requireAuth } from "@/lib/utils/auth-helpers";
+import { loadOrganizationMirrorOverrides } from "@/lib/utils/mirror-overrides";
+
+/**
+ * Look up one organization's mirror overrides by name.
+ *
+ * The repositories payload carries an organization *name*, not an id, so the
+ * repository overrides dialog needs a name-keyed lookup to show what "Inherit"
+ * actually resolves to (global -> org). Reuses the same loader the mirror paths
+ * use, which scopes the query to the calling user.
+ *
+ * GET /api/organizations/mirror-overrides?name=<orgName>
+ */
+export const GET: APIRoute = async (context) => {
+  try {
+    const { user, response } = await requireAuth(context);
+    if (response) return response;
+
+    const name = context.url.searchParams.get("name")?.trim();
+    if (!name) {
+      return new Response(
+        JSON.stringify({ error: "Organization name is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Returns null for unknown orgs, which the caller treats the same as
+    // "no overrides" — the hint then falls back to the global values.
+    const mirrorOverrides = await loadOrganizationMirrorOverrides({
+      organizationName: name,
+      userId: user!.id,
+    });
+
+    return new Response(
+      JSON.stringify({ success: true, name, mirrorOverrides }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (error) {
+    return createSecureErrorResponse(
+      error,
+      "Load organization mirror overrides",
+      500
+    );
+  }
+};

--- a/src/pages/api/repositories/[id].ts
+++ b/src/pages/api/repositories/[id].ts
@@ -1,8 +1,21 @@
 import type { APIRoute } from "astro";
 import { db, repositories } from "@/lib/db";
 import { eq, and } from "drizzle-orm";
+import { z } from "zod";
 import { createSecureErrorResponse } from "@/lib/utils";
 import { requireAuth } from "@/lib/utils/auth-helpers";
+import { mirrorOverridesSchema } from "@/lib/db/schema";
+import { normalizeMirrorOverrides } from "@/lib/utils/mirror-overrides";
+
+/**
+ * Partial update. Each field is optional and only written when present in the
+ * body, so updating mirror overrides does not clobber destinationOrg (and vice
+ * versa).
+ */
+const patchBodySchema = z.object({
+  destinationOrg: z.string().nullable().optional(),
+  mirrorOverrides: mirrorOverridesSchema.nullable().optional(),
+});
 
 export const PATCH: APIRoute = async (context) => {
   try {
@@ -20,8 +33,21 @@ export const PATCH: APIRoute = async (context) => {
       });
     }
 
-    const body = await context.request.json();
-    const { destinationOrg } = body;
+    const parsed = patchBodySchema.safeParse(await context.request.json());
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid request body",
+          details: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const body = parsed.data;
 
     // Validate that the repository belongs to the user
     const [existingRepo] = await db
@@ -37,20 +63,38 @@ export const PATCH: APIRoute = async (context) => {
       });
     }
 
-    // Update the repository's destination override
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+    if ("destinationOrg" in body) {
+      updates.destinationOrg = body.destinationOrg || null;
+    }
+
+    if ("mirrorOverrides" in body) {
+      // normalize drops null-valued flags so "no overrides" is stored as NULL
+      // rather than an empty object.
+      updates.mirrorOverrides = normalizeMirrorOverrides(body.mirrorOverrides);
+    }
+
     await db
       .update(repositories)
-      .set({
-        destinationOrg: destinationOrg || null,
-        updatedAt: new Date(),
-      })
+      .set(updates)
       .where(eq(repositories.id, repoId));
+
+    const [updated] = await db
+      .select({
+        destinationOrg: repositories.destinationOrg,
+        mirrorOverrides: repositories.mirrorOverrides,
+      })
+      .from(repositories)
+      .where(eq(repositories.id, repoId))
+      .limit(1);
 
     return new Response(
       JSON.stringify({
         success: true,
-        message: "Repository destination updated successfully",
-        destinationOrg: destinationOrg || null,
+        message: "Repository updated successfully",
+        destinationOrg: updated?.destinationOrg ?? null,
+        mirrorOverrides: updated?.mirrorOverrides ?? null,
       }),
       {
         status: 200,
@@ -58,7 +102,6 @@ export const PATCH: APIRoute = async (context) => {
       }
     );
   } catch (error) {
-    return createSecureErrorResponse(error, "Update repository destination", 500);
+    return createSecureErrorResponse(error, "Update repository", 500);
   }
 };
-

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -8,6 +8,7 @@ export interface FilterParams {
   owner?: string; // owner of the repos
   organization?: string; // organization of the repos
   sort?: string; // repository sort order
+  hasOverrides?: "overridden" | "default" | ""; // repos with custom mirror options
   type?: string; //types in activity log
   name?: string; // name in activity log
 }


### PR DESCRIPTION
Closes #361.

Mirror options are global today, so a single repo that fails with LFS enabled can't be mirrored at all. The reporter's case: `browser-use` fails at the LFS stage every time, and the only workarounds are losing LFS everywhere or losing that repo.

We pass `lfs: true` straight into Gitea's `/repos/migrate`, so the LFS pull happens inside Gitea's own migration. When it fails, Gitea discards the whole migration and there's nothing left for us to salvage. That's why a per-repo opt-out is the fix rather than making the failure non-fatal.

## What this adds

Per-repository and per-organization overrides for mirror options, resolved per flag: **repository -> organization -> global -> false**. `null` at a tier means inherit, so overriding LFS on one repo leaves its other flags alone.

Editing lives on the objects themselves, via the existing three-dot menus on the Repositories and Organizations pages. The Configuration page keeps the global defaults and gains no new surface. The repositories table gets a filter and a row badge so you can find which repos deviate.

## Notable pieces

**One resolver replaces scattered reads.** `resolveMirrorOptions()` replaces 24 reads of `config.giteaConfig?.*` in `gitea.ts`, which were duplicated across two near-identical blocks, plus a third copy in `gitea-enhanced.ts` (`syncGiteaRepoEnhanced`). That third copy is the scheduled-sync path. Without it, overrides would have applied on the first mirror and been silently ignored on every sync afterwards.

**Toggles that can't take effect are disabled and explained.** `starredCodeOnly` forces metadata off for starred repos, and `mirrorLabels` is suppressed whenever issues run. Both used to be invisible. `getMirrorOverrideGating()` now disables those controls and shows the reason. `STARRED_CLAMPED_KEYS` is shared between that gating and the resolver's clamp, so the set the UI greys out can't drift from the set the runtime forces off.

**Two pre-existing bugs fixed along the way.** Both `PATCH /api/repositories/[id]` and `PATCH /api/organizations/[id]` unconditionally wrote `destinationOrg: destinationOrg || null`, so a request carrying only `mirrorOverrides` would have wiped the destination override. They're now real partial updates keyed on field presence, with Zod validation.

## Notes

`mirrorMetadata` is deliberately not exposed. No mirror path reads it (`grep` returns 0 hits in both `gitea.ts` and `gitea-enhanced.ts`); it's a write-time master switch that `config-mapper.ts` ANDs into the individual flags at save time. A per-object override would store and resolve correctly and change nothing. Making it a real runtime gate is possible but would change behavior for anyone running `MIRROR_METADATA=false` with `MIRROR_ISSUES=true`, which works today.

Migration `0014` adds two nullable `mirror_overrides` text columns. Additive, existing rows read as inherit.

## Testing

`bun test` 485 pass / 11 skip / 0 fail (up from 450 on main). `bun run build` succeeds. `validate-migrations` passes from scratch and on the upgrade path. No dependency changes, so `bun.lock` and `bun.nix` are untouched.
