### PR TITLE
fix(auth): trust registered SSO provider origins and honor deleteFromGitea

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -279,7 +279,7 @@ Configure automatic cleanup of old events and data.
 
 | Variable | Description | Default | Options |
 |----------|-------------|---------|---------|
-| `CLEANUP_DELETE_FROM_GITEA` | Delete repositories from Gitea | `false` | `true`, `false` |
+| `CLEANUP_DELETE_FROM_GITEA` | Apply the orphaned-repo action on the Gitea side too. When `false` (default), cleanup only updates gitea-mirror's own database (orphans are marked archived or removed from the repo list) and the Gitea/Forgejo copies are left untouched | `false` | `true`, `false` |
 | `CLEANUP_DELETE_IF_NOT_IN_GITHUB` | Delete repos not found in GitHub (automatically enables cleanup) | `true` | `true`, `false` |
 | `CLEANUP_ORPHANED_REPO_ACTION` | Action for orphaned repositories. **Note**: `archive` is recommended to preserve backups | `archive` | `skip`, `archive`, `delete` |
 | `CLEANUP_DRY_RUN` | Test mode without actual deletion | `false` | `true`, `false` |

--- a/docs/SSO-OIDC-SETUP.md
+++ b/docs/SSO-OIDC-SETUP.md
@@ -115,6 +115,7 @@ Working Authentik deployments (see [#134](https://github.com/RayLabsHQ/gitea-mir
 
 Notes:
 - Make sure `BETTER_AUTH_URL` and (if you serve the UI from multiple origins) `BETTER_AUTH_TRUSTED_ORIGINS` point at the public URL users reach. A mismatch can surface as 500 errors after redirect.
+- **Internal / split-DNS IdPs**: since v3.21.0 the SSO sign-in refuses identity providers whose hostnames resolve to private addresses (SSRF hardening in the auth library) unless the IdP's origin is trusted. Providers you register through the UI are trusted automatically, but if you register a *new* provider whose hostname resolves to a LAN IP from inside the container (common with split-horizon DNS), add its origin to `BETTER_AUTH_TRUSTED_ORIGINS` first, e.g. `BETTER_AUTH_TRUSTED_ORIGINS=https://auth.example.com`.
 - Set the **Domain** field to the email domain your Authentik users actually have. Auto-linking to an existing local admin only happens for emails in that domain — see [Account Linking](#account-linking) for the trust model. (Authentik's default email scope mapping returns `email_verified: False` for OIDC clients, which is why account linking is gated on the domain match here rather than the IdP's verified-email claim.)
 - If you created an Authentik provider before v3.8.10 you should delete it and re-add it after upgrading; older versions saved incomplete endpoint data which leads to the `url.startsWith` error explained in the Troubleshooting section.
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -69,13 +69,22 @@ export function LoginForm() {
         typeof window !== 'undefined'
           ? new URL(withBase('/'), window.location.origin).toString()
           : `http://localhost:4321${withBase('/')}`;
-      await authClient.signIn.sso({
+      const result = await authClient.signIn.sso({
         email: ssoEmail || undefined,
         domain: domain,
         providerId: providerId,
         callbackURL,
         scopes: ['openid', 'email', 'profile'], // TODO: This is not being respected by the SSO plugin.
       });
+      // The auth client resolves with { data, error } instead of throwing, so
+      // a server-side rejection (e.g. the SSO plugin refusing an IdP whose
+      // hostname resolves to a private address) never reaches the catch below.
+      if (result?.error) {
+        showErrorToast(
+          new Error(result.error.message || `SSO sign-in failed (HTTP ${result.error.status})`),
+          toast
+        );
+      }
     } catch (error) {
       showErrorToast(error, toast);
     } finally {

--- a/src/lib/auth-origins.test.ts
+++ b/src/lib/auth-origins.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { resolveTrustedOrigins } from "./auth";
+import { resolveTrustedOrigins, extractSsoProviderOrigins } from "./auth";
 
 // Helper to create a mock Request with specific headers
 function mockRequest(headers: Record<string, string>): Request {
@@ -115,5 +115,60 @@ describe("resolveTrustedOrigins", () => {
     });
     const origins = await resolveTrustedOrigins(req);
     expect(origins).toContain("http://gitea.internal");
+  });
+});
+
+/**
+ * Regression coverage for issue #366: better-auth 1.6.23's SSO plugin
+ * refuses OIDC discovery from untrusted origins and rejects endpoints whose
+ * hostnames resolve to private addresses unless the origin is in
+ * trustedOrigins. Operator-registered providers are trusted automatically;
+ * extractSsoProviderOrigins is the pure extraction step feeding that.
+ */
+describe("extractSsoProviderOrigins", () => {
+  test("extracts the issuer origin, stripping any path", () => {
+    const origins = extractSsoProviderOrigins([
+      { issuer: "https://auth.example.dev/application/o/gitea-mirror/", oidcConfig: null },
+    ]);
+    expect(origins).toContain("https://auth.example.dev");
+    expect(origins).not.toContain("https://auth.example.dev/application/o/gitea-mirror/");
+  });
+
+  test("extracts endpoint origins from oidcConfig, including hosts that differ from the issuer", () => {
+    const origins = extractSsoProviderOrigins([
+      {
+        issuer: "https://auth.example.dev",
+        oidcConfig: JSON.stringify({
+          discoveryEndpoint: "https://auth.example.dev/.well-known/openid-configuration",
+          authorizationEndpoint: "https://auth.example.dev/authorize",
+          tokenEndpoint: "https://token.internal.example:8443/oauth/token",
+          userInfoEndpoint: "https://auth.example.dev/userinfo",
+          jwksEndpoint: "https://keys.example.dev/jwks",
+        }),
+      },
+    ]);
+    expect(origins).toContain("https://auth.example.dev");
+    expect(origins).toContain("https://token.internal.example:8443");
+    expect(origins).toContain("https://keys.example.dev");
+  });
+
+  test("malformed oidcConfig JSON still yields the issuer origin without throwing", () => {
+    const origins = extractSsoProviderOrigins([
+      { issuer: "https://auth.example.dev", oidcConfig: "{not json" },
+    ]);
+    expect(origins).toContain("https://auth.example.dev");
+  });
+
+  test("skips non-URL values such as SAML entity IDs", () => {
+    const origins = extractSsoProviderOrigins([
+      { issuer: "urn:example:idp", oidcConfig: null },
+    ]);
+    expect(origins).toEqual([]);
+  });
+
+  test("handles empty and null fields without throwing", () => {
+    expect(extractSsoProviderOrigins([])).toEqual([]);
+    expect(extractSsoProviderOrigins([{ issuer: null, oidcConfig: null }])).toEqual([]);
+    expect(extractSsoProviderOrigins([{ issuer: "", oidcConfig: "" }])).toEqual([]);
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,11 +3,71 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt } from "better-auth/plugins";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { sso } from "@better-auth/sso";
-import { db, users } from "./db";
+import { db, users, ssoProviders } from "./db";
 import * as schema from "./db/schema";
 import { eq } from "drizzle-orm";
 import { withBase } from "./base-path";
 import { headerAuthPlugin } from "./auth-header-plugin";
+
+/**
+ * Extracts the origins implied by registered SSO identity providers.
+ *
+ * The SSO plugin (since better-auth 1.6.23, shipped in v3.21.0) hardens
+ * sign-in against SSRF: it refuses to fetch OIDC discovery documents from
+ * untrusted origins and rejects token/userinfo/jwks endpoints whose
+ * hostnames resolve to private addresses — unless the origin is listed in
+ * `trustedOrigins`, the documented escape hatch for internal IdPs. Homelab
+ * deployments with split-horizon DNS (auth.example.com resolving to a LAN
+ * IP from inside the container) hit this on every sign-in, which the login
+ * UI used to swallow silently (#366).
+ *
+ * Registering a provider is an explicit operator action — the same trust
+ * model behind the `domainVerified` flag we set at registration — so the
+ * provider's issuer and endpoint origins are trusted automatically instead
+ * of requiring BETTER_AUTH_TRUSTED_ORIGINS to be set by hand. Note this
+ * also lets those origins pass Better Auth's CSRF/redirect-target checks,
+ * which is acceptable for operator-registered IdP infrastructure.
+ *
+ * Exported for testing.
+ */
+export function extractSsoProviderOrigins(
+  rows: Array<{ issuer?: string | null; oidcConfig?: string | null }>
+): string[] {
+  const origins: string[] = [];
+  for (const row of rows) {
+    const candidates: unknown[] = [row?.issuer];
+    if (typeof row?.oidcConfig === "string" && row.oidcConfig.trim() !== "") {
+      try {
+        const cfg = JSON.parse(row.oidcConfig);
+        candidates.push(
+          cfg?.discoveryEndpoint,
+          cfg?.authorizationEndpoint,
+          cfg?.tokenEndpoint,
+          cfg?.userInfoEndpoint,
+          cfg?.jwksEndpoint,
+        );
+      } catch {
+        // A malformed provider row must not break auth for everyone;
+        // the issuer candidate above still applies.
+      }
+    }
+    for (const candidate of candidates) {
+      if (typeof candidate !== "string" || candidate.trim() === "") continue;
+      try {
+        const url = new URL(candidate);
+        // Only http(s) URLs have a meaningful origin — new URL() accepts
+        // values like SAML entity IDs ("urn:...") without throwing, but
+        // their .origin is the literal string "null".
+        if (url.protocol === "http:" || url.protocol === "https:") {
+          origins.push(url.origin);
+        }
+      } catch {
+        // Skip values that aren't URLs at all.
+      }
+    }
+  }
+  return origins;
+}
 
 /**
  * Resolves the list of trusted origins for Better Auth CSRF validation.
@@ -46,6 +106,21 @@ export async function resolveTrustedOrigins(request?: Request): Promise<string[]
         console.warn(`Invalid trusted origin: ${origin}, skipping`);
       }
     }
+  }
+
+  // Trust the origins of operator-registered SSO identity providers so the
+  // SSO plugin's SSRF checks accept them without manual env configuration.
+  // See extractSsoProviderOrigins for the rationale.
+  try {
+    const providerRows = await db
+      .select({ issuer: ssoProviders.issuer, oidcConfig: ssoProviders.oidcConfig })
+      .from(ssoProviders);
+    if (Array.isArray(providerRows)) {
+      origins.push(...extractSsoProviderOrigins(providerRows));
+    }
+  } catch {
+    // Fresh DB before migration or DB briefly unavailable — fall back to
+    // env-configured origins rather than failing auth outright.
   }
 
   // Auto-detect origin from the incoming request's Host header when running

--- a/src/lib/repository-cleanup-service.test.ts
+++ b/src/lib/repository-cleanup-service.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { resolveOrphanVerdict } from "./repository-cleanup-service";
+import { resolveOrphanVerdict, planOrphanedRepoAction } from "./repository-cleanup-service";
 
 describe("resolveOrphanVerdict", () => {
   test("repo present in the bulk fetch is never orphaned, regardless of the direct check", () => {
@@ -48,5 +48,37 @@ describe("resolveOrphanVerdict", () => {
     expect(
       resolveOrphanVerdict({ fullNameFoundInBulkList: false, directCheckConfirmsGone: false })
     ).toBe(false);
+  });
+});
+
+/**
+ * Regression coverage for issue #366: `deleteFromGitea`
+ * (CLEANUP_DELETE_FROM_GITEA) was documented as "Delete repositories from
+ * Gitea" with a `false` default, but the cleanup service never read it —
+ * orphaned repos were archived/deleted on the Gitea side unconditionally.
+ * planOrphanedRepoAction is the pure decision function that now gates the
+ * Gitea-side operation on that flag while the local-database bookkeeping
+ * always happens.
+ */
+describe("planOrphanedRepoAction", () => {
+  test("skip does nothing anywhere, regardless of deleteFromGitea", () => {
+    expect(planOrphanedRepoAction("skip", false)).toEqual({ gitea: "none", db: "none" });
+    expect(planOrphanedRepoAction("skip", true)).toEqual({ gitea: "none", db: "none" });
+  });
+
+  test("archive with deleteFromGitea disabled only marks the local record archived", () => {
+    expect(planOrphanedRepoAction("archive", false)).toEqual({ gitea: "none", db: "archive" });
+  });
+
+  test("archive with deleteFromGitea enabled archives on Gitea too", () => {
+    expect(planOrphanedRepoAction("archive", true)).toEqual({ gitea: "archive", db: "archive" });
+  });
+
+  test("delete with deleteFromGitea disabled removes only the local record (the #366 ask)", () => {
+    expect(planOrphanedRepoAction("delete", false)).toEqual({ gitea: "none", db: "delete" });
+  });
+
+  test("delete with deleteFromGitea enabled deletes from Gitea and the local database", () => {
+    expect(planOrphanedRepoAction("delete", true)).toEqual({ gitea: "delete", db: "delete" });
   });
 });

--- a/src/lib/repository-cleanup-service.ts
+++ b/src/lib/repository-cleanup-service.ts
@@ -47,6 +47,34 @@ export function resolveOrphanVerdict({
 }
 
 /**
+ * Decide what an orphaned-repo cleanup action actually does, split into the
+ * Gitea-side operation and the local-database operation.
+ *
+ * `deleteFromGitea` (CLEANUP_DELETE_FROM_GITEA) gates the Gitea side: it has
+ * always been documented as "Delete repositories from Gitea" with a `false`
+ * default, but until #366 the code never read it and archived/deleted on
+ * Gitea unconditionally. With it disabled (the default), cleanup only
+ * updates gitea-mirror's own records — orphans are marked archived or
+ * removed from the local database, and the Gitea/Forgejo copy is left
+ * untouched.
+ *
+ * Pure/exported so the decision logic is unit-testable (see
+ * repository-cleanup-service.test.ts).
+ */
+export function planOrphanedRepoAction(
+  action: "skip" | "archive" | "delete",
+  deleteFromGitea: boolean
+): { gitea: "archive" | "delete" | "none"; db: "archive" | "delete" | "none" } {
+  if (action === "skip") {
+    return { gitea: "none", db: "none" };
+  }
+  if (action === "archive") {
+    return { gitea: deleteFromGitea ? "archive" : "none", db: "archive" };
+  }
+  return { gitea: deleteFromGitea ? "delete" : "none", db: "delete" };
+}
+
+/**
  * Identify orphaned repositories for a user
  * These are repositories that exist in our database (and likely in Gitea)
  * but are no longer in GitHub based on current criteria
@@ -240,6 +268,40 @@ async function identifyOrphanedRepositories(config: any): Promise<any[]> {
 }
 
 /**
+ * Resolve the Gitea client and the owner/name the repo lives under on the
+ * Gitea side. Only called when the cleanup plan actually touches Gitea, so
+ * a database-only cleanup never needs a decryptable Gitea token.
+ */
+async function resolveGiteaTarget(config: any, repo: any): Promise<{
+  giteaClient: ReturnType<typeof createGiteaClient>;
+  giteaOwner: string;
+  giteaRepoName: string;
+}> {
+  const giteaToken = getDecryptedGiteaToken(config);
+  const giteaClient = createGiteaClient(config.giteaConfig.url, giteaToken);
+
+  // Determine the Gitea owner and repo name more robustly
+  const mirroredLocation = (repo.mirroredLocation || '').trim();
+  let giteaOwner: string;
+  let giteaRepoName: string;
+
+  if (mirroredLocation && mirroredLocation.includes('/')) {
+    const [ownerPart, namePart] = mirroredLocation.split('/');
+    giteaOwner = ownerPart;
+    giteaRepoName = namePart;
+  } else {
+    // Fall back to expected owner based on config and repo flags (starred/org overrides)
+    giteaOwner = await getGiteaRepoOwnerAsync({ config, repository: repo });
+    giteaRepoName = repo.name;
+  }
+
+  // Normalize owner casing to avoid GetUserByName issues on some Gitea setups
+  giteaOwner = giteaOwner.trim();
+
+  return { giteaClient, giteaOwner, giteaRepoName };
+}
+
+/**
  * Handle an orphaned repository based on configuration
  */
 async function handleOrphanedRepository(
@@ -260,82 +322,74 @@ async function handleOrphanedRepository(
     return;
   }
 
+  const plan = planOrphanedRepoAction(action, config.cleanupConfig?.deleteFromGitea === true);
+
   if (dryRun) {
-    console.log(`[Repository Cleanup] DRY RUN: Would ${action} orphaned repository ${repoFullName}`);
+    console.log(`[Repository Cleanup] DRY RUN: Would ${action} orphaned repository ${repoFullName}${plan.gitea === 'none' ? ' (database only; deleteFromGitea is disabled)' : ' (including the Gitea copy)'}`);
     return;
   }
-  
+
   try {
-    // Get Gitea client
-    const giteaToken = getDecryptedGiteaToken(config);
-    const giteaClient = createGiteaClient(config.giteaConfig.url, giteaToken);
-    
-    // Determine the Gitea owner and repo name more robustly
-    const mirroredLocation = (repo.mirroredLocation || '').trim();
-    let giteaOwner: string;
-    let giteaRepoName: string;
-
-    if (mirroredLocation && mirroredLocation.includes('/')) {
-      const [ownerPart, namePart] = mirroredLocation.split('/');
-      giteaOwner = ownerPart;
-      giteaRepoName = namePart;
-    } else {
-      // Fall back to expected owner based on config and repo flags (starred/org overrides)
-      giteaOwner = await getGiteaRepoOwnerAsync({ config, repository: repo });
-      giteaRepoName = repo.name;
-    }
-
-    // Normalize owner casing to avoid GetUserByName issues on some Gitea setups
-    giteaOwner = giteaOwner.trim();
-    
     if (action === 'archive') {
-      console.log(`[Repository Cleanup] Archiving orphaned repository ${repoFullName} in Gitea`);
-      // Best-effort check to validate actual location; falls back gracefully
-      try {
-        const { present, actualOwner } = await checkRepoLocation({
-          config,
-          repository: repo,
-          expectedOwner: giteaOwner,
-        });
-        if (present) {
-          giteaOwner = actualOwner;
-        }
-      } catch {
-        // Non-fatal; continue with best guess
-      }
-
-      const { archivedName } = await archiveGiteaRepo(giteaClient, giteaOwner, giteaRepoName);
-
-      // Update database status. If the archive call renamed the repo in Gitea
-      // (mirror path), persist the new location so a subsequent "Manual Sync"
-      // (the UI's documented path for refreshing an archived mirror) can find
-      // it by its actual current name instead of the stale pre-rename one —
-      // otherwise syncGiteaRepoEnhanced looks up a name that no longer exists
-      // and Gitea returns HTTP 405 ("not a pull mirror").
-      //
-      // Only mirroredLocation gets the Gitea-side `archived-{name}` value.
-      // Do NOT write it into `name`: repositories.name is consumed as the
-      // GITHUB repo name elsewhere (release listing, force-push detection),
-      // and mirroredLocation alone is what syncGiteaRepoEnhanced resolves
-      // first when locating the Gitea mirror.
       const dbUpdate: Record<string, any> = {
         status: 'archived',
         isArchived: true,
-        errorMessage: 'Repository archived - no longer in GitHub',
+        errorMessage: plan.gitea === 'archive'
+          ? 'Repository archived - no longer in GitHub'
+          : 'Repository archived in gitea-mirror - no longer in GitHub (Gitea copy untouched)',
         updatedAt: new Date(),
       };
-      if (archivedName && archivedName !== giteaRepoName) {
-        dbUpdate.mirroredLocation = `${giteaOwner}/${archivedName}`;
+
+      if (plan.gitea === 'archive') {
+        console.log(`[Repository Cleanup] Archiving orphaned repository ${repoFullName} in Gitea`);
+        const { giteaClient, giteaRepoName, giteaOwner: expectedOwner } = await resolveGiteaTarget(config, repo);
+        let giteaOwner = expectedOwner;
+        // Best-effort check to validate actual location; falls back gracefully
+        try {
+          const { present, actualOwner } = await checkRepoLocation({
+            config,
+            repository: repo,
+            expectedOwner: giteaOwner,
+          });
+          if (present) {
+            giteaOwner = actualOwner;
+          }
+        } catch {
+          // Non-fatal; continue with best guess
+        }
+
+        const { archivedName } = await archiveGiteaRepo(giteaClient, giteaOwner, giteaRepoName);
+
+        // If the archive call renamed the repo in Gitea (mirror path), persist
+        // the new location so a subsequent "Manual Sync" (the UI's documented
+        // path for refreshing an archived mirror) can find it by its actual
+        // current name instead of the stale pre-rename one — otherwise
+        // syncGiteaRepoEnhanced looks up a name that no longer exists and
+        // Gitea returns HTTP 405 ("not a pull mirror").
+        //
+        // Only mirroredLocation gets the Gitea-side `archived-{name}` value.
+        // Do NOT write it into `name`: repositories.name is consumed as the
+        // GITHUB repo name elsewhere (release listing, force-push detection),
+        // and mirroredLocation alone is what syncGiteaRepoEnhanced resolves
+        // first when locating the Gitea mirror.
+        if (archivedName && archivedName !== giteaRepoName) {
+          dbUpdate.mirroredLocation = `${giteaOwner}/${archivedName}`;
+        }
+      } else {
+        console.log(`[Repository Cleanup] Marking orphaned repository ${repoFullName} archived in gitea-mirror (deleteFromGitea disabled; Gitea copy untouched)`);
       }
+
       await db.update(repositories).set(dbUpdate).where(eq(repositories.id, repo.id));
-      
+
       // Create event
       await publishEvent({
         userId: config.userId,
         channel: 'repository',
         payload: {
           type: 'repository.archived',
-          message: `Repository ${repoFullName} archived (no longer in GitHub)`,
+          message: plan.gitea === 'archive'
+            ? `Repository ${repoFullName} archived (no longer in GitHub)`
+            : `Repository ${repoFullName} marked archived in gitea-mirror (no longer in GitHub; Gitea copy untouched)`,
           metadata: {
             repositoryId: repo.id,
             repositoryName: repo.name,
@@ -345,19 +399,26 @@ async function handleOrphanedRepository(
         },
       });
     } else if (action === 'delete') {
-      console.log(`[Repository Cleanup] Deleting orphaned repository ${repoFullName} from Gitea`);
-      await deleteGiteaRepo(giteaClient, giteaOwner, giteaRepoName);
-      
+      if (plan.gitea === 'delete') {
+        console.log(`[Repository Cleanup] Deleting orphaned repository ${repoFullName} from Gitea`);
+        const { giteaClient, giteaOwner, giteaRepoName } = await resolveGiteaTarget(config, repo);
+        await deleteGiteaRepo(giteaClient, giteaOwner, giteaRepoName);
+      } else {
+        console.log(`[Repository Cleanup] Removing orphaned repository ${repoFullName} from gitea-mirror (deleteFromGitea disabled; Gitea copy untouched)`);
+      }
+
       // Delete from database
       await db.delete(repositories).where(eq(repositories.id, repo.id));
-      
+
       // Create event
       await publishEvent({
         userId: config.userId,
         channel: 'repository',
         payload: {
           type: 'repository.deleted',
-          message: `Repository ${repoFullName} deleted (no longer in GitHub)`,
+          message: plan.gitea === 'delete'
+            ? `Repository ${repoFullName} deleted (no longer in GitHub)`
+            : `Repository ${repoFullName} removed from gitea-mirror (no longer in GitHub; Gitea copy untouched)`,
           metadata: {
             repositoryId: repo.id,
             repositoryName: repo.name,
@@ -415,9 +476,10 @@ async function runRepositoryCleanup(config: any): Promise<{
       return results;
     }
     
-    // Warn if deleteFromGitea is explicitly disabled but deleteIfNotInGitHub is enabled
-    if (cleanupConfig.deleteFromGitea === false && cleanupConfig.deleteIfNotInGitHub) {
-      console.warn(`[Repository Cleanup] Warning: CLEANUP_DELETE_FROM_GITEA is false but CLEANUP_DELETE_IF_NOT_IN_GITHUB is true. Proceeding with cleanup.`);
+    // deleteFromGitea gates whether the orphaned-repo action also touches the
+    // Gitea/Forgejo side (see planOrphanedRepoAction).
+    if (cleanupConfig.deleteFromGitea !== true) {
+      console.log(`[Repository Cleanup] deleteFromGitea is disabled: orphaned repositories will only be updated in gitea-mirror's database; the Gitea copies stay untouched. Set CLEANUP_DELETE_FROM_GITEA=true to also apply the '${cleanupConfig.orphanedRepoAction || 'archive'}' action on Gitea.`);
     }
     
     // Identify orphaned repositories


### PR DESCRIPTION
Fixes #366.

## What broke

better-auth 1.6.23 (shipped in v3.21.0) added SSRF hardening to the SSO plugin: every SSO sign-in now DNS-resolves the IdP's token/userinfo/jwks endpoints and rejects them with a 400 if they resolve to a private address, unless the IdP origin is in `trustedOrigins`. Homelab split-DNS setups (IdP domain resolving to a LAN IP from inside the container) break on every sign-in. Because sessions last 30 days, the breakage only surfaces when someone actually has to sign in again, which is why it looks like a recent regression.

On top of that, the login form swallowed the error entirely: the auth client resolves with `{ data, error }` instead of throwing, so the `catch` never fired. The button flipped back from "Redirecting..." with no toast and nothing in the server log at default level.

## Changes

- **Auto-trust registered SSO provider origins** (`src/lib/auth.ts`): `resolveTrustedOrigins()` now includes the issuer and endpoint origins of every registered SSO provider. Registering a provider is an explicit operator action (same trust model as the `domainVerified` flag we set at registration), so this is the sanctioned escape hatch applied automatically. `BETTER_AUTH_TRUSTED_ORIGINS` still works and is still needed when *registering* a new internal IdP (documented in SSO-OIDC-SETUP.md).
- **Surface SSO sign-in errors** (`LoginForm.tsx`): server-side rejections now show as an error toast instead of failing silently.
- **Honor `deleteFromGitea` / `CLEANUP_DELETE_FROM_GITEA`** (`repository-cleanup-service.ts`): the flag was documented as "Delete repositories from Gitea" with a `false` default but was never read — cleanup always archived/deleted orphans on the Gitea side. It now gates the Gitea-side operation: when disabled (the default), orphans are only marked archived or removed in gitea-mirror's own database and the Gitea/Forgejo copies stay untouched. Note this is a deliberate behavior change: installs relying on the old unconditional Gitea-side archive must set `CLEANUP_DELETE_FROM_GITEA=true` to keep it.

## Verification

- Live before/after with a registered IdP on a private IP: `POST /api/auth/sign-in/sso` returns **400 `discovery_private_host`** on v3.27.1 and **200 with the authorization URL** on this branch.
- Browser test: a failing SSO sign-in now shows the server's error message as a toast.
- Live cleanup test against an unreachable Gitea URL: `delete` with the flag off removes only the DB row (Gitea never contacted); with the flag on, the Gitea call is attempted (fails with network error and marks the repo `failed`, as before).
- New unit tests for both pure decision functions (`extractSsoProviderOrigins`, `planOrphanedRepoAction`); full suite 503 pass / 0 fail.