### PR TITLE
docs(www): align use-case articles with the actual configuration UI

### DIFF
--- a/www/src/pages/use-cases/backup-github-repositories.mdx
+++ b/www/src/pages/use-cases/backup-github-repositories.mdx
@@ -55,9 +55,9 @@ On the dashboard:
 
 1. Click **Mirror Repository** for a small test project.
 2. Open Gitea and confirm the mirror appears with the right owner/org.
-3. In **Configuration → Connections**, open the **Content & Data** section to enable **Mirror metadata** and **Git LFS** if you rely on issues, wikis, or large assets. Metadata brings [issues and pull requests](/use-cases/mirror-github-issues-pull-requests/) along; LFS has [its own guide](/use-cases/mirror-git-lfs-repositories/) worth reading before you enable it account-wide.
+3. In **Configuration → Connections**, open the **Mirror Content** section to enable **Repository metadata** and **Git LFS** if you rely on issues, wikis, or large assets. Metadata brings [issues and pull requests](/use-cases/mirror-github-issues-pull-requests/) along; LFS has [its own guide](/use-cases/mirror-git-lfs-repositories/) worth reading before you enable it account-wide.
 
-For broader coverage, switch the organization strategy to **Preserve structure** so Gitea mirrors your GitHub org layout automatically.
+For broader coverage, switch the organization strategy to **Preserve Structure** so Gitea mirrors your GitHub org layout automatically.
 
 ### 4. Turn on automatic syncs and cleanup
 
@@ -109,7 +109,7 @@ Treat the mirror like any other DR asset:
 
 ### Does Gitea Mirror copy issues, pull requests, releases, and LFS?
 
-Yes. Enable Mirror metadata, Mirror releases, and Git LFS from **Configuration → Connections → Content & Data**. Pull requests are mirrored as enriched issues with linked branches and metadata.
+Yes. Enable Repository metadata, Releases & tags, and Git LFS objects from **Configuration → Connections → Mirror Content**. Pull requests are mirrored as enriched issues with linked branches and metadata.
 
 ### How often should I sync GitHub backups?
 

--- a/www/src/pages/use-cases/preserve-github-history.mdx
+++ b/www/src/pages/use-cases/preserve-github-history.mdx
@@ -22,16 +22,16 @@ GitHub accounts get banned, repos go private, and owners rage-delete history. If
 
 ### 1. Set archival-friendly defaults
 
-In **Configuration → Connections**, open **Content & Data**:
+In **Configuration → Connections**, open **Mirror Content**:
 
-- Enable **Mirror metadata** and choose the components you care about (issues, pull requests, labels, milestones, wiki). See [how each piece transfers](/use-cases/mirror-github-issues-pull-requests/), including the shape pull requests arrive in.
+- Enable **Repository metadata** and choose the components you care about (issues, pull requests, labels, milestones, wiki). See [how each piece transfers](/use-cases/mirror-github-issues-pull-requests/), including the shape pull requests arrive in.
 - Enable **Mirror releases** and raise the **Latest releases** limit if you need a deeper history of release assets.
-- Toggle **Git LFS (Large File Storage)** so binaries follow the repository, assuming LFS is enabled in your Gitea instance. Old repositories sometimes have [broken LFS stores that fail the whole migration](/use-cases/mirror-git-lfs-repositories/); turn LFS off per repository when that happens.
+- Toggle **Git LFS objects** so binaries follow the repository, assuming LFS is enabled in your Gitea instance. Old repositories sometimes have [broken LFS stores that fail the whole migration](/use-cases/mirror-git-lfs-repositories/); turn LFS off per repository when that happens.
 
 ### 2. Create an "Archive" organization in Gitea
 
 1. In Gitea, create an org like `github-archive` and grant read-only access to everyone who needs the history.
-2. Back in Gitea Mirror under **Configuration → Connections**, pick the **Preserve structure** strategy (or set a destination organization) so repos land in that archive org.
+2. Back in Gitea Mirror under **Configuration → Connections**, pick the **Preserve Structure** strategy (or set a destination organization) so repos land in that archive org.
 3. Tighten permissions in Gitea—disable pushes for regular users so the archive stays immutable while the service updates it via its token.
 
 <figure class="mt-8 flex flex-col items-center">
