### PR TITLE
feat(releases): limit release assets to the newest N releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Transfer complete repository metadata from GitHub to Gitea/Forgejo:
 - **Wiki** - Mirror wiki content
 - **Releases** - Transfer GitHub releases with assets
 
+Releases have two limits. The release limit keeps only the newest N releases in Gitea/Forgejo. The release asset limit uploads assets only for the newest N of those, so a repository with years of releases can keep every release note and tag while only the recent binaries take up space. Leave the asset limit empty to upload assets for every mirrored release, or set it to 0 for release notes only. Both limits can be overridden per organization and per repository, and lowering the asset limit never deletes assets that were already uploaded.
+
 Enable in Settings → Mirror Options → Mirror metadata
 
 ### Repository Management
@@ -369,6 +371,14 @@ To avoid this:
 
 1. Set Gitea Mirror interval to a value greater than or equal to your server `MIN_INTERVAL`.
 2. Do not rely on manual per-repository mirror interval edits in Gitea/Forgejo, as they will be overwritten on sync.
+
+### Pushing to a mirror fails with `mirror repository is read-only`
+
+Every repository this tool creates is a Gitea/Forgejo pull mirror, and pull mirrors are read-only by design. Gitea/Forgejo refuses pushes to them so the copy can never drift from the source.
+
+Make your commits in the source repository (on GitHub, GitLab or wherever the mirror pulls from). They arrive in the mirror on the next sync. Gitea Mirror is a backup tool and does not push changes back to the source.
+
+If you want a repository you can push to, clone the mirror, push the clone to a normal (non-mirror) repository, and stop mirroring the original.
 
 ## Development
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -206,6 +206,7 @@ Control what content gets mirrored from GitHub to Gitea.
 |----------|-------------|---------|---------|
 | `MIRROR_RELEASES` | Mirror GitHub releases | `false` | `true`, `false` |
 | `RELEASE_LIMIT` | Maximum number of releases to mirror per repository | `10` | Number (1-100) |
+| `RELEASE_ASSET_LIMIT` | Upload release assets only for the newest N mirrored releases. Older releases still get their notes and tag. Unset means assets for every mirrored release, `0` means release notes only. Lowering it never deletes assets already uploaded | unset (all) | Number (0 or more) |
 | `MIRROR_WIKI` | Mirror wiki content | `false` | `true`, `false` |
 | `MIRROR_METADATA` | Master toggle for metadata mirroring | `false` | `true`, `false` |
 | `MIRROR_ISSUES` | Mirror issues (requires MIRROR_METADATA=true) | `false` | `true`, `false` |

