### PR TITLE
fix(ci): skip Docker Scout on fork PRs and add a Trivy scan for every PR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,7 @@ This directory contains GitHub Actions workflows that automate the build, test, 
 | Workflow | File | Purpose |
 |----------|------|---------|
 | Astro Build and Test | `astro-build-test.yml` | Builds and tests the Astro application for all branches and PRs |
-| Docker Build and Push | `docker-build.yml` | Builds and pushes Docker images only for the main branch |
-| Docker Security Scan | `docker-scan.yml` | Scans Docker images for security vulnerabilities |
+| Docker Build, Push & Security Scan | `docker-build.yml` | Builds, scans, and pushes Docker images |
 
 ## Workflow Details
 
@@ -28,14 +27,15 @@ This workflow runs on all branches and pull requests. It:
 - Caches dependencies to speed up builds
 - Uploads build artifacts for 7 days
 
-### Docker Build and Push (`docker-build.yml`)
+### Docker Build, Push & Security Scan (`docker-build.yml`)
 
-This workflow builds Docker images on pushes and pull requests, and pushes to GitHub Container Registry (ghcr.io) when permissions allow (main/tags and same-repo PRs).
+This workflow builds Docker images on pushes and pull requests, scans them, and pushes to GitHub Container Registry (ghcr.io) when permissions allow (main/tags and same-repo PRs).
 
 **When it runs:**
 - On push to the main branch
 - On tag creation (v*)
 - On pull requests (build + scan; push only for same-repo PRs)
+- Weekly on Sunday at midnight (scheduled security scan)
 
 **Key features:**
 - Builds multi-architecture images (amd64 and arm64)
@@ -47,25 +47,18 @@ This workflow builds Docker images on pushes and pull requests, and pushes to Gi
 - Validates release tags use semver format before building
 - After tag builds succeed, writes the same version back to `main/package.json`
 
-### Docker Security Scan (`docker-scan.yml`)
-
-This workflow scans Docker images for security vulnerabilities using Trivy.
-
-**When it runs:**
-- On push to the main branch that affects Docker-related files
-- Weekly on Sunday at midnight (scheduled)
-
-**Key features:**
-- Scans for critical and high severity vulnerabilities
-- Fails the build if vulnerabilities are found
-- Ignores unfixed vulnerabilities
+**Security scanning:**
+- Docker Scout runs on main/tag pushes, the weekly schedule, and same-repo PRs. It needs the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets, posts a PR comment, and uploads SARIF to the Security tab.
+- Trivy runs on every PR, including forks. It needs no credentials and writes critical/high (fixable) findings to the job summary.
+- Fork PRs cannot use Docker Scout because GitHub never exposes repository secrets to them. Do not "fix" that with `pull_request_target`; it would run untrusted PR code with the secrets available.
+- Both scanners are informational and do not fail the build.
 
 ## CI/CD Pipeline Philosophy
 
 Our CI/CD pipeline follows these principles:
 
 1. **Fast feedback for developers**: The Astro build and test workflow runs on all branches and PRs to provide quick feedback.
-2. **Efficient resource usage**: Docker images are only built when changes are merged to main, not for every PR.
+2. **Efficient resource usage**: Docker images are built for every PR so they can be scanned, but only pushed for main, tags, and same-repo PRs.
 3. **Security first**: Regular security scanning ensures our Docker images are free from known vulnerabilities.
 4. **Multi-architecture support**: All Docker images are built for both amd64 and arm64 architectures.
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,8 +64,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Login to Docker Hub for Docker Scout (optional - provides better vulnerability data)
-      # Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to enable this
+      # Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to enable this.
+      # Skipped on fork PRs: GitHub never exposes repository secrets to them,
+      # so the login could only fail with "Username and password required".
       - name: Log into Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         continue-on-error: true
         with:
@@ -224,10 +227,14 @@ jobs:
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Docker Scout for Pull Requests (using local image)
+      # Docker Scout for Pull Requests (using local image).
+      # Same-repo PRs only: Scout needs the Docker Hub login above, and fork
+      # PRs never receive the secrets for it. They used to fail here with
+      # "user githubactions not entitled to use Docker Scout". Fork PRs get
+      # the credential-free Trivy scan further down instead.
       - name: Docker Scout - Vulnerability Analysis (PR)
         uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           command: cves,recommendations
           image: local://gitea-mirror:scan
@@ -238,10 +245,10 @@ jobs:
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Compare to latest for PRs and pushes
+      # Compare to latest (same-repo PRs only, same reason as above)
       - name: Docker Scout - Compare to Latest
         uses: docker/scout-action@bacf462e8d090c09660de30a6ccc718035f961e3 # v1.20.4
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           command: compare
           image: local://gitea-mirror:scan
@@ -250,6 +257,39 @@ jobs:
           only-severities: critical,high
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Trivy runs on every PR, forks included. It needs no credentials, so it
+      # is the scan external contributors actually get. Results go to the job
+      # summary because GITHUB_TOKEN is read-only on fork PRs (no PR comments,
+      # no SARIF upload). Informational only, matching Scout's exit-code: false.
+      - name: Trivy - Vulnerability Analysis (PR)
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: gitea-mirror:scan
+          scanners: vuln
+          format: table
+          output: trivy-results.txt
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Trivy - Write job summary
+        if: github.event_name == 'pull_request'
+        run: |
+          {
+            echo "## Trivy image scan (critical and high, fixable only)"
+            echo
+            echo "Image: \`gitea-mirror:scan\` built from this PR. Unfixed vulnerabilities are hidden."
+            echo
+            if [ -s trivy-results.txt ]; then
+              echo '```'
+              cat trivy-results.txt
+              echo '```'
+            else
+              echo "No critical or high vulnerabilities with an available fix."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # GitHub rejects SARIF files where a single result carries more than
       # 1000 relatedLocations, which Scout produces for widely-referenced OS
@@ -266,10 +306,12 @@ jobs:
             mv scout-results.sanitized.sarif scout-results.sarif
           fi
 
-      # Upload security scan results to GitHub Security tab
+      # Upload security scan results to GitHub Security tab.
+      # Skipped when no Scout step ran (fork PRs), otherwise the upload
+      # errors with "Path does not exist: scout-results.sarif".
       - name: Upload Docker Scout scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && hashFiles('scout-results.sarif') != ''
         continue-on-error: true
         with:
           sarif_file: scout-results.sarif


### PR DESCRIPTION
Context: #368. The docker check fails on every fork PR (and Dependabot PR) because GitHub never hands repository secrets to those runs. The Docker Hub login gets empty credentials and Docker Scout then dies with `could not authenticate: user githubactions not entitled to use Docker Scout`. Same-repo PRs pass because the secrets are there. You can see the pattern in the run history: #367, #365, #362 green, #368, #356, #357, #359 red at the same step.

This isn't a security problem, it's the secret isolation doing its job. The only way to get Scout working on forks would be `pull_request_target` with the PR head checked out, which would build an untrusted Dockerfile with the Docker Hub token in the environment. Not doing that.

What changed:

- Docker Hub login and both Scout PR steps now only run when the PR comes from this repo. Same guard the login/push/comment steps already use.
- New Trivy step scans the locally loaded image on every PR, forks included. No credentials needed. Critical/high with an available fix, written to the job summary since `GITHUB_TOKEN` is read-only on fork PRs so a comment or SARIF upload wouldn't work anyway. Informational only, same as Scout's `exit-code: false`.
- Scout SARIF upload only runs if the file exists, so fork PRs stop logging `Path does not exist`.
- Workflows README cleaned up. It still described a `docker-scan.yml` that doesn't exist.

Testing: this PR is from the main repo so it exercises the same-repo path (Scout + Trivy both run). The fork path can't be triggered from here, but the `head.repo.full_name == github.repository` guard is the one that already skipped the login/push/comment steps correctly on #368. `actionlint` is clean apart from four pre-existing shellcheck infos in the tag extraction step.