@@ -86,7 +86,7 @@ In **Configuration → Connections**, open **Content & Data**:
 
 ### Does this preserve issues, pull requests, and releases?
 
-Yes—enable Mirror metadata and Mirror releases from **Configuration → Connections → Content & Data**. Pull requests copy as enriched issues, keeping discussion and labels.
+Yes. Enable Repository metadata and Releases & tags from **Configuration → Connections → Mirror Content**. Pull requests copy as enriched issues, keeping discussion and labels.
 
 ### What happens if a GitHub repo is deleted or goes private?
 

--- a/www/src/pages/use-cases/sync-github-to-self-hosted-gitea.mdx
+++ b/www/src/pages/use-cases/sync-github-to-self-hosted-gitea.mdx
@@ -25,7 +25,7 @@ You may still collaborate on GitHub every day, yet want a LAN Gitea copy you con
 1. Sign in at `http://<mirror-host>:4321`.
 2. Open **Configuration → Connections**.
 3. Paste the GitHub PAT and choose the owners (user + orgs) you want mirrored.
-4. Add your self-hosted Gitea URL and token; pick the destination org structure (typically **Preserve structure**).
+4. Add your self-hosted Gitea URL and token; pick the destination org structure (typically **Preserve Structure**).
 
 ### 2. Import the repository inventory
 
@@ -51,11 +51,11 @@ You may still collaborate on GitHub every day, yet want a LAN Gitea copy you con
   </figcaption>
 </figure>
 
-### 4. Mirror metadata and LFS
+### 4. Metadata and LFS
 
-In **Configuration → Connections → Content & Data**:
+In **Configuration → Connections → Mirror Content**:
 
-- Enable **Mirror metadata** so issues, pull requests (as enriched issues), labels, milestones, and wikis stay in sync.
+- Enable **Repository metadata** so issues, pull requests (as enriched issues), labels, milestones, and wikis stay in sync.
 - Enable **Mirror LFS** if your repos store binaries; confirm your Gitea instance has LFS enabled.
 - If you want deleted GitHub repos archived or removed locally, enable **Handle orphaned repositories automatically** in the Automation tab and choose the action (Archive or Delete) that matches your retention policy.
 
@@ -90,7 +90,7 @@ Intervals of 15–30 minutes keep most orgs near real-time. You can shorten for 
 
 ### Can I mirror multiple GitHub users and organizations?
 
-Yes. Add each owner in Configuration → Connections, then choose a destination strategy (Preserve structure or a specific org) for Gitea.
+Yes. Add each owner in Configuration → Connections, then choose a destination strategy (Preserve Structure or a specific org) for Gitea.
 
 ### Is it safe to store tokens in Gitea Mirror?
 

--- a/www/src/pages/use-cases/vendor-lock-in-prevention.mdx
+++ b/www/src/pages/use-cases/vendor-lock-in-prevention.mdx
@@ -23,8 +23,8 @@ GitHub can change pricing, authentication rules, or terms without notice. With G
 ### 1. Mirror everything continuously
 
 - In **Configuration → Connections**, add every GitHub organization you care about as an owner. Auto-discovery pulls new repositories on the next scheduler run.
-- Set the organization strategy to **Preserve structure** so Gitea mirrors the GitHub org layout.
-- Open **Content & Data** to enable metadata, releases, and Git LFS, ensuring [issues, pull requests](/use-cases/mirror-github-issues-pull-requests/), and [binaries](/use-cases/mirror-git-lfs-repositories/) survive the switchover.
+- Set the organization strategy to **Preserve Structure** so Gitea mirrors the GitHub org layout.
+- Open **Mirror Content** to enable metadata, releases, and Git LFS, ensuring [issues, pull requests](/use-cases/mirror-github-issues-pull-requests/), and [binaries](/use-cases/mirror-git-lfs-repositories/) survive the switchover.
 
 ### 2. Simulate a cutover
 


### PR DESCRIPTION
Older articles named UI elements that no longer exist ("Content & Data", "Mirror metadata", "Git LFS (Large File Storage)"). Each replacement verified against the real labels in `src/components/config/`: **Mirror Content**, **Repository metadata**, **Git LFS objects**, **Releases & tags**, **Preserve Structure**. Build passes, 27 pages. Website only, no version bump needed.