--- a/src/components/config/GitHubMirrorSettings.tsx
+++ b/src/components/config/GitHubMirrorSettings.tsx
@@ -137,7 +137,7 @@ export function GitHubMirrorSettings({
     onGitHubConfigChange({ ...githubConfig, [field]: value });
   };
 
-  const handleMirrorChange = (field: keyof MirrorOptions, value: boolean | number) => {
+  const handleMirrorChange = (field: keyof MirrorOptions, value: boolean | number | null) => {
     onMirrorOptionsChange({ ...mirrorOptions, [field]: value });
   };
 
@@ -883,29 +883,59 @@ export function GitHubMirrorSettings({
             icon={Tag}
             label="Releases & tags"
             description={
-              isGithubSource
-                ? "Includes release assets and tags"
-                : "Release assets need a GitHub source. Tags always come with the code"
+              !isGithubSource
+                ? "Release assets need a GitHub source. Tags always come with the code"
+                : mirrorOptions.mirrorReleases
+                  ? "Includes tags. Leave the assets box empty to upload assets for every mirrored release, or set it to 0 for release notes only"
+                  : "Includes release assets and tags"
             }
             disabled={!isGithubSource}
             checked={mirrorOptions.mirrorReleases}
             onCheckedChange={(checked) => handleMirrorChange('mirrorReleases', checked)}
             extra={
               mirrorOptions.mirrorReleases ? (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <label htmlFor="release-limit">Latest</label>
-                  <input
-                    id="release-limit"
-                    type="number"
-                    min="1"
-                    value={mirrorOptions.releaseLimit || 10}
-                    onChange={(e) => {
-                      const value = parseInt(e.target.value) || 10;
-                      const clampedValue = Math.max(1, value);
-                      handleMirrorChange('releaseLimit', clampedValue);
-                    }}
-                    className="w-16 rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
-                  />
+                <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+                  <div className="flex items-center gap-1.5">
+                    <label htmlFor="release-limit">Latest</label>
+                    <input
+                      id="release-limit"
+                      type="number"
+                      min="1"
+                      value={mirrorOptions.releaseLimit || 10}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value) || 10;
+                        const clampedValue = Math.max(1, value);
+                        handleMirrorChange('releaseLimit', clampedValue);
+                      }}
+                      className="w-16 rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
+                    />
+                  </div>
+                  {/* Empty means every mirrored release gets its assets (the
+                      behaviour before #311); 0 means notes only. */}
+                  <div className="flex items-center gap-1.5">
+                    <label htmlFor="release-asset-limit">Assets for latest</label>
+                    <input
+                      id="release-asset-limit"
+                      type="number"
+                      min="0"
+                      placeholder="all"
+                      title="Leave empty to upload assets for every mirrored release, or 0 for none"
+                      value={mirrorOptions.releaseAssetLimit ?? ''}
+                      onChange={(e) => {
+                        const raw = e.target.value.trim();
+                        if (raw === '') {
+                          handleMirrorChange('releaseAssetLimit', null);
+                          return;
+                        }
+                        const value = parseInt(raw, 10);
+                        handleMirrorChange(
+                          'releaseAssetLimit',
+                          Number.isFinite(value) ? Math.max(0, value) : null
+                        );
+                      }}
+                      className="w-16 rounded border border-input bg-background px-2 py-1 text-xs text-foreground"
+                    />
+                  </div>
                 </div>
               ) : undefined
             }

--- a/src/components/config/MirrorOverridesDialog.tsx
+++ b/src/components/config/MirrorOverridesDialog.tsx
@@ -21,6 +21,7 @@ import type { MirrorOverrides } from "@/lib/db/schema";
 import {
   getMirrorOverrideGating,
   MIRROR_OVERRIDE_LABELS,
+  normalizeReleaseAssetLimit,
   normalizeReleaseLimit,
   UI_MIRROR_OVERRIDE_KEYS,
   type InheritedMirrorOptions,
@@ -54,6 +55,13 @@ function parseReleaseLimitDraft(text: string): number | undefined {
   const trimmed = text.trim();
   if (!trimmed) return undefined;
   return normalizeReleaseLimit(Number(trimmed));
+}
+
+/** Same free-text handling for the asset limit, where 0 is a valid pin. */
+function parseReleaseAssetLimitDraft(text: string): number | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return normalizeReleaseAssetLimit(Number(trimmed));
 }
 
 export interface MirrorOverridesDialogProps {
@@ -101,6 +109,9 @@ export function MirrorOverridesDialog({
   const [releaseLimitDraft, setReleaseLimitDraft] = useState(() =>
     buildReleaseLimitDraft(value)
   );
+  const [releaseAssetLimitDraft, setReleaseAssetLimitDraft] = useState(() =>
+    buildReleaseAssetLimitDraft(value)
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   // Re-seed whenever the dialog opens or targets a different object, so a
@@ -109,6 +120,7 @@ export function MirrorOverridesDialog({
     if (open) {
       setDraft(buildDraft(value));
       setReleaseLimitDraft(buildReleaseLimitDraft(value));
+      setReleaseAssetLimitDraft(buildReleaseAssetLimitDraft(value));
     }
   }, [open, value]);
 
@@ -140,11 +152,16 @@ export function MirrorOverridesDialog({
   const releaseLimitInvalid =
     releaseLimitDraft.trim() !== "" && pinnedReleaseLimit === undefined;
 
+  const pinnedReleaseAssetLimit = parseReleaseAssetLimitDraft(releaseAssetLimitDraft);
+  const releaseAssetLimitInvalid =
+    releaseAssetLimitDraft.trim() !== "" && pinnedReleaseAssetLimit === undefined;
+
   const overriddenCount = useMemo(
     () =>
       Object.values(draft).filter((state) => state !== "inherit").length +
-      (pinnedReleaseLimit !== undefined ? 1 : 0),
-    [draft, pinnedReleaseLimit]
+      (pinnedReleaseLimit !== undefined ? 1 : 0) +
+      (pinnedReleaseAssetLimit !== undefined ? 1 : 0),
+    [draft, pinnedReleaseLimit, pinnedReleaseAssetLimit]
   );
 
   const handleSave = async () => {
@@ -158,6 +175,9 @@ export function MirrorOverridesDialog({
         if (typeof resolved === "boolean") next[key] = resolved;
       }
       if (pinnedReleaseLimit !== undefined) next.releaseLimit = pinnedReleaseLimit;
+      if (pinnedReleaseAssetLimit !== undefined) {
+        next.releaseAssetLimit = pinnedReleaseAssetLimit;
+      }
       await onSave(Object.keys(next).length > 0 ? next : null);
       onOpenChange(false);
     } finally {
@@ -168,6 +188,7 @@ export function MirrorOverridesDialog({
   const handleResetAll = () => {
     setDraft(buildDraft(null));
     setReleaseLimitDraft("");
+    setReleaseAssetLimitDraft("");
   };
 
   const releaseLimitReason = gating.releaseLimit;
@@ -180,6 +201,16 @@ export function MirrorOverridesDialog({
     !releaseLimitDisabled &&
     releaseLimitDraft.trim() === "" &&
     inheritedReleaseLimit !== undefined;
+
+  const releaseAssetLimitReason = gating.releaseAssetLimit;
+  const releaseAssetLimitDisabled = !!releaseAssetLimitReason;
+  // null is a known value here ("all"), so it still earns a hint.
+  const inheritedReleaseAssetLimit = inheritedFrom?.releaseAssetLimit;
+  const showReleaseAssetLimitHint =
+    !inheritedLoading &&
+    !releaseAssetLimitDisabled &&
+    releaseAssetLimitDraft.trim() === "" &&
+    inheritedReleaseAssetLimit !== undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -243,9 +274,10 @@ export function MirrorOverridesDialog({
                   )}
                 </div>
 
-                {/* The limit only means something while releases are mirrored,
-                    so it sits directly under that row. */}
+                {/* The limits only mean something while releases are mirrored,
+                    so they sit directly under that row. */}
                 {key === "mirrorReleases" && (
+                  <>
                   <div className="space-y-1">
                     <div className="flex items-center justify-between gap-4">
                       <Label
@@ -288,11 +320,66 @@ export function MirrorOverridesDialog({
                       </p>
                     ) : (
                       <p className="text-xs text-muted-foreground">
-                        Newest releases to keep, assets included. Older ones
-                        past the limit are removed from Gitea on the next sync.
+                        Newest releases to keep. Older ones past the limit are
+                        removed from Gitea on the next sync.
                       </p>
                     )}
                   </div>
+
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between gap-4">
+                      <Label
+                        htmlFor="override-releaseAssetLimit"
+                        className={
+                          releaseAssetLimitDisabled
+                            ? "flex-1 text-muted-foreground"
+                            : "flex-1"
+                        }
+                      >
+                        {MIRROR_OVERRIDE_LABELS.releaseAssetLimit}
+                        {showReleaseAssetLimitHint && (
+                          <span className="ml-2 text-xs font-normal text-muted-foreground">
+                            currently{" "}
+                            {inheritedReleaseAssetLimit === null
+                              ? "all"
+                              : inheritedReleaseAssetLimit}
+                          </span>
+                        )}
+                      </Label>
+                      <Input
+                        id="override-releaseAssetLimit"
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        step={1}
+                        placeholder="Inherit"
+                        className="w-32"
+                        value={releaseAssetLimitDraft}
+                        disabled={releaseAssetLimitDisabled}
+                        aria-invalid={releaseAssetLimitInvalid || undefined}
+                        onChange={(event) =>
+                          setReleaseAssetLimitDraft(event.target.value)
+                        }
+                      />
+                    </div>
+                    {releaseAssetLimitDisabled ? (
+                      <p className="text-xs text-muted-foreground">
+                        {releaseAssetLimitReason}
+                      </p>
+                    ) : releaseAssetLimitInvalid ? (
+                      <p className="text-xs text-destructive">
+                        Enter a whole number of 0 or more, or leave it empty to
+                        inherit.
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">
+                        Assets are uploaded only for this many of the newest
+                        releases; 0 keeps release notes only. Assets already in
+                        Gitea are never removed.
+                      </p>
+                    )}
+                  </div>
+                  </>
                 )}
               </Fragment>
             );
@@ -320,7 +407,10 @@ export function MirrorOverridesDialog({
           >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isSaving || releaseLimitInvalid}>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || releaseLimitInvalid || releaseAssetLimitInvalid}
+          >
             {isSaving ? "Saving..." : "Save"}
           </Button>
         </DialogFooter>
@@ -343,5 +433,12 @@ function buildReleaseLimitDraft(
   value: MirrorOverrides | null | undefined
 ): string {
   const limit = normalizeReleaseLimit(value?.releaseLimit);
+  return limit === undefined ? "" : String(limit);
+}
+
+function buildReleaseAssetLimitDraft(
+  value: MirrorOverrides | null | undefined
+): string {
+  const limit = normalizeReleaseAssetLimit(value?.releaseAssetLimit);
   return limit === undefined ? "" : String(limit);
 }

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -33,6 +33,7 @@ import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog
 import {
   hasMirrorOverrides,
   mirrorOptionsToFlags,
+  normalizeReleaseAssetLimit,
   normalizeReleaseLimit,
   type MirrorOverrideKey,
 } from "@/lib/utils/mirror-overrides";
@@ -181,6 +182,8 @@ export default function RepositoryTable({
     }
     const orgReleaseLimit = normalizeReleaseLimit(orgOverrides.releaseLimit);
     if (orgReleaseLimit !== undefined) globals.releaseLimit = orgReleaseLimit;
+    const orgReleaseAssetLimit = normalizeReleaseAssetLimit(orgOverrides.releaseAssetLimit);
+    if (orgReleaseAssetLimit !== undefined) globals.releaseAssetLimit = orgReleaseAssetLimit;
     return globals;
   }, [mirrorOptions, orgOverrides]);
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -67,6 +67,10 @@ export const backupStrategyEnum = z.enum([
  * out-of-range value must degrade to "inherit" for that field alone, not make
  * the whole overrides object unparseable and silently drop the LFS opt-out
  * next to it. `normalizeReleaseLimit` does the sanitizing.
+ *
+ * `releaseAssetLimit` follows the same rule (`normalizeReleaseAssetLimit`):
+ * assets are uploaded only for the newest N mirrored releases. 0 is a real
+ * value (notes only); null/absent means inherit.
  */
 export const mirrorOverridesSchema = z.object({
   lfs: z.boolean().nullable().optional(),
@@ -78,6 +82,7 @@ export const mirrorOverridesSchema = z.object({
   mirrorLabels: z.boolean().nullable().optional(),
   mirrorMilestones: z.boolean().nullable().optional(),
   releaseLimit: z.number().nullable().optional(),
+  releaseAssetLimit: z.number().nullable().optional(),
 });
 
 export type MirrorOverrides = z.infer<typeof mirrorOverridesSchema>;
@@ -111,6 +116,9 @@ export const giteaConfigSchema = z.object({
   pullRequestConcurrency: z.number().int().min(1).default(5),
   mirrorReleases: z.boolean().default(false),
   releaseLimit: z.number().default(10),
+  // Upload assets only for the newest N mirrored releases. null/absent means
+  // every mirrored release gets its assets; 0 means release notes only.
+  releaseAssetLimit: z.number().nullable().optional(),
   mirrorMetadata: z.boolean().default(false),
   mirrorIssues: z.boolean().default(false),
   mirrorPullRequests: z.boolean().default(false),

--- a/src/lib/env-config-loader.ts
+++ b/src/lib/env-config-loader.ts
@@ -10,6 +10,7 @@ import { encrypt } from '@/lib/utils/encryption';
 import { isSourceProviderKind, type SourceProviderKind } from '@/lib/source-providers/kinds';
 import { isDestinationProviderKind, type DestinationProviderKind } from '@/lib/destination-kinds';
 import { hasDestinationChanged, hasSourceChanged, loadConfigLocks } from '@/lib/config-locks';
+import { normalizeReleaseAssetLimit } from '@/lib/utils/mirror-overrides';
 
 interface EnvConfig {
   github: {
@@ -63,6 +64,7 @@ interface EnvConfig {
     mirrorMilestones?: boolean;
     mirrorMetadata?: boolean;
     releaseLimit?: number;
+    releaseAssetLimit?: number;
     issueConcurrency?: number;
     pullRequestConcurrency?: number;
   };
@@ -180,6 +182,7 @@ function parseEnvConfig(): EnvConfig {
       mirrorMilestones: process.env.MIRROR_MILESTONES === 'true',
       mirrorMetadata: process.env.MIRROR_METADATA === 'true',
       releaseLimit: process.env.RELEASE_LIMIT ? parseInt(process.env.RELEASE_LIMIT, 10) : undefined,
+      releaseAssetLimit: process.env.RELEASE_ASSET_LIMIT ? parseInt(process.env.RELEASE_ASSET_LIMIT, 10) : undefined,
       issueConcurrency: process.env.MIRROR_ISSUE_CONCURRENCY ? parseInt(process.env.MIRROR_ISSUE_CONCURRENCY, 10) : undefined,
       pullRequestConcurrency: process.env.MIRROR_PULL_REQUEST_CONCURRENCY ? parseInt(process.env.MIRROR_PULL_REQUEST_CONCURRENCY, 10) : undefined,
     },
@@ -367,6 +370,11 @@ export async function initializeConfigFromEnv(): Promise<void> {
       // Mirror metadata options
       mirrorReleases: envConfig.mirror.mirrorReleases ?? existingConfig?.[0]?.giteaConfig?.mirrorReleases ?? false,
       releaseLimit: envConfig.mirror.releaseLimit ?? existingConfig?.[0]?.giteaConfig?.releaseLimit ?? 10,
+      // 0 is a real value (notes only); unset means assets for every mirrored release.
+      releaseAssetLimit:
+        normalizeReleaseAssetLimit(envConfig.mirror.releaseAssetLimit) ??
+        existingConfig?.[0]?.giteaConfig?.releaseAssetLimit ??
+        null,
       issueConcurrency: envConfig.mirror.issueConcurrency && envConfig.mirror.issueConcurrency > 0
         ? envConfig.mirror.issueConcurrency
         : existingConfig?.[0]?.giteaConfig?.issueConcurrency ?? 3,

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -822,6 +822,7 @@ export async function syncGiteaRepoEnhanced({
               giteaOwner: repoOwner,
               giteaRepoName: repoName,
               releaseLimit: mirrorOptions.releaseLimit,
+              releaseAssetLimit: mirrorOptions.releaseAssetLimit,
             });
             metadataState.components.releases = true;
             metadataUpdated = true;

--- a/src/lib/gitea.ts
+++ b/src/lib/gitea.ts
@@ -23,8 +23,11 @@ import {
   serializeRepositoryMetadataState,
 } from "./metadata-state";
 import {
+  normalizeReleaseAssetLimit,
   normalizeReleaseLimit,
+  releaseGetsAssets,
   resolveMirrorOptionsForRepository,
+  type ResolvedMirrorOptions,
 } from "./utils/mirror-overrides";
 
 /**
@@ -1027,6 +1030,7 @@ export const mirrorGithubRepoToGitea = async ({
           giteaOwner: repoOwner,
           giteaRepoName: targetRepoName,
           releaseLimit: mirrorOptions.releaseLimit,
+          releaseAssetLimit: mirrorOptions.releaseAssetLimit,
         });
         metadataState.components.releases = true;
         metadataUpdated = true;
@@ -1783,6 +1787,7 @@ export async function mirrorGitHubRepoToGiteaOrg({
           giteaOwner: orgName,
           giteaRepoName: targetRepoName,
           releaseLimit: mirrorOptions.releaseLimit,
+          releaseAssetLimit: mirrorOptions.releaseAssetLimit,
         });
         metadataState.components.releases = true;
         metadataUpdated = true;
@@ -3079,6 +3084,7 @@ export async function mirrorGitHubReleasesToGitea({
   giteaOwner,
   giteaRepoName,
   releaseLimit: releaseLimitOverride,
+  releaseAssetLimit: releaseAssetLimitOverride,
 }: {
   octokit: Octokit;
   repository: Repository;
@@ -3091,6 +3097,12 @@ export async function mirrorGitHubReleasesToGitea({
    * here so direct callers still honor per-repo overrides.
    */
   releaseLimit?: number;
+  /**
+   * Already-resolved asset limit (#311): assets are uploaded only for the
+   * newest N of the mirrored releases. `null` means every release, 0 means
+   * none, `undefined` means resolve it here like the release limit.
+   */
+  releaseAssetLimit?: number | null;
 }) {
   if (
     !config.giteaConfig?.defaultOwner ||
@@ -3132,9 +3144,22 @@ export async function mirrorGitHubReleasesToGitea({
   // win over the global setting (#361); the resolver guarantees a positive
   // integer. Everything below the limit is created/updated, everything beyond
   // it is pruned from Gitea by the retention pass at the end.
+  let resolvedOptions: ResolvedMirrorOptions | undefined;
+  const resolveOptions = async () =>
+    (resolvedOptions ??= await resolveMirrorOptionsForRepository({ config, repository }));
+
   const releaseLimit =
     normalizeReleaseLimit(releaseLimitOverride) ??
-    (await resolveMirrorOptionsForRepository({ config, repository })).releaseLimit;
+    (await resolveOptions()).releaseLimit;
+
+  // Which of those releases also get their assets (#311). Older releases
+  // past this point are still created with notes and tag, just without the
+  // uploads. Assets already in Gitea are never removed by this limit; it only
+  // decides what a sync uploads.
+  const releaseAssetLimit =
+    releaseAssetLimitOverride !== undefined
+      ? (normalizeReleaseAssetLimit(releaseAssetLimitOverride) ?? null)
+      : (await resolveOptions()).releaseAssetLimit;
 
   // GitHub API max per page is 100; paginate until we reach the configured limit.
   const releases: Awaited<
@@ -3167,7 +3192,11 @@ export async function mirrorGitHubReleasesToGitea({
   const limitedReleases = releases.slice(0, releaseLimit);
 
   console.log(
-    `[Releases] Found ${limitedReleases.length} releases (limited to latest ${releaseLimit}) to mirror for ${repository.fullName}`
+    `[Releases] Found ${limitedReleases.length} releases (limited to latest ${releaseLimit}; ${
+      releaseAssetLimit === null
+        ? "assets for every release"
+        : `assets for the newest ${releaseAssetLimit}`
+    }) to mirror for ${repository.fullName}`
   );
 
   if (limitedReleases.length === 0) {
@@ -3180,6 +3209,7 @@ export async function mirrorGitHubReleasesToGitea({
   let skippedMissingTagCount = 0;
   let totalAssetsUploaded = 0;
   let totalAssetsFailed = 0;
+  let releasesPastAssetLimit = 0;
 
   // Process releases in their GitHub API order (newest first by default)
   const releasesToProcess = limitedReleases.slice();
@@ -3194,7 +3224,9 @@ export async function mirrorGitHubReleasesToGitea({
     console.log(`[Releases] ${idx + 1}. ${rel.tag_name} - ${dateInfo}`);
   });
 
-  for (const release of releasesToProcess) {
+  // The index doubles as the release's rank, newest first, which is what the
+  // asset limit is measured against.
+  for (const [releaseIndex, release] of releasesToProcess.entries()) {
     try {
       // Always check if release already exists — reconcile by tag set, not by ordering
       const existingReleasesResponse = await httpGet(
@@ -3254,22 +3286,33 @@ export async function mirrorGitHubReleasesToGitea({
         // Reconcile assets on every sync — backfill any that are missing or changed.
         // The update path used to `continue` here without touching assets, so a
         // release that existed without its full asset set stayed broken forever (#331).
-        const assetResult = await reconcileReleaseAssets({
-          config,
-          decryptedConfig,
-          repoOwner,
-          repoName,
-          giteaReleaseId: existingRelease.id,
-          githubAssets: release.assets || [],
-          tagName: release.tag_name,
-        });
-        if (assetResult.uploaded > 0) {
+        //
+        // The asset limit (#311) only gates the upload. Assets that reached
+        // Gitea before the limit was set or lowered stay where they are;
+        // nothing on this path deletes attachments.
+        if (releaseGetsAssets(releaseIndex, releaseAssetLimit)) {
+          const assetResult = await reconcileReleaseAssets({
+            config,
+            decryptedConfig,
+            repoOwner,
+            repoName,
+            giteaReleaseId: existingRelease.id,
+            githubAssets: release.assets || [],
+            tagName: release.tag_name,
+          });
+          if (assetResult.uploaded > 0) {
+            console.log(
+              `[Releases] Backfilled ${assetResult.uploaded} missing/changed asset(s) for existing release ${release.tag_name}`
+            );
+          }
+          totalAssetsUploaded += assetResult.uploaded;
+          totalAssetsFailed += assetResult.failed;
+        } else if (release.assets && release.assets.length > 0) {
           console.log(
-            `[Releases] Backfilled ${assetResult.uploaded} missing/changed asset(s) for existing release ${release.tag_name}`
+            `[Releases] Skipping ${release.assets.length} asset(s) for ${release.tag_name}: outside the newest ${releaseAssetLimit} release(s) that get assets (anything already uploaded is kept)`
           );
+          releasesPastAssetLimit++;
         }
-        totalAssetsUploaded += assetResult.uploaded;
-        totalAssetsFailed += assetResult.failed;
         continue;
       }
 
@@ -3312,19 +3355,27 @@ export async function mirrorGitHubReleasesToGitea({
       );
       
       // Mirror release assets if they exist (idempotent — see reconcileReleaseAssets)
+      // and the release sits inside the asset limit (#311).
       if (release.assets && release.assets.length > 0) {
-        console.log(`[Releases] Mirroring ${release.assets.length} assets for release ${release.tag_name}`);
-        const assetResult = await reconcileReleaseAssets({
-          config,
-          decryptedConfig,
-          repoOwner,
-          repoName,
-          giteaReleaseId: createReleaseResponse.data.id,
-          githubAssets: release.assets,
-          tagName: release.tag_name,
-        });
-        totalAssetsUploaded += assetResult.uploaded;
-        totalAssetsFailed += assetResult.failed;
+        if (releaseGetsAssets(releaseIndex, releaseAssetLimit)) {
+          console.log(`[Releases] Mirroring ${release.assets.length} assets for release ${release.tag_name}`);
+          const assetResult = await reconcileReleaseAssets({
+            config,
+            decryptedConfig,
+            repoOwner,
+            repoName,
+            giteaReleaseId: createReleaseResponse.data.id,
+            githubAssets: release.assets,
+            tagName: release.tag_name,
+          });
+          totalAssetsUploaded += assetResult.uploaded;
+          totalAssetsFailed += assetResult.failed;
+        } else {
+          console.log(
+            `[Releases] Skipping ${release.assets.length} asset(s) for ${release.tag_name}: outside the newest ${releaseAssetLimit} release(s) that get assets`
+          );
+          releasesPastAssetLimit++;
+        }
       }
 
       mirroredCount++;
@@ -3336,7 +3387,7 @@ export async function mirrorGitHubReleasesToGitea({
   }
 
   console.log(
-    `✅ Mirrored/Updated ${mirroredCount} releases to Gitea (${skippedCount} already up-to-date, ${skippedMissingTagCount} skipped: tag not synced yet); assets uploaded: ${totalAssetsUploaded}, failed: ${totalAssetsFailed}`
+    `✅ Mirrored/Updated ${mirroredCount} releases to Gitea (${skippedCount} already up-to-date, ${skippedMissingTagCount} skipped: tag not synced yet); assets uploaded: ${totalAssetsUploaded}, failed: ${totalAssetsFailed}, releases past the asset limit: ${releasesPastAssetLimit}`
   );
 
   if (skippedMissingTagCount > 0) {

--- a/src/lib/utils/config-mapper.ts
+++ b/src/lib/utils/config-mapper.ts
@@ -17,6 +17,7 @@ import { normalizeDestinationProviderKind } from "@/lib/destination-kinds";
 import { z } from "zod";
 import { githubConfigSchema, giteaConfigSchema, scheduleConfigSchema, cleanupConfigSchema } from "@/lib/db/schema";
 import { parseInterval } from "@/lib/utils/duration-parser";
+import { normalizeReleaseAssetLimit } from "@/lib/utils/mirror-overrides";
 import { buildClockCronExpression, normalizeTimezone, parseClockCronExpression } from "@/lib/utils/schedule-utils";
 
 // Use the actual database schema types
@@ -167,6 +168,9 @@ export function mapUiToDbConfig(
     pullRequestConcurrency: giteaConfig.pullRequestConcurrency ?? 5,
     mirrorReleases: mirrorOptions.mirrorReleases,
     releaseLimit: mirrorOptions.releaseLimit || 10,
+    // null is a real value here ("assets for every mirrored release"), so
+    // it is stored as such rather than dropped.
+    releaseAssetLimit: normalizeReleaseAssetLimit(mirrorOptions.releaseAssetLimit) ?? null,
     mirrorMetadata: mirrorOptions.mirrorMetadata,
     mirrorIssues: mirrorOptions.mirrorMetadata && mirrorOptions.metadataComponents.issues,
     mirrorPullRequests: mirrorOptions.mirrorMetadata && mirrorOptions.metadataComponents.pullRequests,
@@ -239,6 +243,7 @@ export function mapDbToUiConfig(dbConfig: any): {
   const mirrorOptions: MirrorOptions = {
     mirrorReleases: dbConfig.giteaConfig?.mirrorReleases || false,
     releaseLimit: dbConfig.giteaConfig?.releaseLimit || 10,
+    releaseAssetLimit: normalizeReleaseAssetLimit(dbConfig.giteaConfig?.releaseAssetLimit) ?? null,
     mirrorLFS: dbConfig.giteaConfig?.lfs || false,
     mirrorMetadata: dbConfig.giteaConfig?.mirrorMetadata || false,
     metadataComponents: {

--- a/src/lib/utils/mirror-overrides.test.ts
+++ b/src/lib/utils/mirror-overrides.test.ts
@@ -6,10 +6,14 @@ import {
   listOverriddenKeys,
   MIRROR_GATING_REASONS,
   MIRROR_OVERRIDE_KEYS,
+  MIRROR_OVERRIDE_LABELS,
+  MIRROR_OVERRIDE_LIMIT_KEYS,
   mirrorOptionsToFlags,
   normalizeMirrorOverrides,
+  normalizeReleaseAssetLimit,
   normalizeReleaseLimit,
   parseMirrorOverrides,
+  releaseGetsAssets,
   resolveMirrorOptions,
   STARRED_CLAMPED_KEYS,
   UI_MIRROR_OVERRIDE_KEYS,
@@ -863,5 +867,201 @@ describe("resolveMirrorOptions for non-GitHub sources", () => {
     });
     expect(resolved.mirrorIssues).toBe(true);
     expect(resolved.mirrorReleases).toBe(true);
+  });
+});
+
+describe("release asset limit (#311)", () => {
+  describe("normalizeReleaseAssetLimit", () => {
+    test("accepts 0 and positive integers, floors fractions", () => {
+      expect(normalizeReleaseAssetLimit(0)).toBe(0);
+      expect(normalizeReleaseAssetLimit(5)).toBe(5);
+      expect(normalizeReleaseAssetLimit(2.9)).toBe(2);
+    });
+
+    test("rejects negatives, NaN, strings and absence", () => {
+      expect(normalizeReleaseAssetLimit(-1)).toBeUndefined();
+      expect(normalizeReleaseAssetLimit(Number.NaN)).toBeUndefined();
+      expect(normalizeReleaseAssetLimit("3")).toBeUndefined();
+      expect(normalizeReleaseAssetLimit(null)).toBeUndefined();
+      expect(normalizeReleaseAssetLimit(undefined)).toBeUndefined();
+    });
+
+    test("differs from the release limit exactly at 0", () => {
+      expect(normalizeReleaseLimit(0)).toBeUndefined();
+      expect(normalizeReleaseAssetLimit(0)).toBe(0);
+    });
+  });
+
+  describe("resolveMirrorOptions", () => {
+    test("resolves to null (assets for every release) when no tier pins one", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseLimit: 10 }),
+        repository: makeRepo(),
+      });
+      expect(resolved.releaseAssetLimit).toBeNull();
+      expect(resolved.releaseLimit).toBe(10);
+    });
+
+    test("global asset limit applies when nothing overrides it", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseAssetLimit: 5 }),
+        repository: makeRepo(),
+      });
+      expect(resolved.releaseAssetLimit).toBe(5);
+    });
+
+    test("a global 0 is a real value, not a fall-through", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseAssetLimit: 0 }),
+        repository: makeRepo(),
+      });
+      expect(resolved.releaseAssetLimit).toBe(0);
+    });
+
+    test("organization override beats global, repository beats organization", () => {
+      const config = makeConfig({ mirrorReleases: true, releaseAssetLimit: 5 });
+
+      expect(
+        resolveMirrorOptions({
+          config,
+          repository: makeRepo(),
+          orgOverrides: { releaseAssetLimit: 2 },
+        }).releaseAssetLimit
+      ).toBe(2);
+
+      expect(
+        resolveMirrorOptions({
+          config,
+          repository: makeRepo({ mirrorOverrides: { releaseAssetLimit: 0 } }),
+          orgOverrides: { releaseAssetLimit: 2 },
+        }).releaseAssetLimit
+      ).toBe(0);
+    });
+
+    test("null in an override means inherit", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseAssetLimit: 5 }),
+        repository: makeRepo({ mirrorOverrides: { releaseAssetLimit: null } }),
+        orgOverrides: { releaseAssetLimit: null },
+      });
+      expect(resolved.releaseAssetLimit).toBe(5);
+    });
+
+    test("an unusable override falls through to the next tier", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseAssetLimit: 5 }),
+        repository: makeRepo({ mirrorOverrides: { releaseAssetLimit: -3 } }),
+        orgOverrides: { releaseAssetLimit: 2 },
+      });
+      expect(resolved.releaseAssetLimit).toBe(2);
+    });
+
+    test("the asset limit is independent of the release limit", () => {
+      const resolved = resolveMirrorOptions({
+        config: makeConfig({ mirrorReleases: true, releaseLimit: 3 }),
+        repository: makeRepo({ mirrorOverrides: { releaseAssetLimit: 1 } }),
+      });
+      expect(resolved.releaseLimit).toBe(3);
+      expect(resolved.releaseAssetLimit).toBe(1);
+    });
+  });
+
+  describe("releaseGetsAssets", () => {
+    test("null means every release gets assets", () => {
+      expect(releaseGetsAssets(0, null)).toBe(true);
+      expect(releaseGetsAssets(999, null)).toBe(true);
+    });
+
+    test("0 means no release gets assets", () => {
+      expect(releaseGetsAssets(0, 0)).toBe(false);
+    });
+
+    test("N covers exactly the newest N releases, by index", () => {
+      // Newest-first ordering: index 0 is the newest release.
+      expect(releaseGetsAssets(0, 2)).toBe(true);
+      expect(releaseGetsAssets(1, 2)).toBe(true);
+      expect(releaseGetsAssets(2, 2)).toBe(false);
+      expect(releaseGetsAssets(3, 2)).toBe(false);
+    });
+
+    test("a list of releases splits at the limit", () => {
+      const tags = ["v5", "v4", "v3", "v2", "v1"];
+      const withAssets = tags.filter((_, index) => releaseGetsAssets(index, 2));
+      expect(withAssets).toEqual(["v5", "v4"]);
+    });
+  });
+
+  describe("override helpers", () => {
+    test("a pinned 0 counts as an override", () => {
+      expect(hasMirrorOverrides({ releaseAssetLimit: 0 })).toBe(true);
+      expect(listOverriddenKeys({ releaseAssetLimit: 0 })).toEqual([
+        "releaseAssetLimit",
+      ]);
+    });
+
+    test("null and unusable values do not count", () => {
+      expect(hasMirrorOverrides({ releaseAssetLimit: null })).toBe(false);
+      expect(hasMirrorOverrides({ releaseAssetLimit: -1 })).toBe(false);
+      expect(listOverriddenKeys({ releaseAssetLimit: null })).toEqual([]);
+    });
+
+    test("normalizeMirrorOverrides keeps 0 and drops null", () => {
+      expect(
+        normalizeMirrorOverrides({ releaseAssetLimit: 0, releaseLimit: null })
+      ).toEqual({ releaseAssetLimit: 0 });
+      expect(normalizeMirrorOverrides({ releaseAssetLimit: null })).toBeNull();
+    });
+
+    test("the limit keys and labels agree", () => {
+      expect(MIRROR_OVERRIDE_LIMIT_KEYS).toEqual(["releaseLimit", "releaseAssetLimit"]);
+      for (const key of MIRROR_OVERRIDE_LIMIT_KEYS) {
+        expect(MIRROR_OVERRIDE_LABELS[key]).toBeTruthy();
+      }
+    });
+  });
+
+  describe("mirrorOptionsToFlags", () => {
+    test("reports null when the API sends no asset limit", () => {
+      expect(
+        mirrorOptionsToFlags({ mirrorReleases: true, releaseLimit: 10 }).releaseAssetLimit
+      ).toBeNull();
+      expect(
+        mirrorOptionsToFlags({ mirrorReleases: true, releaseAssetLimit: null }).releaseAssetLimit
+      ).toBeNull();
+    });
+
+    test("passes 0 and N through", () => {
+      expect(mirrorOptionsToFlags({ releaseAssetLimit: 0 }).releaseAssetLimit).toBe(0);
+      expect(mirrorOptionsToFlags({ releaseAssetLimit: 4 }).releaseAssetLimit).toBe(4);
+    });
+  });
+
+  describe("getMirrorOverrideGating", () => {
+    test("the asset limit is disabled with the release limit when releases are off", () => {
+      const gating = getMirrorOverrideGating({
+        targetKind: "repository",
+        effective: { mirrorReleases: false },
+      });
+      expect(gating.releaseLimit).toBe(MIRROR_GATING_REASONS.releasesOff);
+      expect(gating.releaseAssetLimit).toBe(MIRROR_GATING_REASONS.releasesOff);
+    });
+
+    test("the asset limit inherits the starred reason", () => {
+      const gating = getMirrorOverrideGating({
+        targetKind: "repository",
+        isStarred: true,
+        starredCodeOnly: true,
+        effective: { mirrorReleases: true },
+      });
+      expect(gating.releaseAssetLimit).toBe(MIRROR_GATING_REASONS.starredCodeOnly);
+    });
+
+    test("the asset limit is editable while releases are on", () => {
+      const gating = getMirrorOverrideGating({
+        targetKind: "organization",
+        effective: { mirrorReleases: true },
+      });
+      expect(gating.releaseAssetLimit).toBeUndefined();
+    });
   });
 });

--- a/src/lib/utils/mirror-overrides.ts
+++ b/src/lib/utils/mirror-overrides.ts
@@ -25,8 +25,12 @@ export type MirrorOverrideKey = (typeof MIRROR_OVERRIDE_KEYS)[number];
  * The numeric mirror options that can be overridden per organization and per
  * repository. Kept apart from the boolean flags because every consumer of
  * MIRROR_OVERRIDE_KEYS (resolver, gating, dialog tri-states) assumes booleans.
+ *
+ * `releaseLimit` is how many of the newest releases exist in Gitea at all.
+ * `releaseAssetLimit` (#311) is how many of those also get their assets
+ * uploaded; the rest are created with notes and tag only.
  */
-export const MIRROR_OVERRIDE_LIMIT_KEYS = ["releaseLimit"] as const;
+export const MIRROR_OVERRIDE_LIMIT_KEYS = ["releaseLimit", "releaseAssetLimit"] as const;
 
 export type MirrorOverrideLimitKey = (typeof MIRROR_OVERRIDE_LIMIT_KEYS)[number];
 
@@ -34,18 +38,24 @@ export type MirrorOverrideLimitKey = (typeof MIRROR_OVERRIDE_LIMIT_KEYS)[number]
 export const DEFAULT_RELEASE_LIMIT = 10;
 
 /**
- * Fully resolved mirror options: every flag has a definite boolean value and
- * every limit a definite positive integer.
+ * Fully resolved mirror options: every flag has a definite boolean value, the
+ * release limit a definite positive integer, and the asset limit either a
+ * non-negative integer or `null` for "assets for every mirrored release".
  */
-export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean> &
-  Record<MirrorOverrideLimitKey, number>;
+export type ResolvedMirrorOptions = Record<MirrorOverrideKey, boolean> & {
+  releaseLimit: number;
+  releaseAssetLimit: number | null;
+};
 
 /**
  * The values the tiers above an override resolve to right now. Used by the
- * dialog to label what "Inherit" means for each row.
+ * dialog to label what "Inherit" means for each row. A `null` asset limit is
+ * a known value ("all"), distinct from `undefined` (not known yet).
  */
-export type InheritedMirrorOptions = Partial<Record<MirrorOverrideKey, boolean>> &
-  Partial<Record<MirrorOverrideLimitKey, number>>;
+export type InheritedMirrorOptions = Partial<Record<MirrorOverrideKey, boolean>> & {
+  releaseLimit?: number;
+  releaseAssetLimit?: number | null;
+};
 
 /**
  * Sanitize a release limit from any tier into a positive integer, or
@@ -57,6 +67,41 @@ export function normalizeReleaseLimit(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   const limit = Math.floor(value);
   return limit >= 1 ? limit : undefined;
+}
+
+/**
+ * Sanitize a release asset limit from any tier into a non-negative integer,
+ * or `undefined` when the value is absent or unusable (so the next tier out
+ * is consulted). Unlike the release limit, 0 is meaningful here: it means
+ * release notes only, no assets. There is no numeric "all"; that is what the
+ * absence of a limit at every tier (`null`) resolves to.
+ */
+export function normalizeReleaseAssetLimit(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const limit = Math.floor(value);
+  return limit >= 0 ? limit : undefined;
+}
+
+/** Per-key sanitizers for the numeric overrides. */
+const LIMIT_NORMALIZERS: Record<
+  MirrorOverrideLimitKey,
+  (value: unknown) => number | undefined
+> = {
+  releaseLimit: normalizeReleaseLimit,
+  releaseAssetLimit: normalizeReleaseAssetLimit,
+};
+
+/**
+ * Whether the release at `index` in the newest-first list gets its assets
+ * uploaded. `null` means no limit. A release past the limit still gets its
+ * notes and tag, and assets that already reached Gitea are never removed
+ * because of this rule; it only decides whether a sync uploads.
+ */
+export function releaseGetsAssets(
+  index: number,
+  releaseAssetLimit: number | null
+): boolean {
+  return releaseAssetLimit === null || index < releaseAssetLimit;
 }
 
 /**
@@ -145,6 +190,7 @@ export function mirrorOptionsToFlags(
         mirrorLFS?: boolean;
         mirrorReleases?: boolean;
         releaseLimit?: number;
+        releaseAssetLimit?: number | null;
         mirrorMetadata?: boolean;
         metadataComponents?: {
           issues?: boolean;
@@ -170,6 +216,8 @@ export function mirrorOptionsToFlags(
     mirrorMilestones: !!components?.milestones,
     releaseLimit:
       normalizeReleaseLimit(mirrorOptions?.releaseLimit) ?? DEFAULT_RELEASE_LIMIT,
+    releaseAssetLimit:
+      normalizeReleaseAssetLimit(mirrorOptions?.releaseAssetLimit) ?? null,
   };
 }
 
@@ -198,8 +246,8 @@ export type MirrorOverrideGating = Partial<
  *  - `shouldMirrorLabels` in gitea.ts / gitea-enhanced.ts is
  *    `mirrorLabels && !mirrorIssues`, so labels cannot take effect while issues
  *    are being mirrored (the issue path already reconciles labels)
- *  - `releaseLimit` is only read inside the release mirror, so it cannot take
- *    effect while `mirrorReleases` resolves to off
+ *  - `releaseLimit` and `releaseAssetLimit` are only read inside the release
+ *    mirror, so they cannot take effect while `mirrorReleases` resolves to off
  *
  * `effective` is the value each flag currently resolves to including the
  * in-progress edit, so the labels and release-limit gates react live as
@@ -242,6 +290,10 @@ export function getMirrorOverrideGating({
   } else if (effective.mirrorReleases === false) {
     gating.releaseLimit = MIRROR_GATING_REASONS.releasesOff;
   }
+  // The asset limit is read in the same place, so it shares the reason.
+  if (gating.releaseLimit) {
+    gating.releaseAssetLimit = gating.releaseLimit;
+  }
 
   return gating;
 }
@@ -259,6 +311,7 @@ export const MIRROR_OVERRIDE_LABELS: Record<
   mirrorLabels: "Labels",
   mirrorMilestones: "Milestones",
   releaseLimit: "Release limit",
+  releaseAssetLimit: "Release asset limit",
 };
 
 /**
@@ -307,7 +360,7 @@ export function listOverriddenKeys(
   return [
     ...MIRROR_OVERRIDE_KEYS.filter((key) => overrides[key] != null),
     ...MIRROR_OVERRIDE_LIMIT_KEYS.filter(
-      (key) => normalizeReleaseLimit(overrides[key]) !== undefined
+      (key) => LIMIT_NORMALIZERS[key](overrides[key]) !== undefined
     ),
   ];
 }
@@ -330,7 +383,7 @@ export function normalizeMirrorOverrides(
     if (typeof flag === "boolean") cleaned[key] = flag;
   }
   for (const key of MIRROR_OVERRIDE_LIMIT_KEYS) {
-    const limit = normalizeReleaseLimit(overrides[key]);
+    const limit = LIMIT_NORMALIZERS[key](overrides[key]);
     if (limit !== undefined) cleaned[key] = limit;
   }
 
@@ -342,8 +395,8 @@ export function normalizeMirrorOverrides(
  *
  * Precedence is per field, most specific tier wins:
  *   repository override -> organization override -> global config -> default
- * where the default is `false` for flags and DEFAULT_RELEASE_LIMIT for the
- * release limit.
+ * where the default is `false` for flags, DEFAULT_RELEASE_LIMIT for the
+ * release limit, and `null` (every mirrored release) for the asset limit.
  *
  * `starredCodeOnly` is applied last as a hard clamp. It is a "code only, no
  * metadata" switch for starred repos, so it forces every metadata flag off
@@ -391,6 +444,15 @@ export function resolveMirrorOptions({
     normalizeReleaseLimit(org?.releaseLimit) ??
     normalizeReleaseLimit(globalConfig?.releaseLimit) ??
     DEFAULT_RELEASE_LIMIT;
+
+  // The asset limit has no numeric default: when no tier pins one, every
+  // mirrored release gets its assets, which is what happened before #311.
+  // A pinned 0 is a real value (notes only) and must not fall through.
+  resolved.releaseAssetLimit =
+    normalizeReleaseAssetLimit(repo?.releaseAssetLimit) ??
+    normalizeReleaseAssetLimit(org?.releaseAssetLimit) ??
+    normalizeReleaseAssetLimit(globalConfig?.releaseAssetLimit) ??
+    null;
 
   // Starred repos with starredCodeOnly mirror code and nothing else. This
   // clamp intentionally outranks explicit per-repo overrides: the setting

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -82,6 +82,7 @@ export interface GitHubConfig {
 export interface MirrorOptions {
   mirrorReleases: boolean;
   releaseLimit?: number;  // Limit number of releases to mirror (default: 10)
+  releaseAssetLimit?: number | null;  // Upload assets only for the newest N releases; null or absent means all, 0 means none
   mirrorLFS: boolean;  // Mirror Git LFS objects
   mirrorMetadata: boolean;
   metadataComponents: {


### PR DESCRIPTION
## What changed

Adds a release asset limit next to the existing release limit.

- The release limit still decides how many of the newest releases exist in Gitea/Forgejo at all.
- The new asset limit decides how many of those also get their assets uploaded. Older releases inside the release limit are still created, with their notes and tag, just without the binaries.
- It can be set globally in Settings > Mirror Options (a second box next to "Latest"), and overridden per organization and per repository in the mirror options dialog, using the same inherit chain as the release limit.
- `RELEASE_ASSET_LIMIT` sets it from the environment.
- The README explains both limits and gains a Troubleshooting entry for the `mirror repository is read-only` error, which is Gitea/Forgejo refusing pushes to a pull mirror by design.

## How the limit behaves

- Unset (null): assets for every mirrored release. This is the default and matches what happened before, so nothing changes for existing setups.
- 0: release notes only, no assets. This also gives the per-repository "no assets for this one" control asked for in #311.
- N: assets for the newest N mirrored releases, counted in the same newest-first order the release limit uses.
- Inheritance is per field: repository override, then organization override, then the global setting. A 0 at any tier is a real value and does not fall through.
- It never deletes assets. Lowering the limit stops future uploads for releases past it; anything already in Gitea stays.

No migration: both the global value and the overrides live in existing JSON columns.

## Verification

- `bun test`: 662 pass, 0 fail. New tests cover the normalizer (0 accepted, negatives rejected), resolution across all three tiers, the gating rule, the override helpers, and the pure `releaseGetsAssets` decision the release loop uses.
- `bun run build` passes. Type check shows the same 169 pre-existing errors as main, none added.
- Booted a dev server on a scratch copy of the database: the config API round-trips 3, 0 and null for the new option, the stored JSON carries null after clearing, and the repository override endpoint keeps a pinned 0, floors 2.7 to 2 next to a release limit, and collapses an unusable -1 to no overrides.

Closes #311
Closes #59
