### PR TITLE
feat(mirror): per-repo release limit, description sync on every sync, tidier mobile cards

### DIFF
--- a/src/components/config/MirrorOverridesDialog.tsx
+++ b/src/components/config/MirrorOverridesDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -20,7 +21,9 @@ import type { MirrorOverrides } from "@/lib/db/schema";
 import {
   getMirrorOverrideGating,
   MIRROR_OVERRIDE_LABELS,
+  normalizeReleaseLimit,
   UI_MIRROR_OVERRIDE_KEYS,
+  type InheritedMirrorOptions,
   type MirrorOverrideKey,
 } from "@/lib/utils/mirror-overrides";
 
@@ -42,6 +45,17 @@ function fromTriState(value: TriState): boolean | undefined {
   return undefined;
 }
 
+/**
+ * The release limit is edited as free text so the user can clear the field
+ * back to "inherit" or type a multi-digit number without every intermediate
+ * keystroke being rejected. Empty means inherit.
+ */
+function parseReleaseLimitDraft(text: string): number | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return normalizeReleaseLimit(Number(trimmed));
+}
+
 export interface MirrorOverridesDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -55,7 +69,7 @@ export interface MirrorOverridesDialogProps {
    * "Inherit" actually resolves to right now. For a repository this should
    * already be global merged with its organization's overrides.
    */
-  inheritedFrom?: Partial<Record<MirrorOverrideKey, boolean>>;
+  inheritedFrom?: InheritedMirrorOptions;
   inheritedLabel?: string;
   /**
    * True while the inherited values are still being fetched. The hint is
@@ -84,18 +98,25 @@ export function MirrorOverridesDialog({
   const [draft, setDraft] = useState<Record<MirrorOverrideKey, TriState>>(
     () => buildDraft(value)
   );
+  const [releaseLimitDraft, setReleaseLimitDraft] = useState(() =>
+    buildReleaseLimitDraft(value)
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   // Re-seed whenever the dialog opens or targets a different object, so a
   // previous edit never leaks into the next one.
   useEffect(() => {
-    if (open) setDraft(buildDraft(value));
+    if (open) {
+      setDraft(buildDraft(value));
+      setReleaseLimitDraft(buildReleaseLimitDraft(value));
+    }
   }, [open, value]);
 
   // What each flag currently resolves to, including the in-progress edit.
-  // Drives the labels gate so it reacts live as issues is toggled.
+  // Drives the labels and release-limit gates so they react live as issues
+  // and releases are toggled.
   const effective = useMemo(() => {
-    const next: Partial<Record<MirrorOverrideKey, boolean>> = {};
+    const next: InheritedMirrorOptions = {};
     for (const key of UI_MIRROR_OVERRIDE_KEYS) {
       const pinned = fromTriState(draft[key]);
       next[key] = pinned ?? inheritedFrom?.[key] ?? false;
@@ -114,9 +135,16 @@ export function MirrorOverridesDialog({
     [targetKind, isStarred, starredCodeOnly, effective]
   );
 
+  const pinnedReleaseLimit = parseReleaseLimitDraft(releaseLimitDraft);
+  // Non-empty text that does not parse to a usable limit (0, negative, junk).
+  const releaseLimitInvalid =
+    releaseLimitDraft.trim() !== "" && pinnedReleaseLimit === undefined;
+
   const overriddenCount = useMemo(
-    () => Object.values(draft).filter((state) => state !== "inherit").length,
-    [draft]
+    () =>
+      Object.values(draft).filter((state) => state !== "inherit").length +
+      (pinnedReleaseLimit !== undefined ? 1 : 0),
+    [draft, pinnedReleaseLimit]
   );
 
   const handleSave = async () => {
@@ -129,6 +157,7 @@ export function MirrorOverridesDialog({
         const resolved = fromTriState(draft[key]);
         if (typeof resolved === "boolean") next[key] = resolved;
       }
+      if (pinnedReleaseLimit !== undefined) next.releaseLimit = pinnedReleaseLimit;
       await onSave(Object.keys(next).length > 0 ? next : null);
       onOpenChange(false);
     } finally {
@@ -138,7 +167,19 @@ export function MirrorOverridesDialog({
 
   const handleResetAll = () => {
     setDraft(buildDraft(null));
+    setReleaseLimitDraft("");
   };
+
+  const releaseLimitReason = gating.releaseLimit;
+  const releaseLimitDisabled = !!releaseLimitReason;
+  const inheritedReleaseLimit = inheritedFrom?.releaseLimit;
+  // Only while the field is genuinely empty: an invalid entry gets the error
+  // line instead, so "currently 10" is not shown next to a rejected "0".
+  const showReleaseLimitHint =
+    !inheritedLoading &&
+    !releaseLimitDisabled &&
+    releaseLimitDraft.trim() === "" &&
+    inheritedReleaseLimit !== undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -164,42 +205,96 @@ export function MirrorOverridesDialog({
               inherited !== undefined;
 
             return (
-              <div key={key} className="space-y-1">
-                <div className="flex items-center justify-between gap-4">
-                  <Label
-                    htmlFor={`override-${key}`}
-                    className={isDisabled ? "flex-1 text-muted-foreground" : "flex-1"}
-                  >
-                    {MIRROR_OVERRIDE_LABELS[key]}
-                    {showHint && (
-                      <span className="ml-2 text-xs font-normal text-muted-foreground">
-                        currently {inherited ? "on" : "off"}
-                      </span>
-                    )}
-                  </Label>
-                  <Select
-                    value={draft[key]}
-                    disabled={isDisabled}
-                    onValueChange={(next) =>
-                      setDraft((prev) => ({ ...prev, [key]: next as TriState }))
-                    }
-                  >
-                    <SelectTrigger id={`override-${key}`} className="w-32">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="inherit">Inherit</SelectItem>
-                      <SelectItem value="on">On</SelectItem>
-                      <SelectItem value="off">Off</SelectItem>
-                    </SelectContent>
-                  </Select>
+              <Fragment key={key}>
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between gap-4">
+                    <Label
+                      htmlFor={`override-${key}`}
+                      className={isDisabled ? "flex-1 text-muted-foreground" : "flex-1"}
+                    >
+                      {MIRROR_OVERRIDE_LABELS[key]}
+                      {showHint && (
+                        <span className="ml-2 text-xs font-normal text-muted-foreground">
+                          currently {inherited ? "on" : "off"}
+                        </span>
+                      )}
+                    </Label>
+                    <Select
+                      value={draft[key]}
+                      disabled={isDisabled}
+                      onValueChange={(next) =>
+                        setDraft((prev) => ({ ...prev, [key]: next as TriState }))
+                      }
+                    >
+                      <SelectTrigger id={`override-${key}`} className="w-32">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="inherit">Inherit</SelectItem>
+                        <SelectItem value="on">On</SelectItem>
+                        <SelectItem value="off">Off</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {isDisabled && (
+                    <p className="text-xs text-muted-foreground">
+                      {disabledReason}
+                    </p>
+                  )}
                 </div>
-                {isDisabled && (
-                  <p className="text-xs text-muted-foreground">
-                    {disabledReason}
-                  </p>
+
+                {/* The limit only means something while releases are mirrored,
+                    so it sits directly under that row. */}
+                {key === "mirrorReleases" && (
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between gap-4">
+                      <Label
+                        htmlFor="override-releaseLimit"
+                        className={
+                          releaseLimitDisabled
+                            ? "flex-1 text-muted-foreground"
+                            : "flex-1"
+                        }
+                      >
+                        {MIRROR_OVERRIDE_LABELS.releaseLimit}
+                        {showReleaseLimitHint && (
+                          <span className="ml-2 text-xs font-normal text-muted-foreground">
+                            currently {inheritedReleaseLimit}
+                          </span>
+                        )}
+                      </Label>
+                      <Input
+                        id="override-releaseLimit"
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        step={1}
+                        placeholder="Inherit"
+                        className="w-32"
+                        value={releaseLimitDraft}
+                        disabled={releaseLimitDisabled}
+                        aria-invalid={releaseLimitInvalid || undefined}
+                        onChange={(event) => setReleaseLimitDraft(event.target.value)}
+                      />
+                    </div>
+                    {releaseLimitDisabled ? (
+                      <p className="text-xs text-muted-foreground">
+                        {releaseLimitReason}
+                      </p>
+                    ) : releaseLimitInvalid ? (
+                      <p className="text-xs text-destructive">
+                        Enter a whole number of 1 or more, or leave it empty to
+                        inherit.
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        Newest releases to keep, assets included. Older ones
+                        past the limit are removed from Gitea on the next sync.
+                      </p>
+                    )}
+                  </div>
                 )}
