### PR TITLE
fix(ui): surface Mirror Options on mobile repo cards and desktop org menu

### DIFF
--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -635,8 +635,12 @@ export function OrganizationList({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => setOverridesTarget(org)}>
+                        <SlidersHorizontal className="h-4 w-4 mr-2" />
+                        Mirror Options
+                      </DropdownMenuItem>
                       {org.status !== "ignored" && (
-                        <DropdownMenuItem 
+                        <DropdownMenuItem
                           onClick={() => org.id && onIgnore && onIgnore({ orgId: org.id, ignore: true })}
                         >
                           <Ban className="h-4 w-4 mr-2" />
@@ -645,7 +649,7 @@ export function OrganizationList({
                       )}
                       {onDelete && (
                         <>
-                          {org.status !== "ignored" && <DropdownMenuSeparator />}
+                          <DropdownMenuSeparator />
                           <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
                             onClick={() => org.id && onDelete(org.id)}

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -9,7 +9,7 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FlipHorizontal, GitFork, RefreshCw, RotateCcw, Star, Lock, Ban, Check, ChevronDown, SlidersHorizontal, Trash2, X } from "lucide-react";
+import { FlipHorizontal, GitFork, MoreVertical, RefreshCw, RotateCcw, Star, Lock, Ban, Check, ChevronDown, SlidersHorizontal, Trash2, X } from "lucide-react";
 import { SiGithub, SiGitea } from "react-icons/si";
 import type { MirrorOverrides, Repository } from "@/lib/db/schema";
 import { Button } from "@/components/ui/button";
@@ -418,8 +418,22 @@ export default function RepositoryTable({
                   {repo.isPrivate && <Badge variant="secondary" className="text-xs h-5"><Lock className="h-3 w-3 mr-1" />Private</Badge>}
                   {repo.isForked && <Badge variant="secondary" className="text-xs h-5"><GitFork className="h-3 w-3 mr-1" />Fork</Badge>}
                   {repo.isStarred && <Badge variant="secondary" className="text-xs h-5"><Star className="h-3 w-3 mr-1" />Starred</Badge>}
+                  {hasMirrorOverrides(repo.mirrorOverrides) && <Badge variant="outline" className="text-xs h-5"><SlidersHorizontal className="h-3 w-3 mr-1" />Custom</Badge>}
                 </div>
               </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" disabled={isLoading}>
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setOverridesTarget(repo)}>
+                    <SlidersHorizontal className="h-4 w-4 mr-2" />
+                    Mirror Options
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             {/* Repository details */}


### PR DESCRIPTION
Follow-up to #362, reported in https://github.com/RayLabsHQ/gitea-mirror/issues/361#issuecomment (mobile screenshot from @MMMMMoris).

The Mirror Options entry from #362 was only reachable from the desktop repositories table. Two gaps:

- **Repositories, mobile**: the card layout had no dropdown menu at all, so per-repo overrides could not be opened on a phone. Cards now have a three-dot menu in the header opening the same dialog, plus the Custom badge when a repository overrides something.
- **Organizations, desktop**: the inverse gap. Mirror Options existed in the mobile card menu but was missing from the desktop dropdown. Added.

Verified in the browser at 390px and 1400px against a seeded database: menu opens, dialog resolves inherited values correctly (including the org tier and the labels gate), save persists. `bun test` 493 pass / 0 fail, build clean.