### PR TITLE
feat(www): homepage reflects sources, push destinations, API keys and the Helm chart

### DIFF
--- a/www/src/components/FAQ.astro
+++ b/www/src/components/FAQ.astro
@@ -4,7 +4,19 @@ import { HelpCircle } from 'lucide-react';
 const faqs = [
   {
     question: "What is Gitea Mirror and why do I need it?",
-    answer: "Gitea Mirror is a self-hosted tool that automatically backs up your GitHub repositories to your own Gitea server. You need it because GitHub outages, account issues, or policy changes can lock you out of your code. With Gitea Mirror, you own your backups completely—no monthly fees, no third-party storage, just full control over your repository history, issues, pull requests, and releases."
+    answer: "Gitea Mirror is a self-hosted tool that automatically backs up your GitHub repositories to your own Gitea server. GitHub outages, account issues, or policy changes can lock you out of your code. With Gitea Mirror you own your backups completely: no monthly fees, no third-party storage, and full control over your repository history, issues, pull requests, and releases. It can also pull from GitLab, Gitea and Forgejo, and push to GitHub, GitLab and Forgejo, all in beta."
+  },
+  {
+    question: "Which hosts can it mirror from and to?",
+    answer: "Sources: GitHub is the default. GitLab and Gitea or Forgejo, which covers Codeberg, are available in beta. Destinations: Gitea is the default. Forgejo, GitHub and GitLab are available in beta. Each account uses one source and one destination at a time. GitHub to Gitea is the supported path; every other combination works end to end but has had less time in the field, so it carries a beta label in the dropdowns.",
+    href: "/docs/sources/",
+    linkText: "Read about sources and destinations"
+  },
+  {
+    question: "Can it push to GitHub or GitLab?",
+    answer: "Yes, in beta. Neither host offers a usable pull mirror, so the app keeps a bare clone of each repository and pushes its branches and tags there with force and prune. The copy always matches the source and is overwritten on every sync, so treat it as read only. Issues, pull requests, releases, wiki and LFS objects do not travel to push targets. The GitHub token needs the repo and workflow scopes; the GitLab token needs api and write_repository.",
+    href: "/docs/destinations/",
+    linkText: "How push destinations work"
   },
   {
     question: "How is this different from BackHub or Rewind?",
@@ -12,35 +24,53 @@ const faqs = [
   },
   {
     question: "Does Gitea Mirror backup issues, pull requests, and releases?",
-    answer: "Yes! Enable 'Mirror metadata' in settings to backup issues with comments, labels, and assignees. Pull requests are mirrored as enriched issues with full metadata, commit history, and file changes (Gitea's API doesn't support creating PRs from external sources). Releases, including binary assets, and wiki pages are also backed up when enabled."
+    answer: "Yes, from GitHub. Enable 'Mirror metadata' in settings to backup issues with comments, labels, and assignees. Pull requests are mirrored as enriched issues with full metadata, commit history, and file changes (Gitea's API doesn't support creating PRs from external sources). Releases, including binary assets, and wiki pages are also backed up when enabled, and the 'Assets for latest' setting limits asset uploads to the newest releases. Other sources carry code, branches, tags, wiki and LFS only."
+  },
+  {
+    question: "Is there an API?",
+    answer: "Yes. Create an API key under Configuration, Authentication, API Keys and send it in the x-api-key header. A key uses the same endpoints as the web UI: list repositories, add one by owner and name, start a mirror, sync, run cleanup, reconcile, and check health. Keys can expire, can be revoked, and cannot create or revoke other keys.",
+    href: "/docs/api/",
+    linkText: "API reference"
   },
   {
     question: "How long does setup take?",
-    answer: "15-20 minutes with Docker. Run 'docker compose -f docker-compose.alt.yml up -d', visit localhost:4321, create an account, paste your GitHub and Gitea tokens, select repos to backup—done. The Proxmox LXC one-liner is even faster. No complex configuration files or manual scripting required."
+    answer: "15-20 minutes with Docker. Run 'docker compose -f docker-compose.alt.yml up -d', visit localhost:4321, create an account, paste your GitHub and Gitea tokens, select repos to backup, and you are done. The Proxmox LXC one-liner is even faster. No complex configuration files or manual scripting required."
+  },
+  {
+    question: "How do I install it with Helm?",
+    answer: "The chart is published to GitHub Container Registry with every release: helm upgrade --install gitea-mirror oci://ghcr.io/raylabshq/charts/gitea-mirror --namespace gitea-mirror --create-namespace. The chart version equals the application version and its default image tag is that release, so a plain install runs the newest version. Installing from a clone of the repository still works.",
+    href: "/docs/deployment/",
+    linkText: "Deployment guide"
+  },
+  {
+    question: "I already have mirrors on Gitea. Can Gitea Mirror take them over?",
+    answer: "Yes. The Reconcile action on the Automation tab compares your Gitea server with the database. Mirrors it does not know about, whose original URL points at your configured source, can be adopted as tracked rows. Rows whose mirror has gone missing can be reset so the next run recreates them. Native repositories and mirrors of other hosts are listed but never touched, and nothing is deleted on either side.",
+    href: "/docs/cleanup-and-reconcile/",
+    linkText: "Cleanup and reconcile"
   },
   {
     question: "What happens if GitHub goes down or I lose access?",
-    answer: "You can immediately clone from your Gitea server instead. Your local backups include full commit history, branches, tags, issues, releases—everything. Recovery time is typically under 2 minutes (just point git to your Gitea URL). This is why it's called disaster recovery, not just mirroring."
+    answer: "You can immediately clone from your Gitea server instead. Your local backups include full commit history, branches, tags, issues, releases, everything. Recovery time is typically under 2 minutes (just point git to your Gitea URL). This is why it's called disaster recovery, not just mirroring."
   },
   {
-    question: "How often does it sync with GitHub?",
-    answer: "Configurable from every 15 minutes to once per day (or longer). Most users choose 1-8 hours based on how fresh they want backups. The scheduler auto-discovers new repos and respects per-repo intervals, unlike Gitea's built-in mirroring which defaults to 24 hours."
+    question: "How often does it sync?",
+    answer: "Configurable from every 15 minutes to once per day (or longer). Most users choose 1-8 hours based on how fresh they want backups. The scheduler auto-discovers new repos and respects per-repo intervals, unlike Gitea's built-in mirroring which defaults to 24 hours. Push destinations run the same schedule."
   },
   {
     question: "Can I backup starred repositories?",
-    answer: "Yes! Gitea Mirror can automatically backup all your GitHub stars into a dedicated Gitea organization. Perfect for preserving important open source projects before they disappear (projects get deleted, renamed, or removed all the time)."
+    answer: "Yes! Gitea Mirror can automatically backup the repositories you have starred on your source host into a dedicated Gitea organization. Perfect for preserving important open source projects before they disappear (projects get deleted, renamed, or removed all the time)."
   },
   {
     question: "What are the system requirements?",
-    answer: "Minimal: 2 vCPU, 2GB RAM, 5-10GB storage (grows with repo count). Runs on Docker, Kubernetes, Proxmox LXC, or bare metal. Works on AMD64 and ARM64 (Raspberry Pi compatible). A small homelab server or cheap VPS is plenty for personal use."
+    answer: "Minimal: 2 vCPU, 2GB RAM, 5-10GB storage (grows with repo count). Runs on Docker, Kubernetes, Proxmox LXC, or bare metal. Works on AMD64 and ARM64 (Raspberry Pi compatible). A small homelab server or cheap VPS is plenty for personal use. Push destinations keep a bare clone per repository on disk, so budget roughly the size of those repositories on top."
   },
   {
-    question: "Is my GitHub token stored securely?",
-    answer: "Yes. All GitHub and Gitea tokens are encrypted at rest using AES-256-GCM. Even if someone gains access to the SQLite database, they can't read your tokens without the encryption key. Use the ENCRYPTION_SECRET environment variable for additional security."
+    question: "Are my tokens stored securely?",
+    answer: "Yes. All source and destination tokens are encrypted at rest using AES-256-GCM. Even if someone gains access to the SQLite database, they can't read your tokens without the encryption key. Set the ENCRYPTION_SECRET environment variable to control that key. Push targets receive tokens through a git credential helper, never in a URL or on disk."
   },
   {
     question: "Can I backup private repositories?",
-    answer: "Absolutely. Just use a GitHub personal access token (classic) with 'repo' scope enabled. Gitea Mirror will backup all repositories you have access to—public, private, and internal."
+    answer: "Absolutely. Use a GitHub personal access token (classic) with the 'repo' scope, a GitLab token with read_api and read_repository, or a Gitea or Forgejo token with read:repository, read:user and read:organization. Gitea Mirror will backup the repositories you have access to: public, private, and internal."
   },
   {
     question: "What if I have multiple GitHub organizations?",
@@ -48,11 +78,11 @@ const faqs = [
   },
   {
     question: "Does it support Git LFS (large files)?",
-    answer: "Yes! Enable 'Mirror LFS' in settings. Make sure your Gitea server has LFS enabled (LFS_START_SERVER = true) and Git v2.1.2+. Large assets like videos, datasets, and binaries are backed up alongside your code."
+    answer: "Yes! Enable 'Mirror LFS' in settings. Make sure your Gitea server has LFS enabled (LFS_START_SERVER = true) and Git v2.1.2+. Large assets like videos, datasets, and binaries are backed up alongside your code. LFS objects are not pushed to GitHub or GitLab destinations yet."
   },
   {
     question: "How do I restore from backup?",
-    answer: "Simple: 'git clone https://your-gitea-server/owner/repo.git'. Your full history, branches, and tags are there. For issues/PRs/releases, they're already in Gitea's web interface. For complete disaster recovery, restore the data volume to a fresh Gitea Mirror instance—everything (config, sync history) is preserved."
+    answer: "Simple: 'git clone https://your-gitea-server/owner/repo.git'. Your full history, branches, and tags are there. For issues/PRs/releases, they're already in Gitea's web interface. For complete disaster recovery, restore the data volume to a fresh Gitea Mirror instance and everything (config, sync history) is preserved."
   },
   {
     question: "Can I run this alongside a cloud backup service?",
@@ -60,7 +90,7 @@ const faqs = [
   },
   {
     question: "Is this enterprise-ready with SLA guarantees?",
-    answer: "No. Gitea Mirror is a community open source project—no 24/7 support, no compliance certifications, no guaranteed uptime. It's perfect for homelabs, indie developers, and small teams comfortable with self-hosting. If you need enterprise SLAs, consider commercial solutions like BackHub or GitHub Enterprise Backup."
+    answer: "No. Gitea Mirror is a community open source project with no 24/7 support, no compliance certifications, and no guaranteed uptime. It's perfect for homelabs, indie developers, and small teams comfortable with self-hosting. If you need enterprise SLAs, consider commercial solutions like BackHub or GitHub Enterprise Backup."
   }
 ];
 
@@ -90,7 +120,7 @@ const faqSchema = {
         Common Questions About GitHub Backups
       </h2>
       <p class="mt-4 text-base sm:text-lg text-muted-foreground">
-        Everything you need to know about self-hosted repository backups with Gitea Mirror.
+        What people ask about self-hosted repository backups with Gitea Mirror, and about the newer GitLab, Forgejo, GitHub and API paths.
       </p>
     </div>
 
@@ -112,6 +142,11 @@ const faqSchema = {
           <p class="mt-4 text-sm sm:text-base text-muted-foreground leading-relaxed">
             {faq.answer}
           </p>
+          {faq.href && (
+            <a href={faq.href} class="mt-3 inline-block text-sm font-medium text-primary hover:text-primary/80 transition-colors">
+              {faq.linkText}
+            </a>
+          )}
         </details>
       ))}
     </div>

--- a/www/src/components/Features.astro
+++ b/www/src/components/Features.astro
@@ -3,22 +3,41 @@ import {
   RefreshCw,
   FileText,
   ShieldCheck,
-  Activity,
   Lock,
   HardDrive,
+  GitBranch,
+  ArrowUpFromLine,
+  KeyRound,
+  ListChecks,
 } from 'lucide-react';
 
 const features = [
   {
     title: "Automated Mirroring",
-    description: "Set it and forget it. Automatically sync your GitHub repositories to Gitea on a schedule.",
+    description: "Set it and forget it. Repositories sync to Gitea on a schedule, new ones are picked up automatically, and the dashboard shows every run live.",
     icon: RefreshCw,
     gradient: "from-primary/10 to-accent/10",
     iconColor: "text-primary"
   },
   {
+    title: "Multiple Sources",
+    badge: "Beta",
+    description: "GitHub is the default. GitLab, Gitea and Forgejo, including Codeberg, work too: code, branches, tags, wiki and LFS come across from any of them.",
+    icon: GitBranch,
+    gradient: "from-accent-teal/10 to-primary/10",
+    iconColor: "text-accent-teal"
+  },
+  {
+    title: "Push to GitHub or GitLab",
+    badge: "Beta",
+    description: "Neither host offers a pull mirror, so the app keeps a bare clone and pushes branches and tags. The copy always matches the source.",
+    icon: ArrowUpFromLine,
+    gradient: "from-accent-coral/10 to-primary/10",
+    iconColor: "text-accent-coral"
+  },
+  {
     title: "Metadata Preservation",
-    description: "Mirror issues, pull requests, releases, labels, milestones, and wiki pages alongside your code.",
+    description: "From GitHub, mirror issues, pull requests, releases, labels, milestones and wiki pages alongside your code. Choose how many releases carry their assets.",
     icon: FileText,
     gradient: "from-accent/10 to-accent-teal/10",
     iconColor: "text-accent"
@@ -31,25 +50,32 @@ const features = [
     iconColor: "text-accent-teal"
   },
   {
-    title: "Real-time Dashboard",
-    description: "Monitor mirror progress with live updates, activity logs, and per-repo status tracking.",
-    icon: Activity,
-    gradient: "from-accent-coral/10 to-primary/10",
-    iconColor: "text-accent-coral"
-  },
-  {
-    title: "Secure & Self-Hosted",
-    description: "Tokens encrypted at rest with AES-256-GCM. Your code stays on your infrastructure.",
-    icon: Lock,
-    gradient: "from-accent-purple/10 to-primary/10",
-    iconColor: "text-accent-purple"
-  },
-  {
     title: "Git LFS Support",
     description: "Mirror large files and binary assets alongside your repositories with full LFS support.",
     icon: HardDrive,
     gradient: "from-primary/10 to-accent-purple/10",
     iconColor: "text-primary"
+  },
+  {
+    title: "API Keys",
+    description: "Create a key, send it in the x-api-key header, and drive the same endpoints the UI uses from CI, cron or n8n: list, add, mirror, sync.",
+    icon: KeyRound,
+    gradient: "from-accent-purple/10 to-accent/10",
+    iconColor: "text-accent-purple"
+  },
+  {
+    title: "Cleanup and Reconcile",
+    description: "Archive or delete mirrors whose source is gone, adopt mirrors you made by hand, and reset rows whose copy went missing. Nothing is deleted without you.",
+    icon: ListChecks,
+    gradient: "from-accent/10 to-accent-coral/10",
+    iconColor: "text-accent"
+  },
+  {
+    title: "Secure & Self-Hosted",
+    description: "Tokens encrypted at rest with AES-256-GCM. Run it with Docker, the Helm chart on ghcr.io, Nix or Proxmox. Your code stays on your infrastructure.",
+    icon: Lock,
+    gradient: "from-accent-purple/10 to-primary/10",
+    iconColor: "text-accent-purple"
   }
 ];
 ---
@@ -62,7 +88,7 @@ const features = [
         <span class="text-gradient from-primary to-accent block sm:inline"> Reliable Backups</span>
       </h2>
       <p class="mt-4 text-base sm:text-lg text-muted-foreground max-w-2xl mx-auto px-4">
-        Powerful features designed to keep your code safe and accessible, no matter what happens.
+        Everything to keep your code safe and reachable, whichever host it lives on today.
       </p>
     </div>
 
@@ -79,7 +105,14 @@ const features = [
                 <Icon className="w-5 h-5 sm:w-6 sm:h-6" />
               </div>
               
-              <h3 class="text-lg sm:text-xl font-semibold mb-2">{feature.title}</h3>
+              <h3 class="text-lg sm:text-xl font-semibold mb-2 flex items-center gap-2 flex-wrap">
+                <span>{feature.title}</span>
+                {feature.badge && (
+                  <span class="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-primary">
+                    {feature.badge}
+                  </span>
+                )}
+              </h3>
               <p class="text-sm sm:text-base text-muted-foreground">{feature.description}</p>
             </div>
           </div>

--- a/www/src/components/Footer.astro
+++ b/www/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { Book, MessageSquare, Bug, Scale } from 'lucide-react';
+import { Book, MessageSquare, Bug, Scale, GitBranch, ArrowUpFromLine, KeyRound } from 'lucide-react';
 import { GithubIcon } from './icons/GithubIcon';
 
 const links = [
@@ -12,6 +12,21 @@ const links = [
     title: "Documentation",
     href: "/docs/",
     icon: Book
+  },
+  {
+    title: "Sources",
+    href: "/docs/sources/",
+    icon: GitBranch
+  },
+  {
+    title: "Destinations",
+    href: "/docs/destinations/",
+    icon: ArrowUpFromLine
+  },
+  {
+    title: "API",
+    href: "/docs/api/",
+    icon: KeyRound
   },
   {
     title: "Compare Tools",
@@ -47,12 +62,12 @@ const currentYear = new Date().getFullYear();
           <span class="font-semibold text-base sm:text-lg">Gitea Mirror</span>
         </div>
         <p class="text-xs sm:text-sm text-muted-foreground">
-          Keep your GitHub code safe and synced
+          Keep your code safe and synced, on a server you own
         </p>
       </div>
 
       <!-- Links -->
-      <nav class="grid grid-cols-2 sm:flex items-center justify-center gap-4 sm:gap-6 text-center">
+      <nav class="grid grid-cols-2 sm:flex sm:flex-wrap items-center justify-center gap-4 sm:gap-6 text-center">
         {links.map((link) => {
           const Icon = link.icon;
           const external = link.href.startsWith('http');

--- a/www/src/components/Hero.tsx
+++ b/www/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { Button } from "./ui/button";
-import { ArrowRight, Shield, RefreshCw, HardDrive } from "lucide-react";
+import { Shield, RefreshCw, HardDrive, GitBranch } from "lucide-react";
 import React, { Suspense } from 'react';
 
 const Spline = React.lazy(() => import('@splinetool/react-spline'));
@@ -49,6 +49,10 @@ export function Hero() {
           Automatic, private, and free. Own your code history forever.
           Preserve issues, PRs, releases, and wiki in your own Gitea server.
         </p>
+        <p className="mt-3 text-sm sm:text-base text-muted-foreground max-w-2xl mx-auto px-4 z-20">
+          It also mirrors from GitLab, Gitea and Forgejo, including Codeberg, and can push to GitHub, GitLab and Forgejo.
+          Those paths are in beta. GitHub to Gitea is the supported default.
+        </p>
 
         <div className="mt-6 sm:mt-8 flex flex-wrap items-center justify-center gap-3 text-xs sm:text-sm text-muted-foreground px-4 z-20">
           <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-primary/10 text-primary">
@@ -62,6 +66,10 @@ export function Hero() {
           <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-accent-purple/10 text-accent-purple">
             <Shield className="w-3 h-3 sm:w-4 sm:h-4" />
             <span className="font-medium">$0/month</span>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-1 rounded-full bg-accent-teal/10 text-accent-teal">
+            <GitBranch className="w-3 h-3 sm:w-4 sm:h-4" />
+            <span className="font-medium">GitLab, Forgejo and Codeberg in beta</span>
           </div>
         </div>
 

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -13,11 +13,11 @@ import Footer from "../components/Footer.astro";
 import { PromoBanner } from "../components/PromoBanner";
 
 const siteUrl = "https://gitea-mirror.raylabs.io";
-const title = "GitHub Backup Tool | Self-Hosted Repository Backup to Gitea";
+const title = "GitHub Backup Tool | Mirror GitHub, GitLab and Forgejo to Self-Hosted Gitea";
 const description =
-  "Automatically backup GitHub repos to your own Gitea server. Preserve issues, PRs, releases & wiki. Self-hosted, Docker-ready. Free alternative to cloud backup services.";
+  "Automatically backup GitHub repos to your own Gitea server with issues, PRs, releases and wiki. GitLab, Codeberg and Forgejo sources and GitHub or GitLab push targets in beta. Self-hosted, Docker and Helm ready, free.";
 const keywords =
-  "github backup, github backup self hosted, github repository backup, backup github to nas, github disaster recovery, offline github backup, github backup docker, automatic github backup, github account backup, gitea mirror, self-hosted git backup, repository sync, github to gitea, git mirror, code backup, self-hosted backup solution";
+  "github backup, github backup self hosted, github repository backup, backup github to nas, github disaster recovery, offline github backup, github backup docker, automatic github backup, github account backup, gitea mirror, self-hosted git backup, repository sync, github to gitea, gitlab to gitea, codeberg backup, forgejo mirror, github to gitlab mirror, git mirror, code backup, helm chart, self-hosted backup solution";
 
 // Structured data for SEO
 const structuredData = {
@@ -32,14 +32,14 @@ const structuredData = {
     priceCurrency: "USD",
   },
   description:
-    "Automatic GitHub repository backup to self-hosted Gitea. Preserves complete history, issues, PRs, and releases. Free alternative to cloud backup services.",
+    "Automatic GitHub repository backup to self-hosted Gitea. Preserves complete history, issues, PRs, and releases. Mirrors from GitLab, Gitea and Forgejo and pushes to GitHub, GitLab and Forgejo in beta. Free alternative to cloud backup services.",
   url: siteUrl,
   author: {
     "@type": "Organization",
     name: "RayLabs",
     url: "https://github.com/RayLabsHQ",
   },
-  softwareVersion: "3.11.0",
+  softwareVersion: "3.31.0",
   screenshot: [
     `${siteUrl}/assets/dashboard.png`,
     `${siteUrl}/assets/repositories.png`,
@@ -49,8 +49,12 @@ const structuredData = {
     "Automated scheduled backups",
     "Self-hosted (full data ownership)",
     "Metadata preservation (issues, PRs, releases, wiki)",
+    "GitLab, Gitea and Forgejo sources (beta)",
+    "Push mirrors to GitHub and GitLab (beta)",
+    "API keys for automation",
+    "Cleanup and reconcile of mirrors",
     "Force-push protection with smart detection",
-    "Docker, Helm, Nix, and Proxmox support",
+    "Docker, Helm chart on ghcr.io, Nix, and Proxmox support",
     "Multi-repository and organization backup",
     "Git LFS support",
     "Free and open source",


### PR DESCRIPTION
## Why

The homepage still described a tool that only mirrors GitHub to Gitea. Since 3.30.0 and 3.31.0 it pulls from GitLab, Gitea and Forgejo, pushes to GitHub, GitLab and Forgejo, has API keys, reconcile and cleanup, release asset limits and a Helm chart on ghcr.io. None of that was on the page.

## What changed

- **Hero**: headline unchanged. A second line says it also mirrors from GitLab, Gitea and Forgejo (Codeberg included) and can push to GitHub, GitLab and Forgejo, that those paths are beta, and that GitHub to Gitea is the supported default. One more pill in the row.
- **Features**: nine tiles. New: Multiple Sources (beta pill), Push to GitHub or GitLab (beta pill), API Keys, Cleanup and Reconcile. Metadata Preservation mentions the release asset limit; Secure and Self-Hosted mentions the Helm chart on ghcr.io. Real-time Dashboard folded into Automated Mirroring to keep the 3 by 3 grid.
- **FAQ**: five new entries with a link under the answer: which hosts are supported and which are beta, whether it can push to GitHub or GitLab and what does not travel there, whether there is an API, how to install with Helm from ghcr.io, and whether existing hand made mirrors can be adopted. Answers that were GitHub only now cover the other hosts (starred repositories, tokens, private repositories, LFS, system requirements, sync interval). The JSON-LD FAQ schema is generated from the same array, so it stays in sync. Em dashes removed from the answers.
- **Footer**: links to `/docs/sources/`, `/docs/destinations/` and `/docs/api/`; tagline no longer says GitHub only; the row wraps instead of overflowing.
- **Metadata**: title and description mention the wider host support, keywords add GitLab, Codeberg and Forgejo terms, structured data lists the new features and reads 3.31.0 instead of 3.11.0.

The four docs links point at pages added in #387. They resolve once that PR is merged.

## Verification

- `pnpm build` in `www` passes, 27 pages.
- The built homepage opened in Playwright at 1440 and 390 wide: no horizontal overflow, nine feature tiles, two beta pills, all five FAQ links and eight footer links present. Console shows only the pre-existing WebGL warnings from the Spline background in headless mode.
- No em dashes and no session links in the diff.

## Not done

- The Screenshots carousel could show the new `destinations.png` from #387, but that file is not on this branch and the carousel imports images at build time, so adding it here would break the build. One line in `Screenshots.astro` after #387 lands.