-              </div>
+              </Fragment>
             );
           })}
         </div>
@@ -225,7 +320,7 @@ export function MirrorOverridesDialog({
           >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isSaving}>
+          <Button onClick={handleSave} disabled={isSaving || releaseLimitInvalid}>
             {isSaving ? "Saving..." : "Save"}
           </Button>
         </DialogFooter>
@@ -242,4 +337,11 @@ function buildDraft(
     draft[key] = toTriState(value?.[key]);
   }
   return draft;
+}
+
+function buildReleaseLimitDraft(
+  value: MirrorOverrides | null | undefined
+): string {
+  const limit = normalizeReleaseLimit(value?.releaseLimit);
+  return limit === undefined ? "" : String(limit);
 }

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -31,6 +31,7 @@ import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog
 import {
   hasMirrorOverrides,
   mirrorOptionsToFlags,
+  normalizeReleaseLimit,
   type MirrorOverrideKey,
 } from "@/lib/utils/mirror-overrides";
 import { Card, CardContent } from "@/components/ui/card";
@@ -162,6 +163,8 @@ export default function RepositoryTable({
       const orgValue = orgOverrides[key];
       if (typeof orgValue === "boolean") globals[key] = orgValue;
     }
+    const orgReleaseLimit = normalizeReleaseLimit(orgOverrides.releaseLimit);
+    if (orgReleaseLimit !== undefined) globals.releaseLimit = orgReleaseLimit;
     return globals;
   }, [mirrorOptions, orgOverrides]);
 
@@ -395,51 +398,66 @@ export default function RepositoryTable({
       <Card className="mb-3">
         <CardContent className="p-4">
           <div className="flex flex-col gap-3">
-            {/* Header with checkbox and repo name */}
-            <div className="flex items-start gap-3">
-              <div
-                onClickCapture={(e) => {
-                  if (e.shiftKey && repo.id) {
-                    e.stopPropagation();
-                    handleShiftRangeSelect(index);
-                  }
-                }}
-              >
-                <Checkbox
-                  checked={isSelected}
-                  onCheckedChange={(checked) => repo.id && handleSelectRepo(repo.id, checked as boolean, index)}
-                  className="mt-1 h-5 w-5"
-                  aria-label={`Select ${repo.name}`}
-                />
+            {/* Header: checkbox, name, Custom badge and menu share one
+                vertically centered row, so the name sits at the same height
+                whether or not the badge is present. Secondary badges get
+                their own row below, indented to the name. */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-3">
+                <div
+                  className="flex shrink-0 items-center"
+                  onClickCapture={(e) => {
+                    if (e.shiftKey && repo.id) {
+                      e.stopPropagation();
+                      handleShiftRangeSelect(index);
+                    }
+                  }}
+                >
+                  <Checkbox
+                    checked={isSelected}
+                    onCheckedChange={(checked) => repo.id && handleSelectRepo(repo.id, checked as boolean, index)}
+                    className="h-5 w-5"
+                    aria-label={`Select ${repo.name}`}
+                  />
+                </div>
+                <h3 className="min-w-0 flex-1 truncate text-base font-medium">{repo.name}</h3>
+                {hasMirrorOverrides(repo.mirrorOverrides) && (
+                  <Badge
+                    variant="outline"
+                    className="h-6 shrink-0 text-xs"
+                    title="This repository overrides the global mirror options"
+                  >
+                    <SlidersHorizontal className="h-3 w-3" />
+                    Custom
+                  </Badge>
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" disabled={isLoading}>
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => setOverridesTarget(repo)}>
+                      <SlidersHorizontal className="h-4 w-4 mr-2" />
+                      Mirror Options
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="font-medium text-base truncate">{repo.name}</h3>
-                <div className="flex items-center gap-2 mt-1 flex-wrap">
+              {(repo.isPrivate || repo.isForked || repo.isStarred) && (
+                <div className="flex flex-wrap items-center gap-2 pl-8">
                   {repo.isPrivate && <Badge variant="secondary" className="text-xs h-5"><Lock className="h-3 w-3 mr-1" />Private</Badge>}
                   {repo.isForked && <Badge variant="secondary" className="text-xs h-5"><GitFork className="h-3 w-3 mr-1" />Fork</Badge>}
                   {repo.isStarred && <Badge variant="secondary" className="text-xs h-5"><Star className="h-3 w-3 mr-1" />Starred</Badge>}
-                  {hasMirrorOverrides(repo.mirrorOverrides) && <Badge variant="outline" className="text-xs h-5"><SlidersHorizontal className="h-3 w-3 mr-1" />Custom</Badge>}
                 </div>
-              </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" disabled={isLoading}>
-                    <MoreVertical className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => setOverridesTarget(repo)}>
-                    <SlidersHorizontal className="h-4 w-4 mr-2" />
-                    Mirror Options
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              )}
             </div>
 
-            {/* Repository details */}
-            <div className="space-y-2">
-              {/* Owner & Organization */}
-              <div className="text-sm text-muted-foreground space-y-1">
+            {/* Details: owner/org/destination on the left, status and last
+                sync stacked on the right so the row's width is used. */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-1 text-sm text-muted-foreground">
                 <div className="flex items-center gap-2">
                   <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Owner:</span>
                   <span className="truncate">{repo.owner}</span>
@@ -457,9 +475,7 @@ export default function RepositoryTable({
                   </div>
                 )}
               </div>
-
-              {/* Status & Last Mirrored */}
-              <div className="flex items-center justify-between">
+              <div className="flex shrink-0 flex-col items-end gap-1">
                 <Badge
                   className={`capitalize
                     ${repo.status === 'imported' ? 'bg-yellow-500/10 text-yellow-600 hover:bg-yellow-500/20 dark:text-yellow-400' :

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -47,11 +47,18 @@ export const backupStrategyEnum = z.enum([
 /**
  * Per-object overrides for the global mirror options in `giteaConfigSchema`.
  *
- * Every flag is nullable, and `null`/absent means "inherit from the next tier
+ * Every field is nullable, and `null`/absent means "inherit from the next tier
  * out". Resolution order is global config -> organization -> repository, and it
- * is applied per flag, so a repository can override LFS while still inheriting
+ * is applied per field, so a repository can override LFS while still inheriting
  * the org's issue setting. See `resolveMirrorOptions` in
  * `src/lib/utils/mirror-overrides.ts`.
+ *
+ * `releaseLimit` is the one non-boolean: how many of the newest GitHub releases
+ * to keep in Gitea (the global default is `giteaConfigSchema.releaseLimit`).
+ * It is deliberately a plain `z.number()` rather than `int().min(1)`: a stored
+ * out-of-range value must degrade to "inherit" for that field alone, not make
+ * the whole overrides object unparseable and silently drop the LFS opt-out
+ * next to it. `normalizeReleaseLimit` does the sanitizing.
  */
 export const mirrorOverridesSchema = z.object({
   lfs: z.boolean().nullable().optional(),
@@ -62,6 +69,7 @@ export const mirrorOverridesSchema = z.object({
   mirrorPullRequests: z.boolean().nullable().optional(),
   mirrorLabels: z.boolean().nullable().optional(),
   mirrorMilestones: z.boolean().nullable().optional(),
+  releaseLimit: z.number().nullable().optional(),
 });
 
 export type MirrorOverrides = z.infer<typeof mirrorOverridesSchema>;

--- a/src/lib/gitea-enhanced.test.ts
+++ b/src/lib/gitea-enhanced.test.ts
@@ -12,6 +12,7 @@ const mockMirrorGitRepoIssuesToGitea = mock(() => Promise.resolve());
 const mockMirrorGitRepoPullRequestsToGitea = mock(() => Promise.resolve());
 const mockMirrorGitRepoLabelsToGitea = mock(() => Promise.resolve());
 const mockMirrorGitRepoMilestonesToGitea = mock(() => Promise.resolve());
+const mockSyncRepositoryMetadataToGitea = mock(() => Promise.resolve());
 const mockGetGiteaRepoOwnerAsync = mock(() => Promise.resolve("starred"));
 const mockCreatePreSyncBundleBackup = mock(() =>
   Promise.resolve({ bundlePath: "/tmp/mock.bundle" })
@@ -355,6 +356,7 @@ describe("Enhanced Gitea Operations", () => {
     mockMirrorGitRepoPullRequestsToGitea.mockClear();
     mockMirrorGitRepoLabelsToGitea.mockClear();
     mockMirrorGitRepoMilestonesToGitea.mockClear();
+    mockSyncRepositoryMetadataToGitea.mockClear();
     mockGetGiteaRepoOwnerAsync.mockClear();
     mockGetGiteaRepoOwnerAsync.mockImplementation(() => Promise.resolve("starred"));
     mockHttpGet.mockClear();
@@ -572,6 +574,7 @@ describe("Enhanced Gitea Operations", () => {
             mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
             mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
             mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+            syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
           }
         )
       ).rejects.toThrow("Repository non-mirror-repo is not a mirror. Cannot sync.");
@@ -620,6 +623,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -631,6 +635,71 @@ describe("Enhanced Gitea Operations", () => {
       expect(releaseCall.giteaRepoName).toBe("mirror-repo");
       expect(releaseCall.config.githubConfig?.token).toBe("github-token");
       expect(releaseCall.octokit).toBeDefined();
+      // No override anywhere: the resolved default limit is handed through.
+      expect(releaseCall.releaseLimit).toBe(10);
+
+      // Description/topics are reconciled on every sync, against the resolved
+      // target, with the Gitea repo info already fetched during target
+      // resolution so unchanged values can skip the write.
+      expect(mockSyncRepositoryMetadataToGitea).toHaveBeenCalledTimes(1);
+      const metadataCall = mockSyncRepositoryMetadataToGitea.mock.calls[0][0] as any;
+      expect(metadataCall.giteaOwner).toBe("starred");
+      expect(metadataCall.giteaRepoName).toBe("mirror-repo");
+      expect(metadataCall.giteaToken).toBe("encrypted-token");
+      expect(metadataCall.octokit).toBeDefined();
+      expect(metadataCall.current?.mirror).toBe(true);
+    });
+
+    test("passes the per-repository release limit through to the release mirror", async () => {
+      const config: Partial<Config> = {
+        userId: "user123",
+        githubConfig: {
+          username: "testuser",
+          token: "github-token",
+          privateRepositories: false,
+          mirrorStarred: true,
+        },
+        giteaConfig: {
+          url: "https://gitea.example.com",
+          token: "encrypted-token",
+          defaultOwner: "testuser",
+          mirrorReleases: true,
+          releaseLimit: 25,
+        },
+      };
+
+      const repository: Repository = {
+        id: "repo456",
+        name: "mirror-repo",
+        fullName: "user/mirror-repo",
+        owner: "user",
+        cloneUrl: "https://github.com/user/mirror-repo.git",
+        isPrivate: false,
+        isStarred: true,
+        status: repoStatusEnum.parse("mirrored"),
+        visibility: "public",
+        userId: "user123",
+        mirrorOverrides: { releaseLimit: 3 },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      await syncGiteaRepoEnhanced(
+        { config, repository },
+        {
+          getGiteaRepoOwnerAsync: mockGetGiteaRepoOwnerAsync,
+          mirrorGitHubReleasesToGitea: mockMirrorGitHubReleasesToGitea,
+          mirrorGitRepoIssuesToGitea: mockMirrorGitRepoIssuesToGitea,
+          mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
+          mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
+          mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
+        }
+      );
+
+      expect(mockMirrorGitHubReleasesToGitea).toHaveBeenCalledTimes(1);
+      const releaseCall = mockMirrorGitHubReleasesToGitea.mock.calls[0][0] as any;
+      expect(releaseCall.releaseLimit).toBe(3);
     });
 
     test("prefers recorded mirroredLocation when owner resolution changes", async () => {
@@ -677,6 +746,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -738,6 +808,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -821,6 +892,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -892,6 +964,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -970,6 +1043,7 @@ describe("Enhanced Gitea Operations", () => {
             mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
             mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
             mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+            syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
           }
         )
       ).rejects.toThrow("Repository collide-repo not found in Gitea. Tried locations:");
@@ -1037,6 +1111,7 @@ describe("Enhanced Gitea Operations", () => {
             mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
             mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
             mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+            syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
           }
         )
       ).rejects.toThrow("Snapshot failed; sync blocked to protect history.");
@@ -1096,6 +1171,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -1153,6 +1229,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 
@@ -1220,6 +1297,7 @@ describe("Enhanced Gitea Operations", () => {
           mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
           mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
           mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
         }
       );
 

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -35,6 +35,7 @@ import {
 
 type SyncDependencies = {
   getGiteaRepoOwnerAsync: typeof import("./gitea")["getGiteaRepoOwnerAsync"];
+  syncRepositoryMetadataToGitea: typeof import("./gitea")["syncRepositoryMetadataToGitea"];
   mirrorGitHubReleasesToGitea: typeof import("./gitea")["mirrorGitHubReleasesToGitea"];
   mirrorGitRepoIssuesToGitea: typeof import("./gitea")["mirrorGitRepoIssuesToGitea"];
   mirrorGitRepoPullRequestsToGitea: typeof import("./gitea")["mirrorGitRepoPullRequestsToGitea"];
@@ -58,6 +59,10 @@ export interface GiteaRepoInfo {
   // GitHub source (vs. a same-named mirror of a different source).
   original_url?: string;
   private: boolean;
+  // Current description/topics, so the per-sync metadata reconciliation can
+  // skip writes that would not change anything.
+  description?: string;
+  topics?: string[];
 }
 
 interface SyncTargetCandidate {
@@ -755,6 +760,33 @@ export async function syncGiteaRepoEnhanced({
         return metadataOctokit;
       };
 
+      // Keep the description and topics in step with GitHub on every sync,
+      // not only at migration time. Mirrors created before the description
+      // was carried over (#224), or whose upstream description changed since,
+      // otherwise stay stale forever (reported in #361). `repoInfo` is the
+      // Gitea state fetched during target resolution, so unchanged values
+      // cost no write. Without a GitHub token the stored description is used
+      // and topics are left alone.
+      try {
+        await dependencies.syncRepositoryMetadataToGitea({
+          config,
+          octokit: ensureOctokit(),
+          repository,
+          giteaOwner: repoOwner,
+          giteaRepoName: repoName,
+          giteaToken: decryptedConfig.giteaConfig.token,
+          current: repoInfo,
+        });
+      } catch (metadataError) {
+        console.warn(
+          `[Sync] Failed to reconcile description/topics for ${repository.name}: ${
+            metadataError instanceof Error
+              ? metadataError.message
+              : String(metadataError)
+          }`
+        );
+      }
+
       // Reconcile metadata on every sync (matches the release path).
       // The underlying mirror* functions are idempotent: issues/PRs are
       // matched via [GH-ISSUE #N] / [GH-PR #N] markers and PATCHed in
@@ -781,6 +813,7 @@ export async function syncGiteaRepoEnhanced({
               repository,
               giteaOwner: repoOwner,
               giteaRepoName: repoName,
+              releaseLimit: mirrorOptions.releaseLimit,
             });
             metadataState.components.releases = true;
             metadataUpdated = true;

--- a/src/lib/gitea-repo-metadata.test.ts
+++ b/src/lib/gitea-repo-metadata.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for syncRepositoryMetadataToGitea (description + topics).
+ *
+ * Follow-up to #361: the description was only sent at migration time, from the
+ * locally stored value, so mirrors created before it was carried over (#224)
+ * or whose upstream description changed since stayed stale for good. The sync
+ * path now reconciles it on every run, reading GitHub live when a token is
+ * available and skipping writes that would change nothing.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+const okResponse = () => ({
+  data: {},
+  status: 200,
+  statusText: "OK",
+  headers: new Headers(),
+});
+
+const mockHttpGet = mock(async (_url: string, _headers?: any) => okResponse());
+const mockHttpPatch = mock(async (_url: string, _body?: any, _headers?: any) =>
+  okResponse()
+);
+const mockHttpPut = mock(async (_url: string, _body?: any, _headers?: any) =>
+  okResponse()
+);
+const mockHttpPost = mock(async () => okResponse());
+const mockHttpDelete = mock(async () => okResponse());
+
+class MockHttpError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public statusText: string,
+    public response?: string
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+mock.module("@/lib/http-client", () => ({
+  httpGet: mockHttpGet,
+  httpPatch: mockHttpPatch,
+  httpPut: mockHttpPut,
+  httpPost: mockHttpPost,
+  httpDelete: mockHttpDelete,
+  HttpError: MockHttpError,
+}));
+
+// Capture what gets written back to the repositories row.
+const dbUpdateSetCalls: any[] = [];
+mock.module("@/lib/db", () => ({
+  db: {
+    update: () => ({
+      set: (data: any) => {
+        dbUpdateSetCalls.push(data);
+        return { where: async () => {} };
+      },
+    }),
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => [] }) }),
+    }),
+    insert: () => ({ values: async () => ({}) }),
+  },
+  users: {},
+  configs: {},
+  repositories: {},
+  organizations: {},
+  mirrorJobs: {},
+  events: {},
+  accounts: {},
+  sessions: {},
+}));
+
+mock.module("@/lib/helpers", () => ({
+  createMirrorJob: mock(async () => "job-id"),
+}));
+
+import { syncRepositoryMetadataToGitea } from "./gitea";
+import type { Config, Repository } from "./db/schema";
+
+const GITEA_URL = "https://gitea.example.com";
+const REPO_API = `${GITEA_URL}/api/v1/repos/mirror/browser-use`;
+const UPSTREAM_DESCRIPTION = "Make websites accessible for AI agents";
+
+function makeConfig(gitea: Record<string, unknown> = {}): Partial<Config> {
+  return {
+    userId: "user-1",
+    giteaConfig: {
+      url: GITEA_URL,
+      token: "gitea-token",
+      defaultOwner: "mirror",
+      ...gitea,
+    } as any,
+  };
+}
+
+function makeRepo(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: "repo-1",
+    userId: "user-1",
+    name: "browser-use",
+    fullName: "browser-use/browser-use",
+    owner: "browser-use",
+    cloneUrl: "https://github.com/browser-use/browser-use.git",
+    isPrivate: false,
+    isStarred: false,
+    status: "mirrored",
+    visibility: "public",
+    description: "stored description",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Repository;
+}
+
+/** Octokit stand-in: a single `request` that resolves to `data` or throws. */
+function makeOctokit(result: Record<string, unknown> | Error) {
+  const request = mock(async () => {
+    if (result instanceof Error) throw result;
+    return { data: result, status: 200, headers: {} };
+  });
+  return { request } as any;
+}
+
+async function run(opts: {
+  octokit: any;
+  repository?: Repository;
+  config?: Partial<Config>;
+  current?: { description?: string | null; topics?: string[] | null } | null;
+}) {
+  await syncRepositoryMetadataToGitea({
+    config: opts.config ?? makeConfig(),
+    octokit: opts.octokit,
+    repository: opts.repository ?? makeRepo(),
+    giteaOwner: "mirror",
+    giteaRepoName: "browser-use",
+    giteaToken: "gitea-token",
+    current: opts.current,
+  });
+}
+
+beforeEach(() => {
+  mockHttpPatch.mockClear();
+  mockHttpPut.mockClear();
+  dbUpdateSetCalls.length = 0;
+});
+
+describe("syncRepositoryMetadataToGitea", () => {
+  test("reads description and topics from GitHub in one call and writes both to Gitea", async () => {
+    const octokit = makeOctokit({
+      description: UPSTREAM_DESCRIPTION,
+      topics: ["ai", "browser"],
+    });
+
+    await run({ octokit });
+
+    expect(octokit.request).toHaveBeenCalledTimes(1);
+    expect(octokit.request.mock.calls[0][0]).toBe("GET /repos/{owner}/{repo}");
+    expect(octokit.request.mock.calls[0][1]).toMatchObject({
+      owner: "browser-use",
+      repo: "browser-use",
+    });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+    expect(mockHttpPatch.mock.calls[0][0]).toBe(REPO_API);
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({
+      description: UPSTREAM_DESCRIPTION,
+    });
+
+    expect(mockHttpPut).toHaveBeenCalledTimes(1);
+    expect(mockHttpPut.mock.calls[0][0]).toBe(`${REPO_API}/topics`);
+    expect(mockHttpPut.mock.calls[0][1]).toEqual({ topics: ["ai", "browser"] });
+  });
+
+  test("GitHub wins over the stored description and the row is refreshed", async () => {
+    await run({
+      octokit: makeOctokit({ description: UPSTREAM_DESCRIPTION, topics: [] }),
+    });
+
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({
+      description: UPSTREAM_DESCRIPTION,
+    });
+    expect(dbUpdateSetCalls).toHaveLength(1);
+    expect(dbUpdateSetCalls[0].description).toBe(UPSTREAM_DESCRIPTION);
+  });
+
+  test("leaves the row alone when the stored description already matches", async () => {
+    await run({
+      octokit: makeOctokit({ description: "stored description", topics: [] }),
+    });
+
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("skips both writes when Gitea already holds the upstream values", async () => {
+    await run({
+      octokit: makeOctokit({
+        description: UPSTREAM_DESCRIPTION,
+        topics: ["ai", "browser"],
+      }),
+      // Topic order from Gitea is not guaranteed; the comparison is a set.
+      current: { description: UPSTREAM_DESCRIPTION, topics: ["browser", "ai"] },
+    });
+
+    expect(mockHttpPatch).not.toHaveBeenCalled();
+    expect(mockHttpPut).not.toHaveBeenCalled();
+  });
+
+  test("writes only what changed", async () => {
+    await run({
+      octokit: makeOctokit({
+        description: UPSTREAM_DESCRIPTION,
+        topics: ["ai", "browser", "llm"],
+      }),
+      current: { description: UPSTREAM_DESCRIPTION, topics: ["ai", "browser"] },
+    });
+
+    expect(mockHttpPatch).not.toHaveBeenCalled();
+    expect(mockHttpPut).toHaveBeenCalledTimes(1);
+    expect(mockHttpPut.mock.calls[0][1]).toEqual({
+      topics: ["ai", "browser", "llm"],
+    });
+  });
+
+  test("a Gitea repo that never had a description still gets one", async () => {
+    // Gitea reports an empty description for such repos. That must read as
+    // "differs from upstream", not "unknown, skip".
+    await run({
+      octokit: makeOctokit({ description: UPSTREAM_DESCRIPTION, topics: [] }),
+      current: { description: "", topics: [] },
+    });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({
+      description: UPSTREAM_DESCRIPTION,
+    });
+  });
+
+  test("without `current` the description is written unconditionally (migration path)", async () => {
+    await run({
+      octokit: makeOctokit({ description: UPSTREAM_DESCRIPTION, topics: [] }),
+    });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+  });
+
+  test("an empty upstream description clears the Gitea one and the stored one", async () => {
+    await run({
+      octokit: makeOctokit({ description: null, topics: [] }),
+      current: { description: "old text", topics: [] },
+    });
+
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({ description: "" });
+    expect(dbUpdateSetCalls).toHaveLength(1);
+    expect(dbUpdateSetCalls[0].description).toBeNull();
+  });
+
+  test("falls back to the stored description when GitHub is unreachable", async () => {
+    await run({ octokit: makeOctokit(new Error("GitHub down")) });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({
+      description: "stored description",
+    });
+    // Nothing fresh to store, and no topic list to push.
+    expect(dbUpdateSetCalls).toHaveLength(0);
+    expect(mockHttpPut).not.toHaveBeenCalled();
+  });
+
+  test("a GitHub outage never wipes a description Gitea already has", async () => {
+    // With no stored value and no upstream answer there is nothing
+    // authoritative to write, so the transient-failure path must not PATCH
+    // an empty string over a real description.
+    await run({
+      octokit: makeOctokit(new Error("GitHub down")),
+      repository: makeRepo({ description: null }),
+      current: { description: UPSTREAM_DESCRIPTION, topics: [] },
+    });
+
+    expect(mockHttpPatch).not.toHaveBeenCalled();
+  });
+
+  test("without a GitHub token uses the stored description and skips topics", async () => {
+    await run({ octokit: null });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+    expect(mockHttpPatch.mock.calls[0][1]).toEqual({
+      description: "stored description",
+    });
+    expect(mockHttpPut).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("honors addTopics=false but still syncs the description", async () => {
+    await run({
+      octokit: makeOctokit({ description: UPSTREAM_DESCRIPTION, topics: ["ai"] }),
+      config: makeConfig({ addTopics: false }),
+    });
+
+    expect(mockHttpPatch).toHaveBeenCalledTimes(1);
+    expect(mockHttpPut).not.toHaveBeenCalled();
+  });
+
+  test("applies the configured topic prefix before comparing and writing", async () => {
+    await run({
+      octokit: makeOctokit({
+        description: UPSTREAM_DESCRIPTION,
+        topics: ["AI", "Browser Use"],
+      }),
+      config: makeConfig({ topicPrefix: "gh" }),
+      current: { description: UPSTREAM_DESCRIPTION, topics: ["gh-ai"] },
+    });
+
+    expect(mockHttpPut).toHaveBeenCalledTimes(1);
+    expect(mockHttpPut.mock.calls[0][1]).toEqual({
+      topics: ["gh-ai", "gh-browser-use"],
+    });
+  });
+
+  test("a failed Gitea write is logged, not thrown, and topics still get their turn", async () => {
+    mockHttpPatch.mockImplementationOnce(async () => {
+      throw new MockHttpError("nope", 500, "Server Error");
+    });
+
+    await expect(
+      run({
+        octokit: makeOctokit({ description: UPSTREAM_DESCRIPTION, topics: ["ai"] }),
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockHttpPut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -18,7 +18,10 @@ import {
   parseRepositoryMetadataState,
   serializeRepositoryMetadataState,
 } from "./metadata-state";
-import { resolveMirrorOptionsForRepository } from "./utils/mirror-overrides";
+import {
+  normalizeReleaseLimit,
+  resolveMirrorOptionsForRepository,
+} from "./utils/mirror-overrides";
 
 /**
  * Helper function to get organization configuration including destination override
@@ -416,17 +419,29 @@ const getSourceRepositoryCoordinates = (repository: Repository) => {
   };
 };
 
-const fetchGitHubTopics = async ({
+type GitHubRepositoryMetadata = {
+  description: string | null;
+  /** Null when the payload carried no usable topic list. */
+  topics: string[] | null;
+};
+
+/**
+ * Fetch the upstream description and topics in one call.
+ * `GET /repos/{owner}/{repo}` carries both, and the client's ETag layer (see
+ * createGitHubClient) turns the per-sync re-check into a rate-limit-free 304
+ * whenever nothing changed upstream.
+ */
+const fetchGitHubRepositoryMetadata = async ({
   octokit,
   repository,
 }: {
   octokit: Octokit;
   repository: Repository;
-}): Promise<string[] | null> => {
+}): Promise<GitHubRepositoryMetadata | null> => {
   const { owner, repo } = getSourceRepositoryCoordinates(repository);
 
   try {
-    const response = await octokit.request("GET /repos/{owner}/{repo}/topics", {
+    const response = await octokit.request("GET /repos/{owner}/{repo}", {
       owner,
       repo,
       headers: {
@@ -434,18 +449,23 @@ const fetchGitHubTopics = async ({
       },
     });
 
-    const names = (response.data as { names?: unknown }).names;
-    if (!Array.isArray(names)) {
+    const data = response.data as { description?: unknown; topics?: unknown };
+    const description =
+      typeof data.description === "string" ? data.description : null;
+    const topics = Array.isArray(data.topics)
+      ? data.topics.filter((topic): topic is string => typeof topic === "string")
+      : null;
+
+    if (topics === null) {
       console.warn(
-        `[Metadata] Unexpected topics payload for ${repository.fullName}; skipping topic sync.`
+        `[Metadata] Unexpected topics payload for ${repository.fullName}; topic sync will be skipped.`
       );
-      return null;
     }
 
-    return names.filter((topic): topic is string => typeof topic === "string");
+    return { description, topics };
   } catch (error) {
     console.warn(
-      `[Metadata] Failed to fetch topics from GitHub for ${repository.fullName}: ${
+      `[Metadata] Failed to fetch repository metadata from GitHub for ${repository.fullName}: ${
         error instanceof Error ? error.message : String(error)
       }`
     );
@@ -453,55 +473,116 @@ const fetchGitHubTopics = async ({
   }
 };
 
-const syncRepositoryMetadataToGitea = async ({
+/** Order-insensitive, case-insensitive topic list comparison. */
+const sameTopicSet = (a: string[], b: string[]): boolean => {
+  if (a.length !== b.length) return false;
+  const sortedA = a.map((topic) => topic.toLowerCase()).sort();
+  const sortedB = b.map((topic) => topic.toLowerCase()).sort();
+  return sortedA.every((topic, index) => topic === sortedB[index]);
+};
+
+/**
+ * Bring the Gitea repository's description and topics in line with GitHub.
+ *
+ * Runs after migration and on every sync. GitHub is authoritative whenever it
+ * can be reached; the stored `repository.description` is only a fallback (no
+ * token, or a transient GitHub failure), and an empty fallback is never
+ * written so a blip upstream cannot wipe a description Gitea already has.
+ * A refreshed description is written back to the local row so the UI and any
+ * token-less path see the same value Gitea does.
+ *
+ * `current` is what Gitea holds right now, for callers that already fetched
+ * the repo. Values that already match are not rewritten.
+ *
+ * Every step degrades to a warning: metadata must never fail a mirror run.
+ */
+export const syncRepositoryMetadataToGitea = async ({
   config,
   octokit,
   repository,
   giteaOwner,
   giteaRepoName,
   giteaToken,
+  current,
 }: {
   config: Partial<Config>;
-  octokit: Octokit;
+  /** Null when no GitHub token is available. */
+  octokit: Octokit | null;
   repository: Repository;
   giteaOwner: string;
   giteaRepoName: string;
   giteaToken: string;
+  current?: { description?: string | null; topics?: string[] | null } | null;
 }): Promise<void> => {
   const giteaBaseUrl = config.giteaConfig?.url;
   if (!giteaBaseUrl) {
     return;
   }
 
-  const repoApiUrl = `${giteaBaseUrl}/api/v1/repos/${giteaOwner}/${giteaRepoName}`;
+  const target = `${giteaOwner}/${giteaRepoName}`;
+  const repoApiUrl = `${giteaBaseUrl}/api/v1/repos/${target}`;
   const authHeaders = {
     Authorization: `token ${giteaToken}`,
   };
-  const description = repository.description?.trim() || "";
 
-  try {
-    await httpPatch(
-      repoApiUrl,
-      { description },
-      authHeaders
-    );
+  const upstream = octokit
+    ? await fetchGitHubRepositoryMetadata({ octokit, repository })
+    : null;
+
+  const storedDescription = repository.description ?? null;
+  const description =
+    (upstream ? upstream.description : storedDescription)?.trim() || "";
+
+  if (upstream && repository.id && upstream.description !== storedDescription) {
+    try {
+      await db
+        .update(repositories)
+        .set({ description: upstream.description, updatedAt: new Date() })
+        .where(eq(repositories.id, repository.id));
+    } catch (error) {
+      console.warn(
+        `[Metadata] Failed to store the refreshed description for ${repository.fullName}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  if (!upstream && !description) {
     console.log(
-      `[Metadata] Synced description for ${repository.fullName} to ${giteaOwner}/${giteaRepoName}`
+      `[Metadata] No description available for ${repository.fullName} (GitHub not consulted); leaving ${target} unchanged`
     );
-  } catch (error) {
-    console.warn(
-      `[Metadata] Failed to sync description for ${repository.fullName} to ${giteaOwner}/${giteaRepoName}: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+  } else if (current && (current.description ?? "").trim() === description) {
+    console.log(
+      `[Metadata] Description for ${repository.fullName} already matches ${target}; skipping`
     );
+  } else {
+    try {
+      await httpPatch(repoApiUrl, { description }, authHeaders);
+      console.log(
+        `[Metadata] Synced description for ${repository.fullName} to ${target}`
+      );
+    } catch (error) {
+      console.warn(
+        `[Metadata] Failed to sync description for ${repository.fullName} to ${target}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
   }
 
   if (config.giteaConfig?.addTopics === false) {
     return;
   }
 
-  const sourceTopics = await fetchGitHubTopics({ octokit, repository });
-  if (sourceTopics === null) {
+  if (!octokit) {
+    console.log(
+      `[Metadata] Skipping topic sync for ${repository.fullName}: no GitHub token`
+    );
+    return;
+  }
+
+  if (!upstream?.topics) {
     console.warn(
       `[Metadata] Skipping topic sync for ${repository.fullName} because GitHub topics could not be fetched.`
     );
@@ -509,22 +590,25 @@ const syncRepositoryMetadataToGitea = async ({
   }
 
   const topics = normalizeTopicsForGitea(
-    sourceTopics,
+    upstream.topics,
     config.giteaConfig?.topicPrefix
   );
 
-  try {
-    await httpPut(
-      `${repoApiUrl}/topics`,
-      { topics },
-      authHeaders
-    );
+  if (current?.topics && sameTopicSet(current.topics, topics)) {
     console.log(
-      `[Metadata] Synced ${topics.length} topic(s) for ${repository.fullName} to ${giteaOwner}/${giteaRepoName}`
+      `[Metadata] Topics for ${repository.fullName} already match ${target}; skipping`
+    );
+    return;
+  }
+
+  try {
+    await httpPut(`${repoApiUrl}/topics`, { topics }, authHeaders);
+    console.log(
+      `[Metadata] Synced ${topics.length} topic(s) for ${repository.fullName} to ${target}`
     );
   } catch (error) {
     console.warn(
-      `[Metadata] Failed to sync topics for ${repository.fullName} to ${giteaOwner}/${giteaRepoName}: ${
+      `[Metadata] Failed to sync topics for ${repository.fullName} to ${target}: ${
         error instanceof Error ? error.message : String(error)
       }`
     );
@@ -940,6 +1024,7 @@ export const mirrorGithubRepoToGitea = async ({
           repository,
           giteaOwner: repoOwner,
           giteaRepoName: targetRepoName,
+          releaseLimit: mirrorOptions.releaseLimit,
         });
         metadataState.components.releases = true;
         metadataUpdated = true;
@@ -1697,6 +1782,7 @@ export async function mirrorGitHubRepoToGiteaOrg({
           repository,
           giteaOwner: orgName,
           giteaRepoName: targetRepoName,
+          releaseLimit: mirrorOptions.releaseLimit,
         });
         metadataState.components.releases = true;
         metadataUpdated = true;
@@ -2992,12 +3078,19 @@ export async function mirrorGitHubReleasesToGitea({
   config,
   giteaOwner,
   giteaRepoName,
+  releaseLimit: releaseLimitOverride,
 }: {
   octokit: Octokit;
   repository: Repository;
   config: Partial<Config>;
   giteaOwner?: string;
   giteaRepoName?: string;
+  /**
+   * Already-resolved limit (global -> org -> repo). Callers that went through
+   * `resolveMirrorOptionsForRepository` pass it in; when absent it is resolved
+   * here so direct callers still honor per-repo overrides.
+   */
+  releaseLimit?: number;
 }) {
   if (
     !config.giteaConfig?.defaultOwner ||
@@ -3035,8 +3128,13 @@ export async function mirrorGitHubReleasesToGitea({
     throw new Error(`Repository ${repository.name} does not exist in Gitea at ${repoOwner}. Please ensure the repository is mirrored first.`);
   }
 
-  // Get release limit from config (default to 10)
-  const releaseLimit = Math.max(1, Math.floor(config.giteaConfig?.releaseLimit || 10));
+  // How many of the newest releases to keep. Per-repo and per-org overrides
+  // win over the global setting (#361); the resolver guarantees a positive
+  // integer. Everything below the limit is created/updated, everything beyond
+  // it is pruned from Gitea by the retention pass at the end.
+  const releaseLimit =
+    normalizeReleaseLimit(releaseLimitOverride) ??
+    (await resolveMirrorOptionsForRepository({ config, repository })).releaseLimit;
 
   // GitHub API max per page is 100; paginate until we reach the configured limit.
   const releases: Awaited<

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_RELEASE_LIMIT,
   getMirrorOverrideGating,
   hasMirrorOverrides,
   listOverriddenKeys,
   MIRROR_GATING_REASONS,
+  MIRROR_OVERRIDE_KEYS,
   mirrorOptionsToFlags,
   normalizeMirrorOverrides,
+  normalizeReleaseLimit,
   parseMirrorOverrides,
   resolveMirrorOptions,
   STARRED_CLAMPED_KEYS,
@@ -53,10 +56,11 @@ describe("resolveMirrorOptions precedence", () => {
       repository: makeRepo(),
     });
 
-    for (const value of Object.values(resolved)) {
-      expect(typeof value).toBe("boolean");
+    for (const key of MIRROR_OVERRIDE_KEYS) {
+      expect(typeof resolved[key]).toBe("boolean");
     }
     expect(resolved.lfs).toBe(false);
+    expect(resolved.releaseLimit).toBe(DEFAULT_RELEASE_LIMIT);
   });
 
   test("organization override beats global config", () => {
@@ -606,5 +610,204 @@ describe("mirrorOptionsToFlags - client/server shape contract", () => {
       expect(flags.lfs).toBe(false);
       expect(flags.mirrorIssues).toBe(false);
     }
+  });
+});
+
+describe("releaseLimit override", () => {
+  test("falls back to the global release limit, then the default", () => {
+    expect(
+      resolveMirrorOptions({
+        config: makeConfig({ releaseLimit: 25 }),
+        repository: makeRepo(),
+      }).releaseLimit
+    ).toBe(25);
+    expect(
+      resolveMirrorOptions({ config: makeConfig({}), repository: makeRepo() })
+        .releaseLimit
+    ).toBe(DEFAULT_RELEASE_LIMIT);
+  });
+
+  test("organization override beats global, repository override beats organization", () => {
+    const config = makeConfig({ releaseLimit: 25 });
+
+    expect(
+      resolveMirrorOptions({
+        config,
+        repository: makeRepo(),
+        orgOverrides: { releaseLimit: 5 },
+      }).releaseLimit
+    ).toBe(5);
+    expect(
+      resolveMirrorOptions({
+        config,
+        repository: makeRepo({ mirrorOverrides: { releaseLimit: 2 } }),
+        orgOverrides: { releaseLimit: 5 },
+      }).releaseLimit
+    ).toBe(2);
+  });
+
+  test("an unusable limit at one tier falls through instead of clamping to 1", () => {
+    const config = makeConfig({ releaseLimit: 25 });
+
+    expect(
+      resolveMirrorOptions({
+        config,
+        repository: makeRepo({ mirrorOverrides: { releaseLimit: 0 } }),
+        orgOverrides: { releaseLimit: 5 },
+      }).releaseLimit
+    ).toBe(5);
+    expect(
+      resolveMirrorOptions({
+        config,
+        repository: makeRepo({ mirrorOverrides: { releaseLimit: -3 } }),
+      }).releaseLimit
+    ).toBe(25);
+    expect(
+      resolveMirrorOptions({
+        config: makeConfig({ releaseLimit: 0 }),
+        repository: makeRepo(),
+      }).releaseLimit
+    ).toBe(DEFAULT_RELEASE_LIMIT);
+  });
+
+  test("fractional limits are floored", () => {
+    expect(
+      resolveMirrorOptions({
+        config: makeConfig({}),
+        repository: makeRepo({ mirrorOverrides: { releaseLimit: 3.9 } }),
+      }).releaseLimit
+    ).toBe(3);
+  });
+
+  test("null means inherit and does not disturb the boolean flags", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ releaseLimit: 7, lfs: true }),
+      repository: makeRepo({
+        mirrorOverrides: { releaseLimit: null, lfs: false },
+      }),
+    });
+
+    expect(resolved.releaseLimit).toBe(7);
+    expect(resolved.lfs).toBe(false);
+  });
+
+  test("a bad limit does not take the other overrides down with it", () => {
+    // The schema accepts any number precisely so that a stored out-of-range
+    // limit degrades to inherit for that field alone. The #361 LFS opt-out
+    // stored next to it must survive.
+    const resolved = resolveMirrorOptions({
+      config: makeConfig({ lfs: true, releaseLimit: 25 }),
+      repository: makeRepo({
+        mirrorOverrides: { lfs: false, releaseLimit: -1 },
+      }),
+    });
+
+    expect(resolved.lfs).toBe(false);
+    expect(resolved.releaseLimit).toBe(25);
+  });
+
+  test("the starred clamp leaves the limit alone; releases are already forced off", () => {
+    const resolved = resolveMirrorOptions({
+      config: makeConfig(
+        { mirrorReleases: true, releaseLimit: 7 },
+        { starredCodeOnly: true }
+      ),
+      repository: makeRepo({
+        isStarred: true,
+        mirrorOverrides: { releaseLimit: 3 },
+      }),
+    });
+
+    expect(resolved.mirrorReleases).toBe(false);
+    expect(resolved.releaseLimit).toBe(3);
+  });
+
+  test("helpers treat a usable limit as a pinned override", () => {
+    expect(hasMirrorOverrides({ releaseLimit: 5 })).toBe(true);
+    expect(hasMirrorOverrides({ releaseLimit: 0 })).toBe(false);
+    expect(hasMirrorOverrides({ releaseLimit: null })).toBe(false);
+    expect(listOverriddenKeys({ lfs: false, releaseLimit: 5 })).toEqual([
+      "lfs",
+      "releaseLimit",
+    ]);
+    expect(normalizeMirrorOverrides({ releaseLimit: 5.7 })).toEqual({
+      releaseLimit: 5,
+    });
+    expect(normalizeMirrorOverrides({ releaseLimit: 0 })).toBeNull();
+    expect(normalizeMirrorOverrides({ lfs: false, releaseLimit: 0 })).toEqual({
+      lfs: false,
+    });
+  });
+
+  test("normalizeReleaseLimit accepts positive finite numbers only", () => {
+    expect(normalizeReleaseLimit(10)).toBe(10);
+    expect(normalizeReleaseLimit(2.5)).toBe(2);
+    expect(normalizeReleaseLimit(0)).toBeUndefined();
+    expect(normalizeReleaseLimit(0.4)).toBeUndefined();
+    expect(normalizeReleaseLimit(-1)).toBeUndefined();
+    expect(normalizeReleaseLimit(NaN)).toBeUndefined();
+    expect(normalizeReleaseLimit(Infinity)).toBeUndefined();
+    expect(normalizeReleaseLimit("5")).toBeUndefined();
+    expect(normalizeReleaseLimit(null)).toBeUndefined();
+    expect(normalizeReleaseLimit(undefined)).toBeUndefined();
+  });
+
+  test("mirrorOptionsToFlags carries the global limit for the Inherit hint", () => {
+    expect(
+      mirrorOptionsToFlags({ mirrorReleases: true, releaseLimit: 42 }).releaseLimit
+    ).toBe(42);
+    expect(mirrorOptionsToFlags(null).releaseLimit).toBe(DEFAULT_RELEASE_LIMIT);
+  });
+
+  test("the global limit survives the DB -> API -> flags round trip", async () => {
+    const { mapDbToUiConfig } = await import("./config-mapper");
+    const apiShape = mapDbToUiConfig({
+      githubConfig: { owner: "acme" },
+      giteaConfig: {
+        url: "https://gitea.example.com",
+        token: "t",
+        defaultOwner: "acme",
+        mirrorReleases: true,
+        releaseLimit: 33,
+      },
+    } as any);
+
+    expect(mirrorOptionsToFlags(apiShape.mirrorOptions).releaseLimit).toBe(33);
+  });
+});
+
+describe("getMirrorOverrideGating - release limit follows releases", () => {
+  test("limit is disabled while releases resolve to off", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective: { mirrorReleases: false },
+    });
+    expect(gating.releaseLimit).toBe(MIRROR_GATING_REASONS.releasesOff);
+  });
+
+  test("limit is editable while releases resolve to on", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      effective: { mirrorReleases: true },
+    });
+    expect(gating.releaseLimit).toBeUndefined();
+  });
+
+  test("the starred reason wins when that is what disabled releases", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "repository",
+      isStarred: true,
+      starredCodeOnly: true,
+      effective: { mirrorReleases: true },
+    });
+    expect(gating.releaseLimit).toBe(MIRROR_GATING_REASONS.starredCodeOnly);
+  });
+
+  test("applies to organizations too", () => {
+    const gating = getMirrorOverrideGating({
+      targetKind: "organization",
+      effective: { mirrorReleases: false },
+    });
+    expect(gating.releaseLimit).toBe(MIRROR_GATING_REASONS.releasesOff);
   });
 });

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -20,8 +20,43 @@ export const MIRROR_OVERRIDE_KEYS = [
 
 export type MirrorOverrideKey = (typeof MIRROR_OVERRIDE_KEYS)[number];
 
-/** Fully resolved mirror options: every flag has a definite boolean value. */
-export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean>;
+/**
+ * The numeric mirror options that can be overridden per organization and per
+ * repository. Kept apart from the boolean flags because every consumer of
+ * MIRROR_OVERRIDE_KEYS (resolver, gating, dialog tri-states) assumes booleans.
+ */
+export const MIRROR_OVERRIDE_LIMIT_KEYS = ["releaseLimit"] as const;
+
+export type MirrorOverrideLimitKey = (typeof MIRROR_OVERRIDE_LIMIT_KEYS)[number];
+
+/** Matches `giteaConfigSchema.releaseLimit`'s default. */
+export const DEFAULT_RELEASE_LIMIT = 10;
+
+/**
+ * Fully resolved mirror options: every flag has a definite boolean value and
+ * every limit a definite positive integer.
+ */
+export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean> &
+  Record<MirrorOverrideLimitKey, number>;
+
+/**
+ * The values the tiers above an override resolve to right now. Used by the
+ * dialog to label what "Inherit" means for each row.
+ */
+export type InheritedMirrorOptions = Partial<Record<MirrorOverrideKey, boolean>> &
+  Partial<Record<MirrorOverrideLimitKey, number>>;
+
+/**
+ * Sanitize a release limit from any tier into a positive integer, or
+ * `undefined` when the value is absent or unusable (so the next tier out is
+ * consulted). Floors fractional input rather than rejecting it, matching what
+ * `mirrorGitHubReleasesToGitea` has always done with the global value.
+ */
+export function normalizeReleaseLimit(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const limit = Math.floor(value);
+  return limit >= 1 ? limit : undefined;
+}
 
 /**
  * Flags the starred-code-only clamp forces off.
@@ -91,6 +126,7 @@ export function mirrorOptionsToFlags(
     | {
         mirrorLFS?: boolean;
         mirrorReleases?: boolean;
+        releaseLimit?: number;
         mirrorMetadata?: boolean;
         metadataComponents?: {
           issues?: boolean;
@@ -102,7 +138,7 @@ export function mirrorOptionsToFlags(
       }
     | null
     | undefined
-): Partial<Record<MirrorOverrideKey, boolean>> {
+): InheritedMirrorOptions {
   const components = mirrorOptions?.metadataComponents;
 
   // Straight through: each field is the raw stored value the runtime reads.
@@ -114,6 +150,8 @@ export function mirrorOptionsToFlags(
     mirrorPullRequests: !!components?.pullRequests,
     mirrorLabels: !!components?.labels,
     mirrorMilestones: !!components?.milestones,
+    releaseLimit:
+      normalizeReleaseLimit(mirrorOptions?.releaseLimit) ?? DEFAULT_RELEASE_LIMIT,
   };
 }
 
@@ -122,10 +160,13 @@ export const MIRROR_GATING_REASONS = {
   starredCodeOnly:
     "Starred repos mirror code only (Advanced Options > starred code only)",
   labelsFollowIssues: "Issues mirroring already syncs labels",
+  releasesOff: "Releases are not being mirrored",
 } as const;
 
 /** key -> reason it cannot take effect. Absent key means editable. */
-export type MirrorOverrideGating = Partial<Record<MirrorOverrideKey, string>>;
+export type MirrorOverrideGating = Partial<
+  Record<MirrorOverrideKey | MirrorOverrideLimitKey, string>
+>;
 
 /**
  * Decide which toggles cannot take effect, and why.
@@ -139,9 +180,12 @@ export type MirrorOverrideGating = Partial<Record<MirrorOverrideKey, string>>;
  *  - `shouldMirrorLabels` in gitea.ts / gitea-enhanced.ts is
  *    `mirrorLabels && !mirrorIssues`, so labels cannot take effect while issues
  *    are being mirrored (the issue path already reconciles labels)
+ *  - `releaseLimit` is only read inside the release mirror, so it cannot take
+ *    effect while `mirrorReleases` resolves to off
  *
  * `effective` is the value each flag currently resolves to including the
- * in-progress edit, so the labels gate reacts live as issues is toggled.
+ * in-progress edit, so the labels and release-limit gates react live as
+ * issues / releases are toggled.
  */
 export function getMirrorOverrideGating({
   targetKind,
@@ -152,7 +196,7 @@ export function getMirrorOverrideGating({
   targetKind: "repository" | "organization";
   isStarred?: boolean;
   starredCodeOnly?: boolean;
-  effective: Partial<Record<MirrorOverrideKey, boolean>>;
+  effective: InheritedMirrorOptions;
 }): MirrorOverrideGating {
   const gating: MirrorOverrideGating = {};
 
@@ -172,10 +216,22 @@ export function getMirrorOverrideGating({
     gating.mirrorLabels = MIRROR_GATING_REASONS.labelsFollowIssues;
   }
 
+  // The release limit rides along with releases: inherit the starred reason
+  // when that is what disabled releases, otherwise report releases being off.
+  // Only an explicit `false` counts; an unknown value leaves the field open.
+  if (gating.mirrorReleases) {
+    gating.releaseLimit = gating.mirrorReleases;
+  } else if (effective.mirrorReleases === false) {
+    gating.releaseLimit = MIRROR_GATING_REASONS.releasesOff;
+  }
+
   return gating;
 }
 
-export const MIRROR_OVERRIDE_LABELS: Record<MirrorOverrideKey, string> = {
+export const MIRROR_OVERRIDE_LABELS: Record<
+  MirrorOverrideKey | MirrorOverrideLimitKey,
+  string
+> = {
   lfs: "Git LFS files",
   wiki: "Wiki",
   mirrorReleases: "Releases",
@@ -184,6 +240,7 @@ export const MIRROR_OVERRIDE_LABELS: Record<MirrorOverrideKey, string> = {
   mirrorPullRequests: "Pull requests",
   mirrorLabels: "Labels",
   mirrorMilestones: "Milestones",
+  releaseLimit: "Release limit",
 };
 
 /**
@@ -218,24 +275,30 @@ export function parseMirrorOverrides(
   return parsed.data;
 }
 
-/** True when the overrides object actually pins at least one flag. */
+/** True when the overrides object actually pins at least one field. */
 export function hasMirrorOverrides(value: unknown): boolean {
-  const overrides = parseMirrorOverrides(value);
-  if (!overrides) return false;
-  return MIRROR_OVERRIDE_KEYS.some((key) => overrides[key] != null);
+  return listOverriddenKeys(value).length > 0;
 }
 
 /** The keys an overrides object pins, for badges and summaries. */
-export function listOverriddenKeys(value: unknown): MirrorOverrideKey[] {
+export function listOverriddenKeys(
+  value: unknown
+): (MirrorOverrideKey | MirrorOverrideLimitKey)[] {
   const overrides = parseMirrorOverrides(value);
   if (!overrides) return [];
-  return MIRROR_OVERRIDE_KEYS.filter((key) => overrides[key] != null);
+  return [
+    ...MIRROR_OVERRIDE_KEYS.filter((key) => overrides[key] != null),
+    ...MIRROR_OVERRIDE_LIMIT_KEYS.filter(
+      (key) => normalizeReleaseLimit(overrides[key]) !== undefined
+    ),
+  ];
 }
 
 /**
- * Strip flags that are null/undefined so only genuine pins are stored, and
- * collapse an empty result to null. Keeps "no overrides" as a single canonical
- * representation instead of `{}` vs `{lfs: null}` vs NULL.
+ * Strip fields that are null/undefined (or, for limits, unusable) so only
+ * genuine pins are stored, and collapse an empty result to null. Keeps "no
+ * overrides" as a single canonical representation instead of `{}` vs
+ * `{lfs: null}` vs NULL.
  */
 export function normalizeMirrorOverrides(
   value: unknown
@@ -248,6 +311,10 @@ export function normalizeMirrorOverrides(
     const flag = overrides[key];
     if (typeof flag === "boolean") cleaned[key] = flag;
   }
+  for (const key of MIRROR_OVERRIDE_LIMIT_KEYS) {
+    const limit = normalizeReleaseLimit(overrides[key]);
+    if (limit !== undefined) cleaned[key] = limit;
+  }
 
   return Object.keys(cleaned).length > 0 ? cleaned : null;
 }
@@ -255,8 +322,10 @@ export function normalizeMirrorOverrides(
 /**
  * Resolve the effective mirror options for one repository.
  *
- * Precedence is per flag, most specific tier wins:
- *   repository override -> organization override -> global config -> false
+ * Precedence is per field, most specific tier wins:
+ *   repository override -> organization override -> global config -> default
+ * where the default is `false` for flags and DEFAULT_RELEASE_LIMIT for the
+ * release limit.
  *
  * `starredCodeOnly` is applied last as a hard clamp. It is a "code only, no
  * metadata" switch for starred repos, so it forces every metadata flag off
@@ -294,6 +363,15 @@ export function resolveMirrorOptions({
       resolved[key] = !!globalConfig?.[key];
     }
   }
+
+  // Same precedence for the release limit. An unusable value at any tier
+  // (0, negative, NaN) falls through to the next one instead of being clamped
+  // up to 1, so a bad override cannot silently shrink a repo to one release.
+  resolved.releaseLimit =
+    normalizeReleaseLimit(repo?.releaseLimit) ??
+    normalizeReleaseLimit(org?.releaseLimit) ??
+    normalizeReleaseLimit(globalConfig?.releaseLimit) ??
+    DEFAULT_RELEASE_LIMIT;
 
   // Starred repos with starredCodeOnly mirror code and nothing else. This
   // clamp intentionally outranks explicit per-repo overrides: the setting


### PR DESCRIPTION
Follow-up to #362 and #365, covering the three points @MMMMMoris raised in https://github.com/RayLabsHQ/gitea-mirror/issues/361#issuecomment-5377981716.

## 1. Releases and tags

To answer the question first: tags are not something we mirror ourselves. Gitea's own git mirror fetches every ref from upstream, tags included, so they arrive with the code on every pull and there is no per-repo control over them. They also cost nothing extra to store, a tag is a pointer to a commit that is already in the clone. Releases are different. We create them through the Gitea API on top of tags that already exist in the mirror, and the release assets are where the disk usage comes from. There is already a global "latest N releases" setting (default 10), and the release mirror prunes anything in Gitea beyond it.

So a "max tags" option does not apply, but a per-repo and per-org release limit does. This PR adds it:

- `releaseLimit` joins `mirrorOverrides` on repositories and organizations, with the same precedence as the flags: repo, then org, then global, then the default of 10. It is the one non-boolean override, so it sits next to `MIRROR_OVERRIDE_KEYS` rather than inside it, and the resolver returns it as a definite positive integer.
- An unusable value (0, negative, NaN) at one tier falls through to the next instead of being clamped to 1. The schema deliberately accepts any number so a bad stored limit degrades to "inherit" for that field alone, rather than making the whole overrides object unparseable and silently dropping the LFS opt-out stored next to it.
- The Mirror Options dialog gets a "Release limit" field directly under Releases, with the inherited value as the hint. It is disabled with a reason while releases resolve to off, Save is blocked on invalid input, and empty means inherit.
- `mirrorGitHubReleasesToGitea` takes the resolved limit from its three callers and resolves it itself when a caller does not pass one, so direct callers honor the overrides too.

## 2. Repository description

The description was already being sent to Gitea at migration time (#224), but only from the value stored in our own database, and only once. Two ways to end up with a blank description in Gitea: the repository was imported before #224 shipped (the bulk import only inserts new rows and never refreshes existing ones, so those rows have no description to send), or the upstream description changed after the mirror was created. Neither case ever recovered, because the sync path did not touch the description at all.

Now `syncRepositoryMetadataToGitea` runs on every sync as well as after migration, and reads the description and topics straight from GitHub. `GET /repos/{owner}/{repo}` carries both, so it replaces the topics-only call rather than adding one. GitHub is authoritative when reachable. The stored value is only a fallback for the no-token and GitHub-down cases, and an empty fallback is never written, so an outage cannot wipe a description Gitea already has. The refreshed description is written back to our row as well. Writes are skipped when Gitea already holds the same values, using the repo info the sync path fetches anyway, and the GitHub client's ETag layer turns the per-sync re-check into a 304 that does not count against the rate limit when nothing changed.

Existing mirrors pick the description up on their next sync, no re-mirror needed.

One behaviour change to be aware of: the sync path used to never touch the description, now it keeps it equal to GitHub's. If someone edited a mirror's description by hand in Gitea, the next sync puts the GitHub one back. That is the mirror semantics topics already follow.

## 3. Mobile repository card

Layout reworked along the lines of the mock-ups in the comment:

- Name, `Custom` badge and the menu share one vertically centred row, so the name sits at the same height whether or not the badge is present. That was the misalignment in the last screenshot: the checkbox, the name and the menu button each had a different centre line.
- Private, Fork and Starred move to their own row under the name, indented to it.
- Owner, Org and Dest stay on the left; status and last-sync time stack on the right.

<img src="https://gist.githubusercontent.com/arunavo4/d044dc02b7cce2d565e8aa1efb032c8e/raw/cf4bcb494f28a0482b696cad399893cf6a74ae9b/mobile-cards.png" width="320" alt="Mobile repository cards with the reworked layout" /> <img src="https://gist.githubusercontent.com/arunavo4/d044dc02b7cce2d565e8aa1efb032c8e/raw/cf4bcb494f28a0482b696cad399893cf6a74ae9b/mobile-dialog.png" width="320" alt="Mirror options dialog on mobile with the new Release limit field" />

Same field in the organization dialog on desktop:

<img src="https://gist.githubusercontent.com/arunavo4/d044dc02b7cce2d565e8aa1efb032c8e/raw/cf4bcb494f28a0482b696cad399893cf6a74ae9b/desktop-org-dialog.png" width="640" alt="Organization mirror options dialog on desktop" />

## Verification

- `bun test`: 533 pass, 0 fail. 30 new tests: resolver precedence and helpers for the limit, the release-limit gating, `syncRepositoryMetadataToGitea` in isolation (GitHub wins, fallback paths, skip-when-unchanged, outage never wipes, prefix handling), and the sync path both calling the metadata sync and passing the resolved limit through.
- `bunx --bun astro build` clean.
- Browser at 390px and 1400px against a seeded database: card layout, dialog save persists `{"lfs":false,"releaseLimit":5}`, releases-off disables the limit with a reason, `0` blocks Save, and an org-level limit shows up as the repository's inherited hint.
