### PR TITLE
Move mirrors to another owner from the app, and follow ones moved in Gitea (#400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ Enable in Settings → Mirror Options → Mirror metadata
 - **Ignore Status** - Mark repositories to skip from mirroring
 - **Automatic Cleanup** - Configure retention period for activity logs
 - **Scheduled Sync** - Set custom intervals for automatic mirroring
-- **Reconcile with Destination** - Compare Gitea/Forgejo with the database from Configuration > Automation: adopt mirrors the database lost track of, or reset rows whose mirror is gone so the next sync recreates them. Nothing is deleted or archived by this step.
+- **Reconcile with Destination** - Compare Gitea/Forgejo with the database from Configuration > Automation: adopt mirrors the database lost track of, record the new owner of mirrors you transferred in Gitea, or reset rows whose mirror is gone so the next sync recreates them. Nothing is deleted or archived by this step.
+- **Move Mirrors from the App** - Changing a repository's or an organization's destination offers to transfer the existing mirrors on Gitea/Forgejo as well, with their history, issues and mirror settings. When the token cannot create repositories under the new owner, Gitea asks its owners to accept and sync follows the mirror once they do.
 
 ### Automatic Syncing & Synchronization
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -121,15 +121,16 @@ Starts mirroring in the background and returns straight away. Poll the list endp
 
 `POST /api/cleanup/reconcile`
 
-Compares what the destination (Gitea or Forgejo) holds with the repositories this account tracks, and reports three groups: mirrors on the destination that the database does not know about, rows marked mirrored whose repository is gone, and a healthy count. Only mirrors whose source URL points at the configured source count as this app's. Native repositories and mirrors of other hosts are listed under `notManaged` and never touched. Useful after a lost or restored database (issue #284).
+Compares what the destination (Gitea or Forgejo) holds with the repositories this account tracks, and reports four groups: mirrors on the destination that the database does not know about, rows whose mirror was moved to another owner, rows marked mirrored whose repository is gone, and a healthy count. Only mirrors whose source URL points at the configured source count as this app's. Native repositories, mirrors of other hosts and second copies of a tracked mirror are listed under `notManaged` and never touched. Useful after a lost or restored database (issue #284) or after transferring mirrors between owners in Gitea (issue #400).
 
 ```json
-{ "dryRun": true, "adoptUntracked": false, "resetMissing": false }
+{ "dryRun": true, "adoptUntracked": false, "relocateMoved": false, "resetMissing": false }
 ```
 
 The body is optional and every field defaults to the value above, so an empty `POST` is a dry run. With `dryRun: false`:
 
 - `adoptUntracked: true` creates a row for each untracked mirror from its source URL, so scheduled sync and the cleanup service include it from then on. The row keeps the mirror where it is, even when the strategy would put it elsewhere.
+- `relocateMoved: true` points each moved row at the owner that holds its mirror now, so sync follows the transfer instead of failing. A row that failed because its mirror was not at the recorded place goes back to `mirrored`. Nothing changes on the destination.
 - `resetMissing: true` sets each missing row back to `imported` so the next mirror run recreates the mirror. Rows are never deleted.
 
 Nothing is deleted or archived on either side by this call; the cleanup service keeps its own rules.
@@ -141,15 +142,16 @@ Nothing is deleted or archived on either side by this call; the cleanup service 
   "report": {
     "untracked": [{ "location": "github-mirrors/hello-world", "originalUrl": "https://github.com/octocat/hello-world.git", "sourcePath": "octocat/hello-world", "isPrivate": false }],
     "missing": [{ "id": "9b2f...", "fullName": "octocat/gone", "location": "github-mirrors/gone" }],
+    "moved": [{ "id": "c41a...", "fullName": "octocat/tools", "from": "github-mirrors/tools", "to": "archive/tools" }],
     "notManaged": [{ "location": "me/notes", "reason": "not a mirror" }],
     "unverified": [],
-    "healthyCount": 41,
+    "healthyCount": 40,
     "elsewhereCount": 0,
-    "scannedOwners": ["e2e_admin", "github-mirrors"],
+    "scannedOwners": ["e2e_admin", "github-mirrors", "archive"],
     "skippedOwners": ["starred"],
     "totalOnDestination": 43
   },
-  "applied": { "adopted": 1, "reset": 1, "skipped": 0 }
+  "applied": { "adopted": 1, "reset": 1, "relocated": 1, "skipped": 0 }
 }
 ```
 
@@ -160,6 +162,56 @@ Nothing is deleted or archived on either side by this call; the cleanup service 
 | `200` | Report computed, and applied when asked. |
 | `400` | A field has the wrong type, or the destination is not configured yet. |
 | `404` | No configuration for this account. |
+
+### Move a mirror to another owner
+
+`POST /api/repositories/{id}/move-mirror`
+
+```json
+{ "destinationOrg": "archive" }
+```
+
+Changes the repository's destination and transfers its existing mirror there on the destination (Gitea or Forgejo), for issue #400. `PATCH /api/repositories/{id}` with `destinationOrg` only changes the label: the mirror stays where it is and the new destination applies if the mirror is ever created again. Send `null` to remove the override and move the mirror back to where the strategy puts it.
+
+The mirror is looked for at its recorded location first, then anywhere on the destination in case someone transferred it by hand. A target organization that does not exist is created, the way a mirror run creates one. When a mirror of the same source already sits under the target, the row is pointed at it and the old copy is left alone. The row is only written once the destination has accepted the transfer, so a refused move changes nothing.
+
+```json
+{
+  "success": true,
+  "destinationOrg": "archive",
+  "mirroredLocation": "archive/hello-world",
+  "transfer": {
+    "outcome": "moved",
+    "from": "github-mirrors/hello-world",
+    "to": "archive/hello-world",
+    "message": "Moved octocat/hello-world from github-mirrors/hello-world to archive/hello-world."
+  }
+}
+```
+
+| `transfer.outcome` | Meaning |
+| --- | --- |
+| `moved` | The destination moved the repository. `mirroredLocation` is the new place. |
+| `pending` | The token cannot create repositories under the new owner, so the destination waits for one of its owners to accept. The mirror keeps syncing where it is, and sync follows it once accepted. |
+| `recorded` | A mirror of the same source already sat under the target; the row now points at it. |
+| `not-mirrored` | The row has never been mirrored, so only the destination changed. |
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Done, see `transfer`. |
+| `400` | Bad owner name, destination not configured, or a GitHub or GitLab destination (`destination-unsupported`). |
+| `403` | The destination token may not transfer the repository (`forbidden`). |
+| `404` | The repository or the configuration does not belong to this account. |
+| `409` | Nothing changed. `code` says why: `not-on-destination`, `name-taken`, `transfer-pending`, or `destination-mismatch` for a row mirrored to another host. |
+| `502` | The destination refused for another reason (`destination-error`). |
+
+`POST /api/organizations/{id}/move-mirrors` does the same for every mirrored repository of an organization:
+
+```json
+{ "destinationOrg": "archive", "dryRun": true }
+```
+
+`dryRun` defaults to `true` and answers with `plan.moves` (`id`, `fullName`, `from`, `to`) and `plan.skipped` (`fullName`, `reason`) without touching anything. Repositories with their own destination, starred repositories, rows that are not mirrored yet and rows in a running mirror or sync are skipped. With `dryRun: false` each planned move runs, the organization's `destinationOrg` is written, and the answer lists `moved`, `pending`, `recorded` and `failed` (`fullName`, `error`). A failed repository keeps syncing where it is.
 
 ## A complete example
 

--- a/src/components/config/ReconcileDialog.tsx
+++ b/src/components/config/ReconcileDialog.tsx
@@ -16,6 +16,8 @@ import { withBase } from "@/lib/base-path";
 interface ReconcileReport {
   untracked: Array<{ location: string; originalUrl: string; sourcePath: string; isPrivate: boolean }>;
   missing: Array<{ id: string; fullName: string; location: string }>;
+  /** Rows whose recorded mirror is gone while the same source is mirrored under another owner. */
+  moved: Array<{ id: string; fullName: string; from: string; to: string }>;
   notManaged: Array<{ location: string; reason: string }>;
   unverified: Array<{ fullName: string; location: string; error: string }>;
   healthyCount: number;
@@ -26,11 +28,13 @@ interface ReconcileReport {
   totalOnDestination: number;
 }
 
+type AppliedSummary = { adopted: number; reset: number; relocated: number; skipped: number };
+
 interface ReconcileResponse {
   success: boolean;
   dryRun: boolean;
   report: ReconcileReport;
-  applied: { adopted: number; reset: number; skipped: number } | null;
+  applied: AppliedSummary | null;
   error?: string;
 }
 
@@ -41,6 +45,7 @@ async function postReconcile(body: {
   dryRun: boolean;
   adoptUntracked?: boolean;
   resetMissing?: boolean;
+  relocateMoved?: boolean;
 }): Promise<ReconcileResponse> {
   const response = await fetch(RECONCILE_API_PATH, {
     method: "POST",
@@ -103,16 +108,17 @@ interface ReconcileDialogProps {
 
 /**
  * Compares the destination with the repository database. Runs a dry run on
- * open, then applies the two opt-in fixes the user ticks.
+ * open, then applies the opt-in fixes the user ticks.
  */
 export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
   const [loading, setLoading] = useState(false);
   const [applying, setApplying] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<ReconcileReport | null>(null);
-  const [applied, setApplied] = useState<{ adopted: number; reset: number; skipped: number } | null>(null);
+  const [applied, setApplied] = useState<AppliedSummary | null>(null);
   const [adopt, setAdopt] = useState(false);
   const [reset, setReset] = useState(false);
+  const [relocate, setRelocate] = useState(false);
 
   const runDryRun = useCallback(async () => {
     setLoading(true);
@@ -133,11 +139,12 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
     setApplied(null);
     setAdopt(false);
     setReset(false);
+    setRelocate(false);
     void runDryRun();
   }, [open, runDryRun]);
 
   const apply = async () => {
-    if (!adopt && !reset) return;
+    if (!adopt && !reset && !relocate) return;
     setApplying(true);
     setError(null);
     try {
@@ -145,14 +152,16 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
         dryRun: false,
         adoptUntracked: adopt,
         resetMissing: reset,
+        relocateMoved: relocate,
       });
-      const summary = result.applied ?? { adopted: 0, reset: 0, skipped: 0 };
+      const summary = result.applied ?? { adopted: 0, reset: 0, relocated: 0, skipped: 0 };
       setApplied(summary);
       toast.success(
-        `Adopted ${summary.adopted} untracked mirror${summary.adopted === 1 ? "" : "s"}, reset ${summary.reset} missing row${summary.reset === 1 ? "" : "s"}`
+        `Adopted ${summary.adopted} untracked mirror${summary.adopted === 1 ? "" : "s"}, recorded ${summary.relocated} new location${summary.relocated === 1 ? "" : "s"}, reset ${summary.reset} missing row${summary.reset === 1 ? "" : "s"}`
       );
       setAdopt(false);
       setReset(false);
+      setRelocate(false);
       await runDryRun();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Reconcile failed";
@@ -165,7 +174,9 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
 
   const untrackedCount = report?.untracked.length ?? 0;
   const missingCount = report?.missing.length ?? 0;
+  const movedCount = report?.moved.length ?? 0;
   const busy = loading || applying;
+  const nothingTicked = !adopt && !reset && !relocate;
 
   return (
     <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
@@ -191,7 +202,9 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
         )}
 
         {report && (
-          <div className="space-y-4">
+          // min-w-0: DialogContent is a grid, and a long monospace entry would
+          // otherwise widen the track past the panel instead of truncating.
+          <div className="min-w-0 space-y-4">
             <p className="text-[12px] text-muted-foreground">
               {report.totalOnDestination} repositor{report.totalOnDestination === 1 ? "y" : "ies"} under{" "}
               {report.scannedOwners.length} owner{report.scannedOwners.length === 1 ? "" : "s"} on the destination,{" "}
@@ -215,6 +228,12 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
               tone={untrackedCount > 0 ? "amber" : "muted"}
             />
             <RepoList
+              title="Moved on the destination"
+              items={report.moved.map((r) => `${r.to} (was ${r.from})`)}
+              hint="Rows whose recorded mirror is gone while a mirror of the same source sits under another owner, usually after a transfer in Gitea. Recording the new location makes sync follow it."
+              tone={movedCount > 0 ? "amber" : "muted"}
+            />
+            <RepoList
               title="In the database, gone from the destination"
               items={report.missing.map((r) => `${r.fullName} (was ${r.location})`)}
               hint="Rows marked mirrored whose repository is no longer there. Resetting them makes the next mirror run recreate the mirror."
@@ -224,7 +243,7 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
               <RepoList
                 title="Not managed by gitea-mirror"
                 items={report.notManaged.map((r) => `${r.location} (${r.reason})`)}
-                hint="Native repositories and mirrors of other hosts. These are listed for information and never touched."
+                hint="Native repositories, mirrors of other hosts, and second copies of a tracked mirror. These are listed for information and never touched."
               />
             )}
             {report.unverified.length > 0 && (
@@ -238,7 +257,7 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
 
             {applied && (
               <p className="text-[12px] text-muted-foreground">
-                Applied: adopted {applied.adopted}, reset {applied.reset}
+                Applied: adopted {applied.adopted}, recorded {applied.relocated}, reset {applied.reset}
                 {applied.skipped > 0 ? `, skipped ${applied.skipped}` : ""}. The lists above are refreshed.
               </p>
             )}
@@ -255,6 +274,20 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
                   Adopt the {untrackedCount} untracked mirror{untrackedCount === 1 ? "" : "s"}
                   <span className="block text-[12px] text-muted-foreground">
                     Creates database rows from the source URL of each mirror.
+                  </span>
+                </span>
+              </label>
+              <label className="flex cursor-pointer items-start gap-3 text-sm">
+                <Checkbox
+                  checked={relocate}
+                  onCheckedChange={(checked) => setRelocate(checked === true)}
+                  disabled={busy || movedCount === 0}
+                  className="mt-0.5"
+                />
+                <span>
+                  Record the {movedCount} new location{movedCount === 1 ? "" : "s"}
+                  <span className="block text-[12px] text-muted-foreground">
+                    Points each row at where its mirror is now. Nothing is moved, created or deleted on the destination.
                   </span>
                 </span>
               </label>
@@ -284,7 +317,7 @@ export function ReconcileDialog({ open, onOpenChange }: ReconcileDialogProps) {
             {loading ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
             Check again
           </Button>
-          <Button type="button" onClick={() => void apply()} disabled={busy || (!adopt && !reset)}>
+          <Button type="button" onClick={() => void apply()} disabled={busy || nothingTicked}>
             {applying ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
             Apply
           </Button>

--- a/src/components/organizations/MirrorDestinationEditor.tsx
+++ b/src/components/organizations/MirrorDestinationEditor.tsx
@@ -1,24 +1,74 @@
 import { useState } from "react";
-import { ArrowRight, Edit3, RotateCcw, CheckCircle2, Building2 } from "lucide-react";
+import { ArrowRight, Edit3, RotateCcw, CheckCircle2, Building2, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import type { OrganizationMoveResult } from "@/lib/destination-transfer";
 
 interface MirrorDestinationEditorProps {
   organizationId: string;
   organizationName: string;
   currentDestination?: string;
   onUpdate: (newDestination: string | null) => Promise<void>;
+  /**
+   * Plan (dryRun) or perform the move of the organization's mirrors on the
+   * destination (issue #400). Absent when the destination cannot move
+   * repositories, which hides the option.
+   */
+  onMoveMirrors?: (newDestination: string | null, dryRun: boolean) => Promise<OrganizationMoveResult>;
+  /** "Gitea" or "Forgejo", for the copy. */
+  destinationLabel?: string;
   isUpdating?: boolean;
   className?: string;
+}
+
+const MAX_LISTED = 8;
+
+function MoveList({ title, items }: { title: string; items: string[] }) {
+  const shown = items.slice(0, MAX_LISTED);
+  const rest = items.length - shown.length;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-sm font-medium">{title}</span>
+        <span className="text-xs font-semibold tabular-nums text-muted-foreground">{items.length}</span>
+      </div>
+      <ul className="max-h-32 space-y-0.5 overflow-y-auto rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-[12px]">
+        {shown.map((item) => (
+          <li key={item} className="truncate" title={item}>
+            {item}
+          </li>
+        ))}
+        {rest > 0 && <li className="pt-1 font-sans text-muted-foreground">and {rest} more</li>}
+      </ul>
+    </div>
+  );
+}
+
+function summarizeSkipped(skipped: OrganizationMoveResult["plan"]["skipped"]): string {
+  if (skipped.length === 0) return "no repository of this organization is mirrored yet";
+  const counts = new Map<string, number>();
+  for (const entry of skipped) counts.set(entry.reason, (counts.get(entry.reason) ?? 0) + 1);
+  return Array.from(counts.entries())
+    .map(([reason, count]) => `${count} ${reason}`)
+    .join(", ");
 }
 
 export function MirrorDestinationEditor({
@@ -26,15 +76,24 @@ export function MirrorDestinationEditor({
   organizationName,
   currentDestination,
   onUpdate,
+  onMoveMirrors,
+  destinationLabel = "Gitea",
   isUpdating = false,
   className,
 }: MirrorDestinationEditorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [editValue, setEditValue] = useState(currentDestination || "");
   const [isLoading, setIsLoading] = useState(false);
+  const [moveMirrors, setMoveMirrors] = useState(false);
+  const [plan, setPlan] = useState<OrganizationMoveResult | null>(null);
+  const [pendingDestination, setPendingDestination] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const hasOverride = currentDestination && currentDestination !== organizationName;
   const effectiveDestination = currentDestination || organizationName;
+  const canMove = typeof onMoveMirrors === "function";
 
   const handleSave = async () => {
     const trimmedValue = editValue.trim();
@@ -44,6 +103,23 @@ export function MirrorDestinationEditor({
 
     setIsLoading(true);
     try {
+      if (moveMirrors && onMoveMirrors) {
+        // Plan first; the confirmation shows exactly what would move.
+        const preview = await onMoveMirrors(newDestination, true);
+        if (preview.plan.moves.length === 0) {
+          await onUpdate(newDestination);
+          setIsOpen(false);
+          toast.success(`Destination updated. Nothing to move: ${summarizeSkipped(preview.plan.skipped)}.`);
+          return;
+        }
+        setPlan(preview);
+        setPendingDestination(newDestination);
+        setConfirmError(null);
+        setIsOpen(false);
+        setConfirmOpen(true);
+        return;
+      }
+
       await onUpdate(newDestination);
       setIsOpen(false);
       toast.success(
@@ -52,9 +128,33 @@ export function MirrorDestinationEditor({
           : "Destination reset to default"
       );
     } catch (error) {
-      toast.error("Failed to update destination");
+      toast.error(error instanceof Error ? error.message : "Failed to update destination");
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleConfirmMove = async () => {
+    if (!onMoveMirrors) return;
+    setApplying(true);
+    setConfirmError(null);
+    try {
+      const result = await onMoveMirrors(pendingDestination, false);
+      setConfirmOpen(false);
+      const parts = [`moved ${result.moved.length}`];
+      if (result.pending.length > 0) parts.push(`${result.pending.length} waiting for acceptance`);
+      if (result.recorded.length > 0) parts.push(`${result.recorded.length} already there`);
+      if (result.failed.length > 0) parts.push(`${result.failed.length} failed`);
+      const summary = `Destination updated: ${parts.join(", ")}.`;
+      if (result.failed.length > 0) {
+        toast.error(summary, { description: result.failed[0]?.error });
+      } else {
+        toast.success(summary);
+      }
+    } catch (error) {
+      setConfirmError(error instanceof Error ? error.message : "Failed to move the mirrors");
+    } finally {
+      setApplying(false);
     }
   };
 
@@ -67,6 +167,12 @@ export function MirrorDestinationEditor({
     setEditValue(currentDestination || "");
     setIsOpen(false);
   };
+
+  const moveCount = plan?.plan.moves.length ?? 0;
+  const targetOwners = Array.from(
+    new Set((plan?.plan.moves ?? []).map((entry) => entry.to.slice(0, entry.to.indexOf("/"))))
+  );
+  const targetLabel = pendingDestination ?? (targetOwners.length === 1 ? targetOwners[0] : "their default owner");
 
   return (
     <div className={cn("flex items-center gap-2 w-full", className)}>
@@ -104,7 +210,7 @@ export function MirrorDestinationEditor({
             <div>
               <h4 className="font-medium text-sm mb-1">Mirror Destination</h4>
               <p className="text-xs text-muted-foreground">
-                Customize where this organization's repositories are mirrored to in Gitea.
+                Where this organization's repositories are mirrored on {destinationLabel}.
               </p>
             </div>
 
@@ -141,9 +247,28 @@ export function MirrorDestinationEditor({
                   disabled={isLoading}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Leave empty to use the default GitHub organization name
+                  Leave empty to use the source organization name.
                 </p>
               </div>
+
+              {canMove && (
+                <label className="flex cursor-pointer items-start gap-2 text-xs">
+                  <Checkbox
+                    checked={moveMirrors}
+                    onCheckedChange={(checked) => setMoveMirrors(checked === true)}
+                    disabled={isLoading}
+                    className="mt-0.5"
+                  />
+                  <span className="min-w-0">
+                    Also move the mirrored repositories on {destinationLabel}
+                    <span className="block text-muted-foreground">
+                      {moveMirrors
+                        ? `Transfers each mirrored repository of this organization, except ones with their own destination. You confirm the list first.`
+                        : `Existing mirrors stay where they are and keep syncing. The new destination applies to repositories mirrored from now on.`}
+                    </span>
+                  </span>
+                </label>
+              )}
 
               {/* Quick Actions */}
               {hasOverride && (
@@ -188,6 +313,58 @@ export function MirrorDestinationEditor({
           </div>
         </PopoverContent>
       </Popover>
+
+      {/* The confirmation lives outside the popover, which closes (and would
+          unmount it) as soon as the dialog takes focus. */}
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!open && !applying) setConfirmOpen(false);
+        }}
+      >
+        <DialogContent className="sm:max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle>
+              Move {moveCount} repositor{moveCount === 1 ? "y" : "ies"} to {targetLabel}?
+            </DialogTitle>
+            <DialogDescription>
+              {destinationLabel} transfers each repository with its history, issues and mirror settings, and
+              creates {targetLabel} if it does not exist. Repositories with their own destination are not
+              touched, and nothing is deleted.
+            </DialogDescription>
+          </DialogHeader>
+          {plan && (
+            <div className="min-w-0 space-y-4">
+              <MoveList title="Will move" items={plan.plan.moves.map((entry) => `${entry.from} to ${entry.to}`)} />
+              {plan.plan.skipped.length > 0 && (
+                <MoveList
+                  title="Left alone"
+                  items={plan.plan.skipped.map((entry) => `${entry.fullName} (${entry.reason})`)}
+                />
+              )}
+              <p className="text-[12px] text-muted-foreground">
+                If the token cannot create repositories under {targetLabel}, {destinationLabel} asks an owner
+                of {targetLabel} to accept each transfer. Those mirrors keep syncing where they are until
+                then, and sync follows them once accepted.
+              </p>
+              {confirmError && (
+                <p className="rounded-md border border-rose-500/30 bg-rose-500/5 px-3 py-2 text-sm text-rose-500">
+                  {confirmError}
+                </p>
+              )}
+            </div>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)} disabled={applying}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void handleConfirmMove()} disabled={applying}>
+              {applying ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
+              Move {moveCount}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -11,6 +11,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { buildGiteaWebUrl } from "@/lib/gitea-url";
 import { MirrorDestinationEditor } from "./MirrorDestinationEditor";
+import { destinationInfo } from "@/components/destination/DestinationIcon";
+import type { OrganizationMoveResult } from "@/lib/destination-transfer";
 import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
 import { hasMirrorOverrides, mirrorOptionsToFlags } from "@/lib/utils/mirror-overrides";
 import { useGiteaConfig } from "@/hooks/useGiteaConfig";
@@ -129,6 +131,34 @@ export function OrganizationList({
       await onRefresh();
     }
   };
+
+  // Plan (dryRun) or perform the move of an organization's mirrors on the
+  // destination when its destination changes (issue #400).
+  const handleMoveMirrors = async (
+    orgId: string,
+    newDestination: string | null,
+    dryRun: boolean
+  ): Promise<OrganizationMoveResult> => {
+    const response = await fetch(`${withBase("/api/organizations")}/${orgId}/move-mirrors`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ destinationOrg: newDestination, dryRun }),
+    });
+    const data = (await response.json().catch(() => ({}))) as Partial<OrganizationMoveResult> & {
+      success?: boolean;
+      error?: string;
+    };
+    if (!response.ok || !data.success || !data.plan) {
+      throw new Error(data.error || "Failed to move the mirrors");
+    }
+    if (!dryRun && onRefresh) {
+      await onRefresh();
+    }
+    return data as OrganizationMoveResult;
+  };
+
+  // GitHub and GitLab destinations are pushed to; only Gitea and Forgejo can transfer a repository.
+  const destination = destinationInfo(giteaConfig);
 
   const hasAnyFilter = Object.values(filter).some(
     (val) => val?.toString().trim() !== ""
@@ -282,6 +312,12 @@ export function OrganizationList({
                   organizationName={org.name!}
                   currentDestination={org.destinationOrg ?? undefined}
                   onUpdate={(newDestination) => handleUpdateDestination(org.id!, newDestination)}
+                  onMoveMirrors={
+                    destination.isPushTarget
+                      ? undefined
+                      : (newDestination, dryRun) => handleMoveMirrors(org.id!, newDestination, dryRun)
+                  }
+                  destinationLabel={destination.label}
                   isUpdating={isLoading}
                 />
               </div>
@@ -338,6 +374,12 @@ export function OrganizationList({
                   organizationName={org.name!}
                   currentDestination={org.destinationOrg ?? undefined}
                   onUpdate={(newDestination) => handleUpdateDestination(org.id!, newDestination)}
+                  onMoveMirrors={
+                    destination.isPushTarget
+                      ? undefined
+                      : (newDestination, dryRun) => handleMoveMirrors(org.id!, newDestination, dryRun)
+                  }
+                  destinationLabel={destination.label}
                   isUpdating={isLoading}
                 />
               </div>

--- a/src/components/repositories/InlineDestinationEditor.tsx
+++ b/src/components/repositories/InlineDestinationEditor.tsx
@@ -1,18 +1,41 @@
 import { useState, useRef, useEffect } from "react";
-import { Edit3, Check, X } from "lucide-react";
+import { Edit3, Check, X, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { destinationInfo } from "@/components/destination/DestinationIcon";
 import { cn } from "@/lib/utils";
 import type { Repository } from "@/lib/db/schema";
+
+export interface DestinationUpdateOptions {
+  /** Transfer the existing mirror on the destination as well (issue #400). */
+  moveMirror: boolean;
+}
 
 interface InlineDestinationEditorProps {
   repository: Repository;
   giteaConfig: any;
-  onUpdate: (repoId: string, newDestination: string | null) => Promise<void>;
+  onUpdate: (
+    repoId: string,
+    newDestination: string | null,
+    options: DestinationUpdateOptions
+  ) => Promise<void>;
   isUpdating?: boolean;
   className?: string;
 }
+
+// Statuses in which the mirror is either absent or being worked on, so the
+// label can change but nothing should be transferred right now.
+const CANNOT_MOVE_STATUSES = new Set(["imported", "deleted", "deleting", "mirroring", "syncing"]);
 
 export function InlineDestinationEditor({
   repository,
@@ -24,6 +47,10 @@ export function InlineDestinationEditor({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [pendingChange, setPendingChange] = useState<{ destination: string | null; owner: string } | null>(null);
+  const [moveMirror, setMoveMirror] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Determine the default destination based on repository properties and config
@@ -69,6 +96,17 @@ export function InlineDestinationEditor({
   const hasOverride = repository.destinationOrg && repository.destinationOrg !== defaultDestination;
   const isStarredRepo = repository.isStarred;
 
+  const destination = destinationInfo(giteaConfig);
+  const mirrorLocation = (repository.mirroredLocation ?? "").trim();
+  const mirrorOwner = mirrorLocation.includes("/") ? mirrorLocation.slice(0, mirrorLocation.indexOf("/")) : "";
+  // A mirror that exists on a Gitea or Forgejo destination can move along with the label.
+  const canMove = mirrorOwner !== "" && !destination.isPushTarget && !CANNOT_MOVE_STATUSES.has(repository.status);
+  // The label names one owner while the mirror sits under another: what issue #400 ran into.
+  const labelDisagrees =
+    Boolean(repository.destinationOrg) &&
+    mirrorOwner !== "" &&
+    mirrorOwner.toLowerCase() !== (repository.destinationOrg ?? "").toLowerCase();
+
   useEffect(() => {
     if (isEditing && inputRef.current) {
       inputRef.current.focus();
@@ -91,15 +129,38 @@ export function InlineDestinationEditor({
       return;
     }
 
+    if (canMove) {
+      // The mirror exists: ask whether to move it before writing anything.
+      setPendingChange({ destination: newDestination, owner: trimmedValue || defaultDestination });
+      setMoveMirror(true);
+      setConfirmError(null);
+      setIsEditing(false);
+      return;
+    }
+
     setIsLoading(true);
     try {
-      await onUpdate(repository.id!, newDestination);
+      await onUpdate(repository.id!, newDestination, { moveMirror: false });
       setIsEditing(false);
     } catch (error) {
       // Revert on error
       setEditValue(currentDestination);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingChange) return;
+    setConfirming(true);
+    setConfirmError(null);
+    try {
+      await onUpdate(repository.id!, pendingChange.destination, { moveMirror });
+      setPendingChange(null);
+    } catch (error) {
+      setConfirmError(error instanceof Error ? error.message : "Failed to update the destination");
+    } finally {
+      setConfirming(false);
     }
   };
 
@@ -118,77 +179,147 @@ export function InlineDestinationEditor({
     }
   };
 
+  const targetOwner = pendingChange?.owner ?? "";
+  const confirmDialog = (
+    <Dialog
+      open={pendingChange !== null}
+      onOpenChange={(open) => {
+        if (!open && !confirming) setPendingChange(null);
+      }}
+    >
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Change the destination of {repository.name}</DialogTitle>
+          <DialogDescription>
+            The mirror is at <span className="font-mono">{mirrorLocation}</span> on {destination.label}.
+          </DialogDescription>
+        </DialogHeader>
+        <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-border p-3 text-sm">
+          <Checkbox
+            checked={moveMirror}
+            onCheckedChange={(checked) => setMoveMirror(checked === true)}
+            disabled={confirming}
+            className="mt-0.5"
+          />
+          <span className="min-w-0">
+            Move the mirror to {targetOwner}
+            <span className="block text-[12px] text-muted-foreground">
+              {moveMirror
+                ? `${destination.label} transfers the repository with its history, issues and mirror settings, and creates ${targetOwner} if it does not exist. If the token cannot create repositories under ${targetOwner}, an owner of ${targetOwner} has to accept the transfer, and sync follows once they do.`
+                : `Only the label changes. The mirror stays at ${mirrorLocation} and keeps syncing there. The new destination is used only if the mirror is created again.`}
+            </span>
+          </span>
+        </label>
+        {confirmError && (
+          <p className="rounded-md border border-rose-500/30 bg-rose-500/5 px-3 py-2 text-sm text-rose-500">
+            {confirmError}
+          </p>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => setPendingChange(null)} disabled={confirming}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void handleConfirm()} disabled={confirming}>
+            {confirming ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
+            {moveMirror ? "Move and save" : "Save the label only"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
   if (isEditing) {
     return (
-      <div className={cn("flex items-center gap-1", className)}>
-        <Input
-          ref={inputRef}
-          value={editValue}
-          onChange={(e) => setEditValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onBlur={handleCancel}
-          className="h-6 text-sm px-2 py-0 w-24"
-          disabled={isLoading}
-        />
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-5 w-5 p-0"
-          onClick={handleSave}
-          disabled={isLoading}
-        >
-          <Check className="h-3 w-3" />
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-5 w-5 p-0"
-          onClick={handleCancel}
-          disabled={isLoading}
-        >
-          <X className="h-3 w-3" />
-        </Button>
-      </div>
+      <>
+        <div className={cn("flex items-center gap-1", className)}>
+          <Input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleCancel}
+            className="h-6 text-sm px-2 py-0 w-24"
+            disabled={isLoading}
+          />
+          {/* preventDefault on mousedown keeps the input focused, so its
+              blur (which cancels the edit) does not fire before the click. */}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-5 w-5 p-0"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleSave}
+            disabled={isLoading}
+            title="Save"
+          >
+            <Check className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-5 w-5 p-0"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleCancel}
+            disabled={isLoading}
+            title="Cancel"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+        {confirmDialog}
+      </>
     );
   }
 
   return (
-    <div className={cn("flex flex-col gap-0.5", className)}>
-      {/* Show GitHub org if exists */}
-      {repository.organization && (
-        <span className="text-xs text-muted-foreground">
-          {repository.organization}
-        </span>
-      )}
-      
-      {/* Show Gitea destination */}
-      <div className="flex items-center gap-1 group">
-        <span className="text-sm">
-          {currentDestination || "-"}
-        </span>
-        {hasOverride && (
-          <Badge variant="outline" className="h-4 px-1 text-[10px] ml-1">
-            custom
-          </Badge>
+    <>
+      <div className={cn("flex flex-col gap-0.5", className)}>
+        {/* Show GitHub org if exists */}
+        {repository.organization && (
+          <span className="text-xs text-muted-foreground">
+            {repository.organization}
+          </span>
         )}
-        {isStarredRepo && (
-          <Badge variant="secondary" className="h-4 px-1 text-[10px] ml-1">
-            starred
-          </Badge>
-        )}
-        {!isStarredRepo && (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-4 w-4 p-0 opacity-0 group-hover:opacity-60 hover:opacity-100 ml-1"
-            onClick={handleStartEdit}
-            disabled={isUpdating || isLoading}
-            title="Edit destination"
-          >
-            <Edit3 className="h-3 w-3" />
-          </Button>
-        )}
+        
+        {/* Show Gitea destination */}
+        <div className="flex items-center gap-1 group">
+          <span className="text-sm">
+            {currentDestination || "-"}
+          </span>
+          {hasOverride && (
+            <Badge variant="outline" className="h-4 px-1 text-[10px] ml-1">
+              custom
+            </Badge>
+          )}
+          {labelDisagrees && (
+            <Badge
+              variant="outline"
+              className="h-4 px-1 text-[10px] ml-1 border-amber-500/60 text-amber-600 dark:text-amber-400"
+              title={`The mirror is at ${mirrorLocation}, not under ${repository.destinationOrg}. Edit the destination and tick Move to transfer it, or run Reconcile with destination.`}
+            >
+              at {mirrorOwner}
+            </Badge>
+          )}
+          {isStarredRepo && (
+            <Badge variant="secondary" className="h-4 px-1 text-[10px] ml-1">
+              starred
+            </Badge>
+          )}
+          {!isStarredRepo && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-4 w-4 p-0 opacity-0 group-hover:opacity-60 hover:opacity-100 ml-1"
+              onClick={handleStartEdit}
+              disabled={isUpdating || isLoading}
+              title="Edit destination"
+            >
+              <Edit3 className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
       </div>
-    </div>
+      {confirmDialog}
+    </>
   );
 }

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -28,7 +28,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { InlineDestinationEditor } from "./InlineDestinationEditor";
+import { toast } from "sonner";
+import { InlineDestinationEditor, type DestinationUpdateOptions } from "./InlineDestinationEditor";
 import { MarqueeText, MarqueeTrigger } from "@/components/ui/marquee-text";
 import { MirrorOverridesDialog } from "@/components/config/MirrorOverridesDialog";
 import {
@@ -208,7 +209,38 @@ export default function RepositoryTable({
     }
   };
 
-  const handleUpdateDestination = async (repoId: string, newDestination: string | null) => {
+  const handleUpdateDestination = async (
+    repoId: string,
+    newDestination: string | null,
+    options?: DestinationUpdateOptions
+  ) => {
+    if (options?.moveMirror) {
+      // Transfer the mirror on the destination and record where it went (issue #400).
+      const response = await fetch(`${withBase("/api/repositories")}/${repoId}/move-mirror`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ destinationOrg: newDestination }),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        success?: boolean;
+        error?: string;
+        transfer?: { outcome: string; message: string };
+      };
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || "Failed to move the mirror");
+      }
+      const message = data.transfer?.message ?? "Destination updated";
+      if (data.transfer?.outcome === "pending") {
+        toast.info(message);
+      } else {
+        toast.success(message);
+      }
+      if (onRefresh) {
+        await onRefresh();
+      }
+      return;
+    }
+
     // Call API to update repository destination
     const response = await fetch(`${withBase("/api/repositories")}/${repoId}`, {
       method: "PATCH",

--- a/src/lib/destination-reconcile-service.ts
+++ b/src/lib/destination-reconcile-service.ts
@@ -3,9 +3,9 @@
  *
  * Lists what the destination holds under every owner this account mirrors
  * into, sorts it against the database (see destination-reconcile.ts), and
- * on request adopts untracked mirrors or resets rows whose mirror is gone.
- * It never deletes or archives anything on either side; the cleanup service
- * keeps its own rules for that.
+ * on request adopts untracked mirrors, records where moved mirrors went, or
+ * resets rows whose mirror is gone. It never deletes or archives anything on
+ * either side; the cleanup service keeps its own rules for that.
  */
 
 import { and, eq, inArray } from "drizzle-orm";
@@ -40,6 +40,8 @@ export interface ReconcileOptions {
   dryRun: boolean;
   adoptUntracked: boolean;
   resetMissing: boolean;
+  /** Repoint rows whose mirror was transferred to another owner (issue #400). */
+  relocateMoved?: boolean;
 }
 
 export interface ReconcileReport {
@@ -52,6 +54,8 @@ export interface ReconcileReport {
   }>;
   /** Rows that say mirrored, whose repository the destination no longer has. */
   missing: Array<{ id: string; fullName: string; location: string }>;
+  /** Rows whose recorded mirror is gone while their source is mirrored under another owner. */
+  moved: Array<{ id: string; fullName: string; from: string; to: string }>;
   /** Repositories on the destination this app does not own. */
   notManaged: Array<{ location: string; reason: string }>;
   /** Rows whose presence could not be confirmed because the check itself failed. */
@@ -68,7 +72,7 @@ export interface ReconcileResult {
   dryRun: boolean;
   report: ReconcileReport;
   /** Null on a dry run. */
-  applied: { adopted: number; reset: number; skipped: number } | null;
+  applied: { adopted: number; reset: number; relocated: number; skipped: number } | null;
 }
 
 /** The subset of Gitea's repository JSON the reconcile reads. */
@@ -291,22 +295,31 @@ export async function reconcileDestination(
       isPrivate: repo.isPrivate,
     })),
     missing,
+    moved: classified.moved.map((entry) => ({
+      id: entry.row.id,
+      fullName: entry.row.fullName,
+      from: entry.row.mirroredLocation ?? "",
+      to: entry.location,
+    })),
     notManaged: classified.notManaged,
     unverified,
-    healthyCount: classified.matchedRowIds.size + confirmedPresent,
+    // Moved rows are present but recorded wrong; they are listed on their own.
+    healthyCount: classified.matchedRowIds.size - classified.moved.length + confirmedPresent,
     elsewhereCount: elsewhere.length,
     scannedOwners,
     skippedOwners,
     totalOnDestination: destinationRepos.length,
   };
 
-  if (options.dryRun || (!options.adoptUntracked && !options.resetMissing)) {
+  const relocateMoved = options.relocateMoved === true;
+  if (options.dryRun || (!options.adoptUntracked && !options.resetMissing && !relocateMoved)) {
     return { dryRun: true, report, applied: null };
   }
 
   let adopted = 0;
   let skipped = 0;
   let reset = 0;
+  let relocated = 0;
 
   if (options.adoptUntracked && classified.untracked.length > 0) {
     const sourceProvider = createSourceProviderFromConfig(config, { userId });
@@ -349,18 +362,64 @@ export async function reconcileDestination(
     reset = updated.length;
   }
 
-  if (adopted > 0 || reset > 0) {
+  if (relocateMoved && classified.moved.length > 0) {
+    const rowsById = new Map(rows.map((row) => [row.id, row]));
+    for (const entry of classified.moved) {
+      const row = rowsById.get(entry.row.id);
+      if (!row) {
+        skipped += 1;
+        continue;
+      }
+      const newOwner = entry.location.split("/")[0];
+
+      // Pin the row to its new owner when the strategy would resolve
+      // elsewhere, as adoption does, so a later reset does not recreate the
+      // mirror at the old place. The strategy already honours the row's own
+      // override, so an override pointing at the old owner is replaced.
+      let destinationOrg = row.destinationOrg ?? null;
+      try {
+        const strategyOwner = await getGiteaRepoOwnerAsync({ config, repository: row as Repository });
+        if (strategyOwner.trim().toLowerCase() !== newOwner.toLowerCase()) {
+          destinationOrg = newOwner;
+        }
+      } catch {
+        destinationOrg = newOwner;
+      }
+
+      try {
+        await db
+          .update(repositories)
+          .set({
+            mirroredLocation: entry.location,
+            destinationOrg,
+            // A sync that failed because the mirror was not at the recorded
+            // place is healthy again once the row points at it.
+            ...(row.status === "failed" ? { status: "mirrored", errorMessage: null } : {}),
+            updatedAt: new Date(),
+          })
+          .where(and(eq(repositories.userId, userId), eq(repositories.id, row.id)));
+        relocated += 1;
+      } catch (error) {
+        skipped += 1;
+        console.warn(
+          `[Reconcile] Could not record the new location of ${row.fullName}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+
+  if (adopted > 0 || reset > 0 || relocated > 0) {
     await createMirrorJob({
       userId,
       status: "synced",
       jobType: "sync",
       message: "Reconciled the database with the destination",
-      details: `Adopted ${adopted} untracked mirror${adopted === 1 ? "" : "s"}, reset ${reset} row${reset === 1 ? "" : "s"} whose mirror was gone.`,
+      details: `Adopted ${adopted} untracked mirror${adopted === 1 ? "" : "s"}, recorded the new location of ${relocated} moved mirror${relocated === 1 ? "" : "s"}, reset ${reset} row${reset === 1 ? "" : "s"} whose mirror was gone.`,
       skipNotification: true,
     });
   }
 
-  return { dryRun: false, report, applied: { adopted, reset, skipped } };
+  return { dryRun: false, report, applied: { adopted, reset, relocated, skipped } };
 }
 
 /**

--- a/src/lib/destination-reconcile.test.ts
+++ b/src/lib/destination-reconcile.test.ts
@@ -176,7 +176,7 @@ describe("classifyDestinationRepos", () => {
     expect(result.unmatchedMirroredRows).toEqual([]);
   });
 
-  test("matches a row by clone URL when the recorded location is stale", () => {
+  test("a mirror found elsewhere while the recorded location is gone is matched and reported as moved (#400)", () => {
     const result = classifyDestinationRepos({
       destinationRepos: [
         destinationRepo({ fullName: "moved/hello", originalUrl: "https://github.com/octocat/hello.git" }),
@@ -185,6 +185,49 @@ describe("classifyDestinationRepos", () => {
       knownHosts,
     });
     expect(result.untracked).toEqual([]);
+    expect(result.matchedRowIds.has("octocat/hello")).toBeTrue();
+    expect(result.unmatchedMirroredRows).toEqual([]);
+    expect(result.moved.map((m) => [m.row.id, m.location])).toEqual([["octocat/hello", "moved/hello"]]);
+  });
+
+  test("a second copy is not a move while the recorded mirror is still there", () => {
+    const result = classifyDestinationRepos({
+      destinationRepos: [
+        destinationRepo({ fullName: "copy/hello", originalUrl: "https://github.com/octocat/hello.git" }),
+        destinationRepo({ fullName: "mirrors/hello", originalUrl: "https://github.com/octocat/hello.git" }),
+      ],
+      rows: [row({ fullName: "octocat/hello", mirroredLocation: "mirrors/hello" })],
+      knownHosts,
+    });
+    expect(result.moved).toEqual([]);
+    expect(result.untracked).toEqual([]);
+    expect(result.notManaged).toEqual([{ location: "copy/hello", reason: "second copy of mirrors/hello" }]);
+    expect(result.trackedLocations.has("mirrors/hello")).toBeTrue();
+    expect(result.trackedLocations.has("copy/hello")).toBeFalse();
+  });
+
+  test("only the first of two relocated copies counts as the move", () => {
+    const result = classifyDestinationRepos({
+      destinationRepos: [
+        destinationRepo({ fullName: "a/hello", originalUrl: "https://github.com/octocat/hello.git" }),
+        destinationRepo({ fullName: "b/hello", originalUrl: "https://github.com/octocat/hello.git" }),
+      ],
+      rows: [row({ fullName: "octocat/hello", mirroredLocation: "gone/hello" })],
+      knownHosts,
+    });
+    expect(result.moved.map((m) => m.location)).toEqual(["a/hello"]);
+    expect(result.notManaged).toEqual([{ location: "b/hello", reason: "second copy of a/hello" }]);
+  });
+
+  test("a row without a recorded location is matched by source and not reported as moved", () => {
+    const result = classifyDestinationRepos({
+      destinationRepos: [
+        destinationRepo({ fullName: "mirrors/hello", originalUrl: "https://github.com/octocat/hello.git" }),
+      ],
+      rows: [row({ fullName: "octocat/hello" })],
+      knownHosts,
+    });
+    expect(result.moved).toEqual([]);
     expect(result.matchedRowIds.has("octocat/hello")).toBeTrue();
   });
 

--- a/src/lib/destination-reconcile.ts
+++ b/src/lib/destination-reconcile.ts
@@ -5,9 +5,10 @@
  * The database is the only thing the cleanup service and the UI look at, so
  * a mirror that exists on the destination without a row is invisible to
  * every maintenance feature (issue #284). The helpers here take what the
- * destination reports and what the database holds and sort it into three
+ * destination reports and what the database holds and sort it into four
  * groups: mirrors the database does not know about, rows whose mirror is
- * gone, and everything that matches. They never touch the network or the
+ * gone, rows whose mirror moved to another owner (issue #400), and
+ * everything that matches. They never touch the network or the
  * database, so they are unit tested directly; the async orchestration lives
  * in destination-reconcile-service.ts.
  */
@@ -93,6 +94,20 @@ export interface ClassifiedDestination {
   matchedRowIds: Set<string>;
   /** Rows that claim to be mirrored but no destination repository matched. */
   unmatchedMirroredRows: TrackedRepositoryRow[];
+  /**
+   * Rows whose recorded location is gone from the destination while a mirror
+   * of the same source sits somewhere else: someone transferred it there
+   * (issue #400). Sync only looks at the recorded and the expected location,
+   * so until the row is repointed every run fails and a retry would create a
+   * second copy at the old place.
+   */
+  moved: MovedMirror[];
+}
+
+export interface MovedMirror {
+  row: TrackedRepositoryRow;
+  /** `owner/name` where the destination has the mirror now. */
+  location: string;
 }
 
 /** Statuses that mean "the mirror is supposed to exist on the destination". */
@@ -219,10 +234,18 @@ export function classifyDestinationRepos({
     if (fullName && !byFullName.has(fullName)) byFullName.set(fullName, row);
   }
 
+  // Every mirror the listing showed, so a source match at a new location can
+  // be told apart from a second copy whose original is still in place.
+  const listedMirrorLocations = new Set(
+    destinationRepos.filter((repo) => repo.mirror).map((repo) => repo.fullName.toLowerCase())
+  );
+
   const untracked: DestinationRepo[] = [];
   const notManaged: NotManagedRepo[] = [];
   const trackedLocations = new Set<string>();
   const matchedRowIds = new Set<string>();
+  const moved: MovedMirror[] = [];
+  const movedRowIds = new Set<string>();
 
   for (const repo of destinationRepos) {
     const location = repo.fullName.toLowerCase();
@@ -243,24 +266,41 @@ export function classifyDestinationRepos({
       continue;
     }
 
+    const atRecordedLocation = byLocation.get(location);
     const row =
-      byLocation.get(location) ??
+      atRecordedLocation ??
       byCloneKey.get(`${origin.host}/${origin.path.toLowerCase()}`) ??
       byFullName.get(origin.path.toLowerCase());
 
-    if (row) {
-      trackedLocations.add(location);
-      matchedRowIds.add(row.id);
-    } else {
+    if (!row) {
       untracked.push(repo);
+      continue;
     }
+
+    // Matched by source rather than by the recorded location. That is a move
+    // only when the recorded mirror is really gone; if it is still listed,
+    // this repository is a second copy and is left alone.
+    const recorded = (row.mirroredLocation ?? "").trim();
+    if (!atRecordedLocation && recorded && recorded.toLowerCase() !== location) {
+      const originalStillThere = listedMirrorLocations.has(recorded.toLowerCase());
+      if (originalStillThere || movedRowIds.has(row.id)) {
+        const original = originalStillThere ? recorded : moved.find((m) => m.row.id === row.id)?.location;
+        notManaged.push({ location: repo.fullName, reason: `second copy of ${original ?? recorded}` });
+        continue;
+      }
+      moved.push({ row, location: repo.fullName });
+      movedRowIds.add(row.id);
+    }
+
+    trackedLocations.add(location);
+    matchedRowIds.add(row.id);
   }
 
   const unmatchedMirroredRows = rows.filter(
     (row) => MIRRORED_STATUSES.has(row.status) && !matchedRowIds.has(row.id)
   );
 
-  return { untracked, notManaged, trackedLocations, matchedRowIds, unmatchedMirroredRows };
+  return { untracked, notManaged, trackedLocations, matchedRowIds, unmatchedMirroredRows, moved };
 }
 
 /**

--- a/src/lib/destination-transfer-service.test.ts
+++ b/src/lib/destination-transfer-service.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Tests for moving a mirror to another owner (issue #400). The destination
+ * is replaced by injected functions, so each test states what sits at the
+ * recorded location, what the search finds, what sits under the target and
+ * how the transfer answers, then checks what the service records.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import type { Config } from "@/types/config";
+import type { Repository } from "@/lib/db/schema";
+import type { MoveDeps } from "./destination-transfer-service";
+import type { MoveErrorCode } from "./destination-transfer";
+
+const dbUpdateSetCalls: any[] = [];
+let selectRows: any[] = [];
+const mockDb = {
+  select: mock(() => ({
+    from: mock(() => ({
+      where: mock(() => {
+        const rows = selectRows;
+        const result: any = Promise.resolve(rows);
+        result.orderBy = mock(() => Promise.resolve(rows));
+        result.limit = mock(() => Promise.resolve(rows));
+        return result;
+      }),
+    })),
+  })),
+  update: mock(() => ({
+    set: mock((data: any) => {
+      dbUpdateSetCalls.push(data);
+      return { where: mock(() => Promise.resolve()) };
+    }),
+  })),
+};
+
+mock.module("@/lib/db", () => ({
+  db: mockDb,
+  users: {},
+  configs: {},
+  organizations: {},
+  mirrorJobs: {},
+  repositories: {},
+  events: {},
+  accounts: {},
+  sessions: {},
+}));
+
+const mockCreateMirrorJob = mock(() => Promise.resolve("job-id"));
+mock.module("@/lib/helpers", () => ({ createMirrorJob: mockCreateMirrorJob }));
+
+mock.module("@/lib/utils/config-encryption", () => ({
+  decryptConfigTokens: (config: any) => config,
+  encryptConfigTokens: (config: any) => config,
+  getDecryptedGitHubToken: (config: any) => config.githubConfig?.token || "",
+  getDecryptedGiteaToken: (config: any) => config.giteaConfig?.token || "",
+}));
+
+class MockHttpError extends Error {
+  constructor(message: string, public status: number, public statusText: string, public response?: string) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+const httpGetRoutes: Array<{ matches: (url: string) => boolean; respond: () => any }> = [];
+const mockHttpGet = mock(async (url: string) => {
+  const route = httpGetRoutes.find((r) => r.matches(url));
+  if (!route) throw new MockHttpError(`HTTP 404: ${url}`, 404, "Not Found");
+  return route.respond();
+});
+const mockHttpPost = mock(async (_url: string, body?: any) => ({
+  data: { id: 5, username: body?.username },
+  status: 201,
+  statusText: "Created",
+  headers: new Headers(),
+}));
+
+mock.module("@/lib/http-client", () => ({
+  HttpError: MockHttpError,
+  httpRequest: mock(async () => ({ data: {}, status: 200, statusText: "OK", headers: new Headers() })),
+  GiteaHttpClient: class {},
+  httpGet: mockHttpGet,
+  httpPost: mockHttpPost,
+  httpPatch: mock(async () => ({ data: {}, status: 200, statusText: "OK", headers: new Headers() })),
+  httpPut: mock(async () => ({ data: {}, status: 200, statusText: "OK", headers: new Headers() })),
+  httpDelete: mock(async () => ({ data: {}, status: 204, statusText: "No Content", headers: new Headers() })),
+}));
+
+const { moveMirror, moveOrganizationMirrors, ensureDestinationOwner } = await import(
+  "./destination-transfer-service"
+);
+const { MoveMirrorError } = await import("./destination-transfer");
+
+const config = {
+  userId: "user-1",
+  githubConfig: { token: "gh-token", owner: "octocat", mirrorStrategy: "preserve" },
+  giteaConfig: {
+    url: "https://gitea.example.com",
+    token: "gitea-token",
+    defaultOwner: "me",
+    provider: "gitea",
+  },
+} as unknown as Partial<Config>;
+
+const pushConfig = {
+  ...config,
+  giteaConfig: { ...(config.giteaConfig as object), url: "https://github.com", provider: "github" },
+} as unknown as Partial<Config>;
+
+function repo(overrides: Record<string, unknown> = {}): Repository {
+  return {
+    id: "r1",
+    userId: "user-1",
+    name: "hello",
+    fullName: "octocat/hello",
+    owner: "octocat",
+    organization: null,
+    url: "https://github.com/octocat/hello",
+    cloneUrl: "https://github.com/octocat/hello.git",
+    mirroredLocation: "mirrors/hello",
+    status: "mirrored",
+    isStarred: false,
+    destinationOrg: null,
+    sourceProvider: "github",
+    sourceUrl: "https://github.com",
+    destinationProvider: "gitea",
+    destinationUrl: "https://gitea.example.com",
+    ...overrides,
+  } as unknown as Repository;
+}
+
+function info(owner: string, name: string, originalUrl: string | undefined = "https://github.com/octocat/hello.git") {
+  return { id: 1, name, owner: { login: owner }, mirror: true, original_url: originalUrl, private: false };
+}
+
+/** The destination as a map of "owner/name" to what GET /repos answers, plus what the search and the transfer do. */
+function deps(present: Record<string, any>, overrides: Partial<MoveDeps> = {}) {
+  const lookups: string[] = [];
+  return {
+    lookups,
+    getRepoInfo: mock(async ({ owner, repoName }: { owner: string; repoName: string }) => {
+      lookups.push(`${owner}/${repoName}`);
+      const key = Object.keys(present).find((k) => k.toLowerCase() === `${owner}/${repoName}`.toLowerCase());
+      return key ? present[key] : null;
+    }),
+    searchBySource: mock(async () => null),
+    ensureOwner: mock(async () => {}),
+    transfer: mock(async ({ repoName, newOwner }: { repoName: string; newOwner: string }) => ({
+      pending: false,
+      repo: info(newOwner, repoName),
+    })),
+    ...overrides,
+  } as MoveDeps & { lookups: string[] };
+}
+
+async function expectMoveError(promise: Promise<unknown>, code: MoveErrorCode, status: number) {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(MoveMirrorError);
+  expect((caught as InstanceType<typeof MoveMirrorError>).code).toBe(code);
+  expect((caught as InstanceType<typeof MoveMirrorError>).status).toBe(status);
+  return caught as InstanceType<typeof MoveMirrorError>;
+}
+
+beforeEach(() => {
+  dbUpdateSetCalls.length = 0;
+  selectRows = [];
+  httpGetRoutes.length = 0;
+  mockCreateMirrorJob.mockClear();
+  mockHttpGet.mockClear();
+  mockHttpPost.mockClear();
+});
+
+describe("moveMirror", () => {
+  test("a row that was never mirrored has nothing to move", async () => {
+    const d = deps({});
+    const result = await moveMirror({
+      userId: "user-1",
+      config,
+      repository: repo({ mirroredLocation: "" }),
+      newOwner: "archive",
+      deps: d,
+    });
+
+    expect(result.outcome).toBe("not-mirrored");
+    expect(d.getRepoInfo).not.toHaveBeenCalled();
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("transfers the mirror at the recorded location and records where it landed", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello") });
+    const result = await moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d });
+
+    expect(result).toMatchObject({ outcome: "moved", from: "mirrors/hello", to: "archive/hello" });
+    expect(d.lookups).toEqual(["mirrors/hello", "archive/hello"]);
+    expect(d.searchBySource).not.toHaveBeenCalled();
+    expect(d.ensureOwner).toHaveBeenCalledWith({ config, owner: "archive" });
+    expect(d.transfer).toHaveBeenCalledWith({ config, owner: "mirrors", repoName: "hello", newOwner: "archive" });
+    expect(dbUpdateSetCalls).toHaveLength(1);
+    expect(dbUpdateSetCalls[0]).toMatchObject({ mirroredLocation: "archive/hello" });
+    expect(dbUpdateSetCalls[0].status).toBeUndefined();
+    expect(mockCreateMirrorJob).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed row is healthy again once its mirror has moved", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello") });
+    await moveMirror({ userId: "user-1", config, repository: repo({ status: "failed" }), newOwner: "archive", deps: d });
+
+    expect(dbUpdateSetCalls[0]).toMatchObject({ mirroredLocation: "archive/hello", status: "mirrored", errorMessage: null });
+  });
+
+  test("trusts a mirror at the recorded location that reports no source URL", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello", undefined) });
+    const result = await moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d });
+
+    expect(result.outcome).toBe("moved");
+    expect(d.searchBySource).not.toHaveBeenCalled();
+  });
+
+  test("finds a mirror someone moved by hand and transfers it from there", async () => {
+    const d = deps(
+      { "other-org/hello": info("other-org", "hello") },
+      { searchBySource: mock(async () => info("other-org", "hello")) }
+    );
+    const result = await moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d });
+
+    expect(result).toMatchObject({ outcome: "moved", from: "mirrors/hello", to: "archive/hello" });
+    expect(d.transfer).toHaveBeenCalledWith({ config, owner: "other-org", repoName: "hello", newOwner: "archive" });
+    expect(dbUpdateSetCalls[0]).toMatchObject({ mirroredLocation: "archive/hello" });
+  });
+
+  test("a different repository at the recorded location does not count as ours", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello", "https://github.com/other/hello.git") });
+    await expectMoveError(
+      moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d }),
+      "not-on-destination",
+      409
+    );
+
+    expect(d.searchBySource).toHaveBeenCalledTimes(1);
+    expect(d.transfer).not.toHaveBeenCalled();
+  });
+
+  test("refuses when the mirror is nowhere on the destination", async () => {
+    const d = deps({});
+    const error = await expectMoveError(
+      moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d }),
+      "not-on-destination",
+      409
+    );
+
+    expect(error.message).toContain("Reconcile");
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("only records when the mirror is already under the new owner", async () => {
+    const d = deps({ "Archive/hello": info("Archive", "hello") });
+    const result = await moveMirror({
+      userId: "user-1",
+      config,
+      repository: repo({ mirroredLocation: "Archive/hello" }),
+      newOwner: "archive",
+      deps: d,
+    });
+
+    expect(result).toMatchObject({ outcome: "recorded", to: "Archive/hello" });
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("points the row at a same-source mirror that already sits under the target", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello"), "archive/hello": info("archive", "hello") });
+    const result = await moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d });
+
+    expect(result).toMatchObject({ outcome: "recorded", from: "mirrors/hello", to: "archive/hello" });
+    expect(result.message).toContain("left alone");
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls[0]).toMatchObject({ mirroredLocation: "archive/hello" });
+  });
+
+  test("refuses to move onto a different repository of the same name", async () => {
+    const d = deps({
+      "mirrors/hello": info("mirrors", "hello"),
+      "archive/hello": info("archive", "hello", "https://github.com/other/hello.git"),
+    });
+    await expectMoveError(
+      moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d }),
+      "name-taken",
+      409
+    );
+
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("a pending transfer leaves the recorded location alone", async () => {
+    const d = deps(
+      { "mirrors/hello": info("mirrors", "hello") },
+      { transfer: mock(async () => ({ pending: true, repo: info("mirrors", "hello") })) }
+    );
+    const result = await moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d });
+
+    expect(result).toMatchObject({ outcome: "pending", from: "mirrors/hello", to: "archive/hello" });
+    expect(result.message).toContain("accept");
+    expect(dbUpdateSetCalls).toHaveLength(0);
+    expect(mockCreateMirrorJob).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps the destination's answers to reasons a user can act on", async () => {
+    const cases: Array<[number, MoveErrorCode, number]> = [
+      [409, "transfer-pending", 409],
+      [422, "name-taken", 409],
+      [403, "forbidden", 403],
+      [404, "not-on-destination", 409],
+      [500, "destination-error", 502],
+    ];
+    for (const [httpStatus, code, status] of cases) {
+      const d = deps(
+        { "mirrors/hello": info("mirrors", "hello") },
+        {
+          transfer: mock(async () => {
+            throw new MockHttpError(`HTTP ${httpStatus}`, httpStatus, "Error");
+          }),
+        }
+      );
+      await expectMoveError(
+        moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d }),
+        code,
+        status
+      );
+    }
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+
+  test("refuses push destinations before touching anything", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello") });
+    await expectMoveError(
+      moveMirror({
+        userId: "user-1",
+        config: pushConfig,
+        repository: repo({ destinationProvider: "github", destinationUrl: "https://github.com" }),
+        newOwner: "archive",
+        deps: d,
+      }),
+      "destination-unsupported",
+      400
+    );
+    expect(d.getRepoInfo).not.toHaveBeenCalled();
+  });
+
+  test("refuses a row that was mirrored to another host", async () => {
+    const d = deps({ "mirrors/hello": info("mirrors", "hello") });
+    await expectMoveError(
+      moveMirror({
+        userId: "user-1",
+        config,
+        repository: repo({ destinationUrl: "https://other.example.com" }),
+        newOwner: "archive",
+        deps: d,
+      }),
+      "destination-mismatch",
+      409
+    );
+    expect(d.getRepoInfo).not.toHaveBeenCalled();
+  });
+
+  test("a target owner that cannot be prepared stops the move", async () => {
+    const d = deps(
+      { "mirrors/hello": info("mirrors", "hello") },
+      {
+        ensureOwner: mock(async () => {
+          throw new Error("Permission denied: cannot create organizations");
+        }),
+      }
+    );
+    const error = await expectMoveError(
+      moveMirror({ userId: "user-1", config, repository: repo(), newOwner: "archive", deps: d }),
+      "destination-error",
+      502
+    );
+    expect(error.message).toContain("Permission denied");
+    expect(d.transfer).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureDestinationOwner", () => {
+  test("the account itself always exists", async () => {
+    await ensureDestinationOwner({ config, owner: "Me" });
+    expect(mockHttpGet).not.toHaveBeenCalled();
+    expect(mockHttpPost).not.toHaveBeenCalled();
+  });
+
+  test("an existing user or organization is left alone", async () => {
+    httpGetRoutes.push({
+      matches: (url) => url.endsWith("/api/v1/users/archive"),
+      respond: () => ({ data: { id: 3, login: "archive" }, status: 200, statusText: "OK", headers: new Headers() }),
+    });
+    await ensureDestinationOwner({ config, owner: "archive" });
+    expect(mockHttpGet).toHaveBeenCalledTimes(1);
+    expect(mockHttpPost).not.toHaveBeenCalled();
+  });
+
+  test("an unknown name is created as an organization, the way a mirror run does", async () => {
+    httpGetRoutes.push({
+      matches: (url) => url.endsWith("/api/v1/user"),
+      respond: () => ({ data: { id: 1, login: "me", username: "me" }, status: 200, statusText: "OK", headers: new Headers() }),
+    });
+    await ensureDestinationOwner({ config, owner: "archive" });
+
+    const orgCreate = mockHttpPost.mock.calls.find((call) => String(call[0]).endsWith("/api/v1/orgs"));
+    expect(orgCreate).toBeDefined();
+    expect((orgCreate as any[])[1]?.username).toBe("archive");
+  });
+});
+
+describe("moveOrganizationMirrors", () => {
+  const orgRepo = (id: string, name: string, overrides: Record<string, unknown> = {}) =>
+    repo({
+      id,
+      name,
+      fullName: `acme/${name}`,
+      organization: "acme",
+      url: `https://github.com/acme/${name}`,
+      cloneUrl: `https://github.com/acme/${name}.git`,
+      mirroredLocation: `acme/${name}`,
+      ...overrides,
+    });
+  const orgInfo = (owner: string, name: string) => info(owner, name, `https://github.com/acme/${name}.git`);
+
+  test("a dry run returns the plan and moves nothing", async () => {
+    selectRows = [
+      orgRepo("a", "api"),
+      orgRepo("b", "custom", { destinationOrg: "elsewhere" }),
+      orgRepo("c", "new", { mirroredLocation: "" }),
+    ];
+    const d = deps({ "acme/api": orgInfo("acme", "api") });
+    const result = await moveOrganizationMirrors({
+      userId: "user-1",
+      config,
+      organization: { id: "o1", name: "acme" },
+      destinationOrg: "archive",
+      dryRun: true,
+      deps: d,
+      strategyOwnerFor: (row) => row.organization ?? "me",
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.plan.moves).toEqual([{ id: "a", fullName: "acme/api", from: "acme/api", to: "archive/api" }]);
+    expect(result.plan.skipped.map((s) => s.fullName)).toEqual(["acme/custom", "acme/new"]);
+    expect(d.getRepoInfo).not.toHaveBeenCalled();
+    expect(d.transfer).not.toHaveBeenCalled();
+    expect(mockCreateMirrorJob).not.toHaveBeenCalled();
+  });
+
+  test("moves what it can, reports what it cannot, and logs a summary", async () => {
+    selectRows = [orgRepo("a", "api"), orgRepo("d", "locked")];
+    const d = deps(
+      { "acme/api": orgInfo("acme", "api"), "acme/locked": orgInfo("acme", "locked") },
+      {
+        transfer: mock(async ({ repoName, newOwner }: { repoName: string; newOwner: string }) => {
+          if (repoName === "locked") throw new MockHttpError("HTTP 403", 403, "Forbidden");
+          return { pending: false, repo: orgInfo(newOwner, repoName) };
+        }),
+      }
+    );
+    const result = await moveOrganizationMirrors({
+      userId: "user-1",
+      config,
+      organization: { id: "o1", name: "acme" },
+      destinationOrg: "archive",
+      dryRun: false,
+      deps: d,
+      strategyOwnerFor: (row) => row.organization ?? "me",
+    });
+
+    expect(result.moved).toEqual([{ fullName: "acme/api", from: "acme/api", to: "archive/api" }]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].fullName).toBe("acme/locked");
+    expect(result.failed[0].error).toContain("not allowed");
+    expect(dbUpdateSetCalls).toEqual([expect.objectContaining({ mirroredLocation: "archive/api" })]);
+
+    const summary = mockCreateMirrorJob.mock.calls.map((call: any[]) => call[0]).find((job: any) => job.organizationName === "acme");
+    expect(summary).toBeDefined();
+    expect((summary as any).details).toContain("Moved 1");
+    expect((summary as any).details).toContain("failed 1");
+  });
+
+  test("removing the override sends rows back to where the strategy puts them", async () => {
+    selectRows = [orgRepo("a", "api", { mirroredLocation: "old/api" }), orgRepo("e", "here")];
+    const d = deps({ "old/api": orgInfo("old", "api"), "acme/here": orgInfo("acme", "here") });
+    const result = await moveOrganizationMirrors({
+      userId: "user-1",
+      config,
+      organization: { id: "o1", name: "acme" },
+      destinationOrg: null,
+      dryRun: false,
+      deps: d,
+      strategyOwnerFor: (row) => row.organization ?? "me",
+    });
+
+    expect(result.plan.moves.map((m) => m.to)).toEqual(["acme/api"]);
+    expect(result.plan.skipped).toEqual([{ fullName: "acme/here", reason: "already under acme" }]);
+    expect(result.moved).toEqual([{ fullName: "acme/api", from: "old/api", to: "acme/api" }]);
+    expect(d.transfer).toHaveBeenCalledWith({ config, owner: "old", repoName: "api", newOwner: "acme" });
+  });
+});

--- a/src/lib/destination-transfer-service.ts
+++ b/src/lib/destination-transfer-service.ts
@@ -1,0 +1,460 @@
+/**
+ * Move mirrors to another owner on the destination (Gitea or Forgejo), for
+ * issue #400. One repository at a time, or every mirrored repository of an
+ * organization. Nothing is ever deleted: when a mirror of the same source
+ * already sits under the target, the row is pointed at it and the old copy
+ * is left where it is for the user to remove.
+ */
+
+import { and, asc, eq } from "drizzle-orm";
+import { db, repositories } from "@/lib/db";
+import type { Repository } from "@/lib/db/schema";
+import type { Config } from "@/types/config";
+import { HttpError, httpGet } from "@/lib/http-client";
+import { decryptConfigTokens } from "@/lib/utils/config-encryption";
+import {
+  findGiteaMirrorBySource,
+  getGiteaRepoInfo,
+  getOrCreateGiteaOrgEnhanced,
+  transferGiteaRepo,
+  type GiteaTransferResult,
+} from "@/lib/gitea-enhanced";
+import { isMirrorOfSource } from "@/lib/utils/mirror-source-match";
+import {
+  assertRepositoryMatchesConfiguredDestination,
+  usesPushEngine,
+} from "@/lib/destination-connection";
+import { createMirrorJob } from "@/lib/helpers";
+import { processInParallel } from "@/lib/utils/concurrency";
+import {
+  MoveMirrorError,
+  isRecordedMirror,
+  ownerLogin,
+  planOrganizationMove,
+  splitLocation,
+  type MoveResult,
+  type OrganizationMoveResult,
+} from "@/lib/destination-transfer";
+
+const ORG_MOVE_CONCURRENCY = 2;
+
+/** The destination calls a move makes; injectable so the decisions can be tested without a server. */
+export interface MoveDeps {
+  getRepoInfo: typeof getGiteaRepoInfo;
+  searchBySource: typeof findGiteaMirrorBySource;
+  ensureOwner: (args: { config: Partial<Config>; owner: string }) => Promise<void>;
+  transfer: typeof transferGiteaRepo;
+}
+
+/**
+ * Make sure the target owner exists, the way a mirror run does: the account
+ * itself always exists, any other name is looked up as a user or
+ * organization and created as an organization when the destination has
+ * neither.
+ */
+export async function ensureDestinationOwner({
+  config,
+  owner,
+}: {
+  config: Partial<Config>;
+  owner: string;
+}): Promise<void> {
+  const defaultOwner = (config.giteaConfig?.defaultOwner ?? "").trim();
+  if (defaultOwner && defaultOwner.toLowerCase() === owner.toLowerCase()) return;
+  if (!config.giteaConfig?.url || !config.giteaConfig?.token) {
+    throw new Error("Gitea config is required.");
+  }
+
+  const decrypted = decryptConfigTokens(config as Config);
+  try {
+    // Gitea serves organizations from /users/{name} as well, so one call
+    // covers both; a 404 means the name is free.
+    await httpGet(`${config.giteaConfig.url}/api/v1/users/${encodeURIComponent(owner)}`, {
+      Authorization: `token ${decrypted.giteaConfig.token}`,
+    });
+    return;
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status !== 404) throw error;
+  }
+
+  await getOrCreateGiteaOrgEnhanced({ orgName: owner, config });
+}
+
+const defaultDeps: MoveDeps = {
+  getRepoInfo: getGiteaRepoInfo,
+  searchBySource: findGiteaMirrorBySource,
+  ensureOwner: ensureDestinationOwner,
+  transfer: transferGiteaRepo,
+};
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function transferError(
+  error: unknown,
+  { fullName, from, to, target }: { fullName: string; from: string; to: string; target: string }
+): MoveMirrorError {
+  if (error instanceof MoveMirrorError) return error;
+  if (error instanceof HttpError) {
+    switch (error.status) {
+      case 409:
+        return new MoveMirrorError(
+          `A transfer of ${from} is already waiting for acceptance on the destination. Accept or reject it there first.`,
+          409,
+          "transfer-pending"
+        );
+      case 422:
+        return new MoveMirrorError(
+          `${to} already exists on the destination, so ${from} cannot be moved there. Rename or remove it there first.`,
+          409,
+          "name-taken"
+        );
+      case 403:
+        return new MoveMirrorError(
+          `The destination token is not allowed to transfer ${from}. It has to own the repository, or be an administrator.`,
+          403,
+          "forbidden"
+        );
+      case 404:
+        return new MoveMirrorError(
+          `The destination could not find ${from} or the owner ${target}.`,
+          409,
+          "not-on-destination"
+        );
+      default:
+        return new MoveMirrorError(
+          `The destination refused to transfer ${fullName} (${from}): ${error.message}`,
+          502,
+          "destination-error"
+        );
+    }
+  }
+  return new MoveMirrorError(
+    `Could not transfer ${fullName} (${from}): ${describeError(error)}`,
+    502,
+    "destination-error"
+  );
+}
+
+async function recordLocation({
+  userId,
+  repository,
+  location,
+}: {
+  userId: string;
+  repository: Repository;
+  location: string;
+}): Promise<void> {
+  const recorded = (repository.mirroredLocation ?? "").trim();
+  if (recorded === location && repository.status !== "failed") return;
+  await db
+    .update(repositories)
+    .set({
+      mirroredLocation: location,
+      // A row that failed because its mirror was not where the app looked
+      // is healthy again once the app knows where the mirror is.
+      ...(repository.status === "failed" ? { status: "mirrored", errorMessage: null } : {}),
+      updatedAt: new Date(),
+    })
+    .where(and(eq(repositories.userId, userId), eq(repositories.id, repository.id!)));
+}
+
+/**
+ * Move one repository's mirror under `newOwner`. Finds the mirror first (at
+ * the recorded location, or anywhere on the destination when someone moved
+ * it by hand), refuses to overwrite a different repository of the same
+ * name, creates the target organization when needed, and asks the
+ * destination to transfer. Records where the mirror is afterwards.
+ *
+ * Throws MoveMirrorError with the HTTP status a route should answer with.
+ * The caller writes `destinationOrg`; this only touches `mirroredLocation`
+ * (and clears a failed status).
+ */
+export async function moveMirror({
+  userId,
+  config,
+  repository,
+  newOwner,
+  deps,
+}: {
+  userId: string;
+  config: Partial<Config>;
+  repository: Repository;
+  newOwner: string;
+  deps?: Partial<MoveDeps>;
+}): Promise<MoveResult> {
+  const io: MoveDeps = { ...defaultDeps, ...deps };
+  const target = newOwner.trim();
+
+  if (usesPushEngine(config)) {
+    throw new MoveMirrorError(
+      "Moving a mirror needs a Gitea or Forgejo destination. On GitHub and GitLab the push engine keeps repositories where it created them.",
+      400,
+      "destination-unsupported"
+    );
+  }
+
+  const recorded = splitLocation(repository.mirroredLocation);
+  if (!recorded) {
+    return {
+      outcome: "not-mirrored",
+      from: "",
+      to: "",
+      message: `${repository.fullName} has not been mirrored yet, so there is nothing to move. The next mirror run uses the new destination.`,
+    };
+  }
+  const from = `${recorded.owner}/${recorded.name}`;
+
+  try {
+    assertRepositoryMatchesConfiguredDestination({ repository, config });
+  } catch (error) {
+    throw new MoveMirrorError(describeError(error), 409, "destination-mismatch");
+  }
+
+  // 1. Where is the mirror now? The recorded location first, then a search
+  //    for anyone who transferred it by hand (the case in issue #400).
+  let current = recorded;
+  try {
+    const atRecorded = await io.getRepoInfo({ config, owner: recorded.owner, repoName: recorded.name });
+    if (!isRecordedMirror(atRecorded, repository.cloneUrl)) {
+      const hit = await io.searchBySource({ config, repository });
+      const hitOwner = ownerLogin(hit);
+      if (hit && hitOwner && hit.name && isMirrorOfSource(hit, repository.cloneUrl)) {
+        current = { owner: hitOwner, name: hit.name };
+      } else {
+        throw new MoveMirrorError(
+          `${repository.fullName} is not on the destination at ${from}. Run Reconcile with destination, or mirror it again.`,
+          409,
+          "not-on-destination"
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof MoveMirrorError) throw error;
+    throw new MoveMirrorError(
+      `Could not look up ${from} on the destination: ${describeError(error)}`,
+      502,
+      "destination-error"
+    );
+  }
+  const currentLocation = `${current.owner}/${current.name}`;
+  const to = `${target}/${current.name}`;
+
+  // 2. Already under the new owner: nothing to transfer, only to record.
+  if (current.owner.toLowerCase() === target.toLowerCase()) {
+    await recordLocation({ userId, repository, location: currentLocation });
+    return {
+      outcome: "recorded",
+      from,
+      to: currentLocation,
+      message: `${repository.fullName} is already under ${current.owner}, at ${currentLocation}.`,
+    };
+  }
+
+  // 3. The name has to be free under the target, unless what sits there is
+  //    another mirror of this same source (a copy made by an earlier retry).
+  let atTarget;
+  try {
+    atTarget = await io.getRepoInfo({ config, owner: target, repoName: current.name });
+  } catch (error) {
+    throw new MoveMirrorError(
+      `Could not look up ${to} on the destination: ${describeError(error)}`,
+      502,
+      "destination-error"
+    );
+  }
+  if (atTarget) {
+    if (isMirrorOfSource(atTarget, repository.cloneUrl)) {
+      const location = `${ownerLogin(atTarget) || target}/${atTarget.name || current.name}`;
+      await recordLocation({ userId, repository, location });
+      await createMirrorJob({
+        userId,
+        repositoryId: repository.id,
+        repositoryName: repository.name,
+        message: `Recorded ${location} as the mirror of ${repository.fullName}`,
+        details: `${location} already mirrors the same source. The copy at ${currentLocation} was left alone.`,
+        status: "mirrored",
+        skipNotification: true,
+      });
+      return {
+        outcome: "recorded",
+        from,
+        to: location,
+        message: `${location} already mirrors ${repository.fullName}, so the row now points at it. The copy at ${currentLocation} was left alone; remove it on the destination if you do not need it.`,
+      };
+    }
+    throw new MoveMirrorError(
+      `${to} already exists on the destination and is not a mirror of ${repository.fullName}. Rename or remove it there first.`,
+      409,
+      "name-taken"
+    );
+  }
+
+  // 4. The owner has to exist; organizations are created the way a mirror run creates them.
+  try {
+    await io.ensureOwner({ config, owner: target });
+  } catch (error) {
+    throw transferError(error, { fullName: repository.fullName, from: currentLocation, to, target });
+  }
+
+  // 5. Ask the destination to move it.
+  let result: GiteaTransferResult;
+  try {
+    result = await io.transfer({ config, owner: current.owner, repoName: current.name, newOwner: target });
+  } catch (error) {
+    throw transferError(error, { fullName: repository.fullName, from: currentLocation, to, target });
+  }
+
+  if (result.pending) {
+    // The repository stays where it is until someone accepts. Sync keeps
+    // using the recorded location, and follows the move once it happens.
+    await recordLocation({ userId, repository, location: currentLocation });
+    await createMirrorJob({
+      userId,
+      repositoryId: repository.id,
+      repositoryName: repository.name,
+      message: `Asked the destination to transfer ${repository.fullName} to ${target}`,
+      details: `The destination is waiting for an owner of ${target} to accept. The mirror stays at ${currentLocation} until then.`,
+      status: "mirrored",
+      skipNotification: true,
+    });
+    return {
+      outcome: "pending",
+      from,
+      to,
+      message: `The destination is waiting for an owner of ${target} to accept the transfer of ${currentLocation}. The mirror keeps syncing where it is until then, and sync follows it once accepted.`,
+    };
+  }
+
+  const landed = `${ownerLogin(result.repo) || target}/${result.repo?.name || current.name}`;
+  await recordLocation({ userId, repository, location: landed });
+  await createMirrorJob({
+    userId,
+    repositoryId: repository.id,
+    repositoryName: repository.name,
+    message: `Moved ${repository.fullName} to ${landed} on the destination`,
+    details: `Was at ${currentLocation}.`,
+    status: "mirrored",
+    skipNotification: true,
+  });
+  console.log(`[Move] ${repository.fullName}: ${currentLocation} -> ${landed}`);
+
+  return {
+    outcome: "moved",
+    from,
+    to: landed,
+    message: `Moved ${repository.fullName} from ${currentLocation} to ${landed}.`,
+  };
+}
+
+/**
+ * Move every mirrored repository of an organization under the owner its new
+ * destination names (or the strategy's owner when the override is removed).
+ * A dry run only returns the plan, which the confirmation dialog shows.
+ * Each move is independent: one failure is reported and the rest go ahead.
+ */
+export async function moveOrganizationMirrors({
+  userId,
+  config,
+  organization,
+  destinationOrg,
+  dryRun,
+  deps,
+  strategyOwnerFor,
+}: {
+  userId: string;
+  config: Partial<Config>;
+  organization: { id?: string; name: string };
+  destinationOrg: string | null;
+  dryRun: boolean;
+  deps?: Partial<MoveDeps>;
+  /** Where the strategy puts a row without any override; injectable for tests. */
+  strategyOwnerFor?: (row: Repository) => string;
+}): Promise<OrganizationMoveResult> {
+  if (usesPushEngine(config)) {
+    throw new MoveMirrorError(
+      "Moving mirrors needs a Gitea or Forgejo destination. On GitHub and GitLab the push engine keeps repositories where it created them.",
+      400,
+      "destination-unsupported"
+    );
+  }
+
+  const rows = (await db
+    .select()
+    .from(repositories)
+    .where(and(eq(repositories.userId, userId), eq(repositories.organization, organization.name)))
+    .orderBy(asc(repositories.fullName))) as Repository[];
+
+  const override = (destinationOrg ?? "").trim();
+  let resolveStrategyOwner = strategyOwnerFor;
+  if (!resolveStrategyOwner) {
+    const { getGiteaRepoOwner } = await import("@/lib/gitea");
+    resolveStrategyOwner = (row) => getGiteaRepoOwner({ config, repository: row });
+  }
+  const plan = planOrganizationMove({
+    rows,
+    targetOwnerFor: (row) => {
+      if (override) return override;
+      try {
+        // Without an override the organization falls back to the strategy,
+        // which is what the next mirror run would use for these rows.
+        return resolveStrategyOwner!(row as Repository);
+      } catch {
+        return "";
+      }
+    },
+  });
+
+  const result: OrganizationMoveResult = {
+    dryRun,
+    plan,
+    moved: [],
+    pending: [],
+    recorded: [],
+    failed: [],
+  };
+  if (dryRun || plan.moves.length === 0) return result;
+
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  await processInParallel(
+    plan.moves,
+    async (entry) => {
+      const row = rowsById.get(entry.id);
+      const target = splitLocation(entry.to)?.owner ?? "";
+      if (!row || !target) {
+        result.failed.push({ fullName: entry.fullName, error: "row or target missing" });
+        return;
+      }
+      try {
+        const moved = await moveMirror({ userId, config, repository: row, newOwner: target, deps });
+        const summary = { fullName: entry.fullName, from: moved.from, to: moved.to };
+        if (moved.outcome === "moved") result.moved.push(summary);
+        else if (moved.outcome === "pending") result.pending.push(summary);
+        else if (moved.outcome === "recorded") result.recorded.push(summary);
+      } catch (error) {
+        result.failed.push({ fullName: entry.fullName, error: describeError(error) });
+      }
+    },
+    ORG_MOVE_CONCURRENCY
+  );
+
+  const sortByName = (a: { fullName: string }, b: { fullName: string }) => a.fullName.localeCompare(b.fullName);
+  result.moved.sort(sortByName);
+  result.pending.sort(sortByName);
+  result.recorded.sort(sortByName);
+  result.failed.sort(sortByName);
+
+  const targetLabel = override || "the strategy's owner";
+  await createMirrorJob({
+    userId,
+    organizationId: organization.id,
+    organizationName: organization.name,
+    message: `Moved the mirrors of ${organization.name} to ${targetLabel}`,
+    details: `Moved ${result.moved.length}, waiting for acceptance ${result.pending.length}, recorded ${result.recorded.length}, failed ${result.failed.length}, skipped ${plan.skipped.length}.`,
+    status: result.failed.length > 0 && result.moved.length === 0 ? "failed" : "mirrored",
+    skipNotification: true,
+  });
+
+  return result;
+}

--- a/src/lib/destination-transfer.test.ts
+++ b/src/lib/destination-transfer.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the pure decisions behind moving a mirror (issue #400):
+ * reading a recorded location, trusting what sits there, and planning an
+ * organization-wide move.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  OWNER_NAME_PATTERN,
+  isRecordedMirror,
+  ownerLogin,
+  planOrganizationMove,
+  splitLocation,
+} from "./destination-transfer";
+
+describe("splitLocation", () => {
+  test("reads owner and name, trimming whitespace", () => {
+    expect(splitLocation(" mirrors/hello ")).toEqual({ owner: "mirrors", name: "hello" });
+  });
+
+  test("keeps everything after the first slash as the name", () => {
+    expect(splitLocation("org/nested/name")).toEqual({ owner: "org", name: "nested/name" });
+  });
+
+  test("rejects blank, owner-only and name-only values", () => {
+    expect(splitLocation("")).toBeNull();
+    expect(splitLocation(null)).toBeNull();
+    expect(splitLocation("hello")).toBeNull();
+    expect(splitLocation("/hello")).toBeNull();
+    expect(splitLocation("mirrors/")).toBeNull();
+  });
+});
+
+describe("ownerLogin", () => {
+  test("accepts both shapes Gitea uses for the owner", () => {
+    expect(ownerLogin({ owner: "archive" } as any)).toBe("archive");
+    expect(ownerLogin({ owner: { login: "archive" } } as any)).toBe("archive");
+    expect(ownerLogin(null)).toBe("");
+  });
+});
+
+describe("isRecordedMirror", () => {
+  const source = "https://github.com/octocat/hello.git";
+
+  test("is false for nothing and for a native repository", () => {
+    expect(isRecordedMirror(null, source)).toBe(false);
+    expect(isRecordedMirror({ mirror: false, original_url: source } as any, source)).toBe(false);
+  });
+
+  test("trusts a mirror at our own recorded location when the server gives no source", () => {
+    expect(isRecordedMirror({ mirror: true } as any, source)).toBe(true);
+  });
+
+  test("accepts the same source in any spelling and rejects another one", () => {
+    expect(isRecordedMirror({ mirror: true, original_url: "https://GitHub.com/octocat/hello" } as any, source)).toBe(true);
+    expect(isRecordedMirror({ mirror: true, original_url: "https://github.com/other/hello.git" } as any, source)).toBe(false);
+  });
+});
+
+describe("OWNER_NAME_PATTERN", () => {
+  test("accepts what Gitea accepts and nothing that could change the URL", () => {
+    for (const ok of ["archive", "my-org", "a.b_c", "Org2"]) expect(OWNER_NAME_PATTERN.test(ok)).toBe(true);
+    for (const bad of ["", "a/b", ".hidden", "with space", "a?b", "-lead"]) expect(OWNER_NAME_PATTERN.test(bad)).toBe(false);
+  });
+});
+
+describe("planOrganizationMove", () => {
+  const row = (overrides: Record<string, unknown>) => ({
+    id: String(overrides.fullName),
+    fullName: "acme/x",
+    isStarred: false,
+    destinationOrg: null,
+    mirroredLocation: "acme/x",
+    status: "mirrored",
+    ...overrides,
+  }) as any;
+
+  test("moves mirrored rows and explains every row it leaves alone", () => {
+    const plan = planOrganizationMove({
+      rows: [
+        row({ fullName: "acme/api", mirroredLocation: "acme/api" }),
+        row({ fullName: "acme/renamed", mirroredLocation: "acme/renamed-2" }),
+        row({ fullName: "acme/starred", isStarred: true }),
+        row({ fullName: "acme/custom", destinationOrg: "elsewhere" }),
+        row({ fullName: "acme/new", mirroredLocation: "" }),
+        row({ fullName: "acme/busy", status: "syncing" }),
+        row({ fullName: "acme/there", mirroredLocation: "Archive/there" }),
+      ],
+      targetOwnerFor: () => "archive",
+    });
+
+    expect(plan.moves).toEqual([
+      { id: "acme/api", fullName: "acme/api", from: "acme/api", to: "archive/api" },
+      // The destination name is kept, suffix and all; only the owner changes.
+      { id: "acme/renamed", fullName: "acme/renamed", from: "acme/renamed-2", to: "archive/renamed-2" },
+    ]);
+    expect(plan.skipped).toEqual([
+      { fullName: "acme/starred", reason: "starred repositories keep their own destination" },
+      { fullName: "acme/custom", reason: "has its own destination (elsewhere)" },
+      { fullName: "acme/new", reason: "not mirrored yet" },
+      { fullName: "acme/busy", reason: "a syncing run is in progress" },
+      { fullName: "acme/there", reason: "already under Archive" },
+    ]);
+  });
+
+  test("asks the resolver per row, so removing the override can send rows to different owners", () => {
+    const plan = planOrganizationMove({
+      rows: [
+        row({ fullName: "acme/a", mirroredLocation: "old/a" }),
+        row({ fullName: "acme/b", mirroredLocation: "old/b" }),
+        row({ fullName: "acme/c", mirroredLocation: "old/c" }),
+      ],
+      targetOwnerFor: (r) => (r.fullName === "acme/b" ? "me" : r.fullName === "acme/c" ? "" : "acme"),
+    });
+
+    expect(plan.moves.map((m) => m.to)).toEqual(["acme/a", "me/b"]);
+    expect(plan.skipped).toEqual([
+      { fullName: "acme/c", reason: "no destination owner could be determined" },
+    ]);
+  });
+});

--- a/src/lib/destination-transfer.ts
+++ b/src/lib/destination-transfer.ts
@@ -1,0 +1,169 @@
+/**
+ * Moving a mirror to another owner on the destination (issue #400).
+ *
+ * Changing a repository's destination used to change a label and nothing
+ * else: the mirror stayed where it was, and the next mirror run created a
+ * second copy. These helpers decide what a move means for a row and for an
+ * organization; destination-transfer-service.ts does the talking to the
+ * destination and the database writes.
+ */
+
+import type { Repository } from "@/lib/db/schema";
+import type { GiteaRepoInfo } from "@/lib/gitea-enhanced";
+import { cloneUrlsMatch } from "@/lib/utils/mirror-source-match";
+
+export type MoveOutcome =
+  /** The destination moved the repository. */
+  | "moved"
+  /** The destination wants an owner of the target to accept first. */
+  | "pending"
+  /** A mirror of this source already sat under the target; the row now points at it. */
+  | "recorded"
+  /** The row has never been mirrored, so there was nothing to move. */
+  | "not-mirrored";
+
+export interface MoveResult {
+  outcome: MoveOutcome;
+  /** owner/name the row pointed at before, empty for a row that was never mirrored. */
+  from: string;
+  /** owner/name the row points at now, or the target of a pending transfer. */
+  to: string;
+  message: string;
+}
+
+export type MoveErrorCode =
+  | "destination-unsupported"
+  | "destination-mismatch"
+  | "not-on-destination"
+  | "name-taken"
+  | "transfer-pending"
+  | "forbidden"
+  | "destination-error";
+
+/** A move that could not be done, with the HTTP status the routes answer with. */
+export class MoveMirrorError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: MoveErrorCode
+  ) {
+    super(message);
+    this.name = "MoveMirrorError";
+  }
+}
+
+/** Letters, digits, dots, dashes and underscores: what Gitea accepts for an owner name. */
+export const OWNER_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function splitLocation(
+  location: string | null | undefined
+): { owner: string; name: string } | null {
+  const trimmed = (location ?? "").trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash === trimmed.length - 1) return null;
+  return { owner: trimmed.slice(0, slash), name: trimmed.slice(slash + 1) };
+}
+
+export function ownerLogin(info: GiteaRepoInfo | null | undefined): string {
+  if (!info) return "";
+  return typeof info.owner === "string" ? info.owner : info.owner?.login ?? "";
+}
+
+/**
+ * Whether the repository at a location this app recorded itself is still
+ * its mirror. Unlike isMirrorOfSource this trusts a mirror without an
+ * original_url, because the location came from our own success path; a
+ * mirror whose original_url names another source is not ours.
+ */
+export function isRecordedMirror(
+  info: GiteaRepoInfo | null,
+  sourceCloneUrl?: string | null
+): boolean {
+  if (!info || !info.mirror) return false;
+  const original = typeof info.original_url === "string" ? info.original_url.trim() : "";
+  if (!original) return true;
+  return cloneUrlsMatch(original, sourceCloneUrl);
+}
+
+export interface MovePlanEntry {
+  id: string;
+  fullName: string;
+  from: string;
+  to: string;
+}
+
+export interface MovePlan {
+  moves: MovePlanEntry[];
+  skipped: Array<{ fullName: string; reason: string }>;
+}
+
+const BUSY_STATUSES = new Set(["mirroring", "syncing", "deleting"]);
+
+type PlanRow = Pick<
+  Repository,
+  "id" | "fullName" | "isStarred" | "destinationOrg" | "mirroredLocation" | "status"
+>;
+
+/**
+ * Which repositories of an organization move when its destination changes.
+ * Rows with their own destination keep it (the per-repository override wins
+ * over the organization's), starred repositories have their own placement,
+ * and a row that was never mirrored has nothing to move.
+ */
+export function planOrganizationMove({
+  rows,
+  targetOwnerFor,
+}: {
+  rows: PlanRow[];
+  targetOwnerFor: (row: PlanRow) => string;
+}): MovePlan {
+  const moves: MovePlanEntry[] = [];
+  const skipped: MovePlan["skipped"] = [];
+
+  for (const row of rows) {
+    if (row.isStarred) {
+      skipped.push({ fullName: row.fullName, reason: "starred repositories keep their own destination" });
+      continue;
+    }
+    if ((row.destinationOrg ?? "").trim()) {
+      skipped.push({ fullName: row.fullName, reason: `has its own destination (${row.destinationOrg})` });
+      continue;
+    }
+    const from = splitLocation(row.mirroredLocation);
+    if (!from) {
+      skipped.push({ fullName: row.fullName, reason: "not mirrored yet" });
+      continue;
+    }
+    if (BUSY_STATUSES.has(row.status)) {
+      skipped.push({ fullName: row.fullName, reason: `a ${row.status} run is in progress` });
+      continue;
+    }
+    const target = targetOwnerFor(row).trim();
+    if (!target) {
+      skipped.push({ fullName: row.fullName, reason: "no destination owner could be determined" });
+      continue;
+    }
+    if (from.owner.toLowerCase() === target.toLowerCase()) {
+      skipped.push({ fullName: row.fullName, reason: `already under ${from.owner}` });
+      continue;
+    }
+    moves.push({
+      id: row.id ?? "",
+      fullName: row.fullName,
+      from: `${from.owner}/${from.name}`,
+      to: `${target}/${from.name}`,
+    });
+  }
+
+  return { moves, skipped };
+}
+
+/** What the organization route answers; the client renders the confirmation from it. */
+export interface OrganizationMoveResult {
+  dryRun: boolean;
+  plan: MovePlan;
+  moved: Array<{ fullName: string; from: string; to: string }>;
+  pending: Array<{ fullName: string; from: string; to: string }>;
+  recorded: Array<{ fullName: string; from: string; to: string }>;
+  failed: Array<{ fullName: string; error: string }>;
+}

--- a/src/lib/gitea-enhanced.test.ts
+++ b/src/lib/gitea-enhanced.test.ts
@@ -242,6 +242,34 @@ const mockHttpGet = mock(async (url: string, headers?: any) => {
       headers: new Headers(),
     };
   }
+  // Gitea's keyword search, used when a mirror is at neither the recorded nor
+  // the expected location (#400). The real API wraps hits in { ok, data }.
+  // Two hits share the name; only the second mirrors user/moved-repo.
+  if (url.includes("/api/v1/repos/search?")) {
+    const keyword = new URL(url).searchParams.get("q");
+    const hits =
+      keyword === "moved-repo"
+        ? [
+            {
+              id: 901,
+              name: "moved-repo",
+              mirror: true,
+              owner: { login: "someone-else" },
+              original_url: "https://github.com/other/moved-repo.git",
+              private: false,
+            },
+            {
+              id: 902,
+              name: "moved-repo",
+              mirror: true,
+              owner: { login: "neworg" },
+              original_url: "https://github.com/user/moved-repo.git",
+              private: false,
+            },
+          ]
+        : [];
+    return { data: { ok: true, data: hits }, status: 200, statusText: "OK", headers: new Headers() };
+  }
   if (url.includes("/api/v1/repos/")) {
     throw new MockHttpError("Not Found", 404, "Not Found");
   }
@@ -298,6 +326,23 @@ const mockHttpPost = mock(async (url: string, body?: any, headers?: any) => {
       headers: new Headers()
     };
   }
+  // Repository transfer (issue #400): "pending-repo" needs acceptance, so the
+  // owner stays and repo_transfer is set; anything else moves at once.
+  if (url.includes("/transfer")) {
+    const pending = url.includes("/pending-repo/");
+    return {
+      data: {
+        id: 950,
+        name: url.split("/").slice(-2)[0],
+        mirror: true,
+        owner: { login: pending ? "mirrors" : body?.new_owner },
+        ...(pending ? { repo_transfer: { recipient: { login: body?.new_owner } } } : {}),
+      },
+      status: pending ? 201 : 202,
+      statusText: pending ? "Created" : "Accepted",
+      headers: new Headers()
+    };
+  }
   return { data: {}, status: 200, statusText: "OK", headers: new Headers() };
 });
 
@@ -330,11 +375,12 @@ mock.module("@/lib/repo-backup", () => ({
 }));
 
 // Now import the modules we're testing
-import { 
-  getGiteaRepoInfo, 
-  getOrCreateGiteaOrgEnhanced, 
+import {
+  getGiteaRepoInfo,
+  getOrCreateGiteaOrgEnhanced,
   syncGiteaRepoEnhanced,
-  handleExistingNonMirrorRepo 
+  handleExistingNonMirrorRepo,
+  transferGiteaRepo,
 } from "./gitea-enhanced";
 import type { Config, Repository } from "./db/schema";
 import { repoStatusEnum } from "@/types/Repository";
@@ -758,6 +804,132 @@ describe("Enhanced Gitea Operations", () => {
       expect(mirrorSyncCalls).toHaveLength(1);
       expect(String(mirrorSyncCalls[0][0])).toContain("/api/v1/repos/starred/test-repo/mirror-sync");
       expect(String(mirrorSyncCalls[0][0])).not.toContain("/api/v1/repos/ceph/test-repo/mirror-sync");
+    });
+
+    test("finds a mirror transferred to another owner through the search and syncs it there (#400)", async () => {
+      const config = {
+        userId: "user123",
+        githubConfig: {
+          username: "testuser",
+          token: "github-token",
+          privateRepositories: false,
+          mirrorStarred: true,
+        },
+        giteaConfig: {
+          url: "https://gitea.example.com",
+          token: "encrypted-token",
+          defaultOwner: "testuser",
+          mirrorReleases: true,
+        },
+      } as unknown as Partial<Config>;
+
+      // Recorded at starred/moved-repo, which the mock answers with 404; the
+      // expected owner is also "starred". Only the search knows where it went.
+      const repository = {
+        id: "repo400",
+        name: "moved-repo",
+        fullName: "user/moved-repo",
+        owner: "user",
+        url: "https://github.com/user/moved-repo",
+        cloneUrl: "https://github.com/user/moved-repo.git",
+        isPrivate: false,
+        isStarred: true,
+        status: repoStatusEnum.parse("mirrored"),
+        visibility: "public",
+        userId: "user123",
+        mirroredLocation: "starred/moved-repo",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Repository;
+
+      const result = await syncGiteaRepoEnhanced(
+        { config, repository },
+        {
+          getGiteaRepoOwnerAsync: mockGetGiteaRepoOwnerAsync,
+          mirrorGitHubReleasesToGitea: mockMirrorGitHubReleasesToGitea,
+          mirrorGitRepoIssuesToGitea: mockMirrorGitRepoIssuesToGitea,
+          mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
+          mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
+          mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+          syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
+        }
+      );
+
+      expect(result).toEqual({ success: true });
+
+      const searchCalls = mockHttpGet.mock.calls.filter((call) =>
+        String(call[0]).includes("/api/v1/repos/search?")
+      );
+      expect(searchCalls).toHaveLength(1);
+      expect(String(searchCalls[0][0])).toContain("q=moved-repo");
+
+      // The hit for another source with the same name is skipped.
+      const mirrorSyncCalls = mockHttpPost.mock.calls.filter((call) =>
+        String(call[0]).includes("/mirror-sync")
+      );
+      expect(mirrorSyncCalls).toHaveLength(1);
+      expect(String(mirrorSyncCalls[0][0])).toContain("/api/v1/repos/neworg/moved-repo/mirror-sync");
+
+      // The success write repoints the row so the next run goes straight there.
+      const recorded = dbUpdateSetCalls.filter((call) => call.mirroredLocation).pop();
+      expect(recorded?.mirroredLocation).toBe("neworg/moved-repo");
+      expect(recorded?.status).toBe("synced");
+    });
+
+    test("still reports not found when every search hit mirrors another source", async () => {
+      const config = {
+        userId: "user123",
+        githubConfig: {
+          username: "testuser",
+          token: "github-token",
+          privateRepositories: false,
+          mirrorStarred: true,
+        },
+        giteaConfig: {
+          url: "https://gitea.example.com",
+          token: "encrypted-token",
+          defaultOwner: "testuser",
+          mirrorReleases: true,
+        },
+      } as unknown as Partial<Config>;
+
+      // Same name as the search hits, but this repository comes from third/.
+      const repository = {
+        id: "repo401",
+        name: "moved-repo",
+        fullName: "third/moved-repo",
+        owner: "third",
+        url: "https://github.com/third/moved-repo",
+        cloneUrl: "https://github.com/third/moved-repo.git",
+        isPrivate: false,
+        isStarred: true,
+        status: repoStatusEnum.parse("mirrored"),
+        visibility: "public",
+        userId: "user123",
+        mirroredLocation: "starred/moved-repo",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Repository;
+
+      await expect(
+        syncGiteaRepoEnhanced(
+          { config, repository },
+          {
+            getGiteaRepoOwnerAsync: mockGetGiteaRepoOwnerAsync,
+            mirrorGitHubReleasesToGitea: mockMirrorGitHubReleasesToGitea,
+            mirrorGitRepoIssuesToGitea: mockMirrorGitRepoIssuesToGitea,
+            mirrorGitRepoPullRequestsToGitea: mockMirrorGitRepoPullRequestsToGitea,
+            mirrorGitRepoLabelsToGitea: mockMirrorGitRepoLabelsToGitea,
+            mirrorGitRepoMilestonesToGitea: mockMirrorGitRepoMilestonesToGitea,
+            syncRepositoryMetadataToGitea: mockSyncRepositoryMetadataToGitea,
+          }
+        )
+      ).rejects.toThrow("not found in Gitea");
+
+      const mirrorSyncCalls = mockHttpPost.mock.calls.filter((call) =>
+        String(call[0]).includes("/mirror-sync")
+      );
+      expect(mirrorSyncCalls).toHaveLength(0);
     });
 
     test("falls back to the archived-{name} candidate when repository.status is 'archived'", async () => {
@@ -1409,6 +1581,45 @@ describe("Enhanced Gitea Operations", () => {
       });
 
       expect(deleteCalled).toBe(true);
+    });
+  });
+
+  describe("transferGiteaRepo", () => {
+    const config = {
+      giteaConfig: {
+        url: "https://gitea.example.com",
+        token: "encrypted-token",
+        defaultOwner: "testuser",
+      },
+    } as unknown as Partial<Config>;
+
+    test("a completed transfer answers with the new owner and is not pending (#400)", async () => {
+      const result = await transferGiteaRepo({
+        config,
+        owner: "mirrors",
+        repoName: "done-repo",
+        newOwner: "archive",
+      });
+
+      expect(result.pending).toBe(false);
+      expect(result.repo.owner).toEqual({ login: "archive" });
+      const call = mockHttpPost.mock.calls.find((c) =>
+        String(c[0]).includes("/api/v1/repos/mirrors/done-repo/transfer")
+      );
+      expect(call).toBeDefined();
+      expect((call as any[])[1]).toEqual({ new_owner: "archive" });
+    });
+
+    test("a transfer waiting for acceptance keeps the old owner and is pending", async () => {
+      const result = await transferGiteaRepo({
+        config,
+        owner: "mirrors",
+        repoName: "pending-repo",
+        newOwner: "someone",
+      });
+
+      expect(result.pending).toBe(true);
+      expect(result.repo.owner).toEqual({ login: "mirrors" });
     });
   });
 });

--- a/src/lib/gitea-enhanced.ts
+++ b/src/lib/gitea-enhanced.ts
@@ -65,6 +65,14 @@ export interface GiteaRepoInfo {
   // skip writes that would not change anything.
   description?: string;
   topics?: string[];
+  // Set while a transfer waits for the new owner to accept it (issue #400).
+  repo_transfer?: { recipient?: { login?: string; username?: string } | null } | null;
+}
+
+export interface GiteaTransferResult {
+  /** True when the destination wants an owner of the target to accept before the move happens. */
+  pending: boolean;
+  repo: GiteaRepoInfo;
 }
 
 interface SyncTargetCandidate {
@@ -156,6 +164,104 @@ export async function getGiteaRepoInfo({
     }
     throw error;
   }
+}
+
+const SEARCH_PAGE_SIZE = 50;
+const SEARCH_MAX_PAGES = 4;
+
+/**
+ * Ask the server for a mirror of this repository's source anywhere the token
+ * can see, for when the recorded and the expected location both came up
+ * empty: someone transferred the mirror to another owner in Gitea (issue
+ * #400). The keyword search is by name, so the match is decided on
+ * `original_url`, never on the name alone; a hit without a source URL is
+ * ignored rather than guessed at.
+ */
+export async function findGiteaMirrorBySource({
+  config,
+  repository,
+}: {
+  config: Partial<Config>;
+  repository: Pick<Repository, "name" | "cloneUrl" | "url">;
+}): Promise<GiteaRepoInfo | null> {
+  if (!config.giteaConfig?.url || !config.giteaConfig?.token) {
+    throw new Error("Gitea config is required.");
+  }
+
+  const ownSources = [repository.cloneUrl, repository.url]
+    .filter((u): u is string => typeof u === "string" && u.trim() !== "")
+    .map(normalizeSourceUrl);
+  if (ownSources.length === 0) return null;
+
+  const decryptedConfig = decryptConfigTokens(config as Config);
+  const headers = { Authorization: `token ${decryptedConfig.giteaConfig.token}` };
+  const keyword = encodeURIComponent(repository.name);
+
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page += 1) {
+    const response = await httpGet<{ data?: GiteaRepoInfo[] }>(
+      `${config.giteaConfig.url}/api/v1/repos/search?q=${keyword}&mode=mirror&limit=${SEARCH_PAGE_SIZE}&page=${page}`,
+      headers
+    );
+    const hits = Array.isArray(response.data?.data) ? response.data.data : [];
+    for (const hit of hits) {
+      if (!hit.mirror) continue;
+      const original = typeof hit.original_url === "string" ? hit.original_url.trim() : "";
+      if (original && ownSources.includes(normalizeSourceUrl(original))) {
+        return hit;
+      }
+    }
+    if (hits.length < SEARCH_PAGE_SIZE) break;
+  }
+
+  return null;
+}
+
+/**
+ * Transfer a repository to another owner on the destination (issue #400).
+ *
+ * Gitea completes the transfer at once when the token may create
+ * repositories under the new owner, and otherwise records a pending transfer
+ * that an owner of the target has to accept. It answers 202 for a completed
+ * transfer and 201 for a pending one; the owner in the body is checked as
+ * well, so a server that numbers them differently still lands in the right
+ * branch. Errors (409 transfer in progress, 422 name taken, 403, 404) are
+ * left to the caller as HttpError.
+ */
+export async function transferGiteaRepo({
+  config,
+  owner,
+  repoName,
+  newOwner,
+}: {
+  config: Partial<Config>;
+  owner: string;
+  repoName: string;
+  newOwner: string;
+}): Promise<GiteaTransferResult> {
+  if (!config.giteaConfig?.url || !config.giteaConfig?.token) {
+    throw new Error("Gitea config is required.");
+  }
+
+  const decryptedConfig = decryptConfigTokens(config as Config);
+  const response = await httpPost<GiteaRepoInfo>(
+    `${config.giteaConfig.url}/api/v1/repos/${owner}/${repoName}/transfer`,
+    { new_owner: newOwner },
+    { Authorization: `token ${decryptedConfig.giteaConfig.token}` }
+  );
+
+  const repo = (response.data ?? {}) as GiteaRepoInfo;
+  const landedOwner = typeof repo.owner === "string" ? repo.owner : repo.owner?.login ?? "";
+
+  let pending: boolean;
+  if (repo.repo_transfer) {
+    pending = true;
+  } else if (landedOwner) {
+    pending = landedOwner.toLowerCase() !== newOwner.toLowerCase();
+  } else {
+    pending = response.status === 201;
+  }
+
+  return { pending, repo };
 }
 
 /**
@@ -456,6 +562,35 @@ export async function syncGiteaRepoEnhanced({
       repoName = candidateInfo.name || target.repoName;
       repoInfo = candidateInfo;
       break;
+    }
+
+    // Neither the recorded nor the expected location holds the mirror. Before
+    // failing, ask the server whether a mirror of this source exists under
+    // another owner: someone may have transferred it in Gitea (issue #400).
+    // A hit is adopted like any other candidate, and the success path below
+    // records its location so the next run goes straight there.
+    if (!repoInfo) {
+      try {
+        const relocated = await findGiteaMirrorBySource({ config, repository });
+        const relocatedOwner =
+          typeof relocated?.owner === "string" ? relocated.owner : relocated?.owner?.login;
+        if (relocated && relocatedOwner) {
+          console.log(
+            `[Sync] ${repository.name} is not at ${candidateTargets
+              .map((t) => `${t.owner}/${t.repoName}`)
+              .join(", ")}; found its mirror at ${relocatedOwner}/${relocated.name}, recording the new location`
+          );
+          repoOwner = relocatedOwner;
+          repoName = relocated.name || repository.name;
+          repoInfo = relocated;
+        }
+      } catch (error) {
+        console.warn(
+          `[Sync] Could not search the destination for a moved mirror of ${repository.name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
     }
 
     if (!repoInfo) {

--- a/src/lib/utils/mirror-source-match.test.ts
+++ b/src/lib/utils/mirror-source-match.test.ts
@@ -324,6 +324,77 @@ describe("findExistingMirror", () => {
     expect(match).not.toBeNull();
     expect(match!.owner).toBe("starred");
   });
+
+  test("finds a mirror transferred to another owner through the search fallback when the recorded location is gone (#400)", async () => {
+    const repo = makeRepo({ mirroredLocation: "old-org/Update", status: "failed" });
+    let searched = 0;
+    const searchBySource = async () => {
+      searched += 1;
+      return {
+        mirror: true,
+        name: "Update",
+        owner: { login: "new-org" },
+        original_url: "https://github.com/NostalgiaForInfinity/Update.git",
+      } as any;
+    };
+
+    const match = await findExistingMirror({
+      repository: repo,
+      config,
+      candidateOwner: "starred",
+      candidateName: "Update",
+      getRepoInfo: async () => null,
+      searchBySource,
+    });
+
+    expect(searched).toBe(1);
+    expect(match).not.toBeNull();
+    expect(match!.owner).toBe("new-org");
+    expect(match!.repoName).toBe("Update");
+  });
+
+  test("does not search for a repository that was never mirrored", async () => {
+    const repo = makeRepo({ mirroredLocation: "" });
+    let searched = 0;
+    const searchBySource = async () => {
+      searched += 1;
+      return null;
+    };
+
+    const match = await findExistingMirror({
+      repository: repo,
+      config,
+      candidateOwner: "starred",
+      candidateName: "Update",
+      getRepoInfo: async () => null,
+      searchBySource,
+    });
+
+    expect(searched).toBe(0);
+    expect(match).toBeNull();
+  });
+
+  test("ignores a search hit that mirrors a different source", async () => {
+    const repo = makeRepo({ mirroredLocation: "old-org/Update" });
+    const searchBySource = async () =>
+      ({
+        mirror: true,
+        name: "Update",
+        owner: { login: "new-org" },
+        original_url: "https://github.com/someone-else/Update.git",
+      }) as any;
+
+    const match = await findExistingMirror({
+      repository: repo,
+      config,
+      candidateOwner: "starred",
+      candidateName: "Update",
+      getRepoInfo: async () => null,
+      searchBySource,
+    });
+
+    expect(match).toBeNull();
+  });
 });
 
 describe("classifyCandidateName — suffix vs reuse decision (#315/#309)", () => {

--- a/src/lib/utils/mirror-source-match.ts
+++ b/src/lib/utils/mirror-source-match.ts
@@ -120,6 +120,9 @@ export interface ExistingMirrorMatch {
  *      differs from the current naming strategy (handles strategy changes — #309).
  *   2. The provided candidate owner/name — if that resolves to a live mirror of
  *      THIS source, reuse it (handles the self-collision that drove suffixing — #315).
+ *   3. When the row was mirrored before and both came up empty, a keyword
+ *      search of the destination for a mirror of THIS source (handles a
+ *      transfer to another owner in Gitea — #400).
  *
  * Returns null when no live same-source mirror is found (caller should create
  * a fresh mirror, generating a unique name if the candidate name is taken by a
@@ -131,6 +134,7 @@ export async function findExistingMirror({
   candidateOwner,
   candidateName,
   getRepoInfo,
+  searchBySource,
 }: {
   repository: Repository;
   config: Partial<Config>;
@@ -141,6 +145,11 @@ export async function findExistingMirror({
     config: Partial<Config>;
     owner: string;
     repoName: string;
+  }) => Promise<GiteaRepoInfo | null>;
+  // Injectable for testing; defaults to the real Gitea keyword search.
+  searchBySource?: (args: {
+    config: Partial<Config>;
+    repository: Repository;
   }) => Promise<GiteaRepoInfo | null>;
 }): Promise<ExistingMirrorMatch | null> {
   const lookup =
@@ -207,6 +216,37 @@ export async function findExistingMirror({
         repoInfo: repoInfo as GiteaRepoInfo,
       };
     }
+  }
+
+  // 3. Nothing at either place, yet the row says it was mirrored before: the
+  //    mirror may have been transferred to another owner in Gitea (#400). Ask
+  //    the server for a mirror of this source before creating a fresh one,
+  //    which would leave two copies. Never-mirrored rows skip this so a bulk
+  //    import does not pay a search per repository.
+  if (!(repository.mirroredLocation ?? "").trim()) return null;
+
+  const search =
+    searchBySource ??
+    (async (args: { config: Partial<Config>; repository: Repository }) => {
+      const { findGiteaMirrorBySource } = await import("@/lib/gitea-enhanced");
+      return findGiteaMirrorBySource(args);
+    });
+
+  try {
+    const hit = await search({ config, repository });
+    const owner = typeof hit?.owner === "string" ? hit.owner : hit?.owner?.login;
+    if (hit && owner && hit.name && isMirrorOfSource(hit, sourceCloneUrl)) {
+      console.log(
+        `[Mirror] ${repository.fullName} is no longer at its recorded location; reusing its mirror at ${owner}/${hit.name}`
+      );
+      return { owner, repoName: hit.name, repoInfo: hit };
+    }
+  } catch (error) {
+    console.warn(
+      `[Mirror] Could not search the destination for a moved mirror of ${repository.fullName}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
   }
 
   return null;

--- a/src/pages/api/cleanup/reconcile.ts
+++ b/src/pages/api/cleanup/reconcile.ts
@@ -12,15 +12,18 @@ const bodySchema = z.object({
   dryRun: z.boolean().optional().default(true),
   adoptUntracked: z.boolean().optional().default(false),
   resetMissing: z.boolean().optional().default(false),
+  relocateMoved: z.boolean().optional().default(false),
 });
 
 /**
  * Compare the destination with the repository database (issue #284).
  *
  * Always computes the report. With `dryRun: false`, `adoptUntracked` creates
- * rows for mirrors the database does not know about and `resetMissing`
- * sends rows whose mirror is gone back to `imported`. Nothing is deleted or
- * archived here; the cleanup service keeps its own rules.
+ * rows for mirrors the database does not know about, `relocateMoved`
+ * repoints rows whose mirror was transferred to another owner (issue #400),
+ * and `resetMissing` sends rows whose mirror is gone back to `imported`.
+ * Nothing is deleted or archived here; the cleanup service keeps its own
+ * rules.
  */
 export const POST: APIRoute = async ({ request, locals }) => {
   try {
@@ -43,7 +46,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const parsed = bodySchema.safeParse(parsedBody);
     if (!parsed.success) {
       return jsonResponse({
-        data: { success: false, error: "dryRun, adoptUntracked and resetMissing must be booleans" },
+        data: { success: false, error: "dryRun, adoptUntracked, resetMissing and relocateMoved must be booleans" },
         status: 400,
       });
     }

--- a/src/pages/api/organizations/[id]/move-mirrors.ts
+++ b/src/pages/api/organizations/[id]/move-mirrors.ts
@@ -1,0 +1,122 @@
+import type { APIRoute } from "astro";
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db, configs, organizations } from "@/lib/db";
+import type { Config } from "@/types/config";
+import { requireAuthenticatedUserId } from "@/lib/auth-guards";
+import { jsonResponse, createSecureErrorResponse } from "@/lib/utils";
+import { moveOrganizationMirrors } from "@/lib/destination-transfer-service";
+import { MoveMirrorError, OWNER_NAME_PATTERN } from "@/lib/destination-transfer";
+
+const bodySchema = z.object({
+  destinationOrg: z.string().trim().max(100).nullable().optional(),
+  dryRun: z.boolean().optional().default(true),
+});
+
+/**
+ * Change an organization's destination and move its mirrors there (issue
+ * #400). A dry run (the default) answers with the plan: which repositories
+ * would move and which are skipped, so the client can ask for confirmation.
+ * With `dryRun: false` each mirrored repository without its own destination
+ * is transferred on the destination, and the organization's `destinationOrg`
+ * is written afterwards even when some transfers failed; those are listed
+ * with their reason and keep syncing where they are.
+ */
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  try {
+    const authResult = await requireAuthenticatedUserId({ request, locals });
+    if ("response" in authResult) return authResult.response;
+    const userId = authResult.userId;
+
+    const orgId = params.id;
+    if (!orgId) {
+      return jsonResponse({ data: { success: false, error: "Organization ID is required" }, status: 400 });
+    }
+
+    const raw = await request.text();
+    let parsedBody: unknown = {};
+    if (raw.trim()) {
+      try {
+        parsedBody = JSON.parse(raw);
+      } catch {
+        return jsonResponse({ data: { success: false, error: "Body must be JSON" }, status: 400 });
+      }
+    }
+    const parsed = bodySchema.safeParse(parsedBody);
+    if (!parsed.success) {
+      return jsonResponse({
+        data: { success: false, error: "destinationOrg must be a string or null and dryRun a boolean" },
+        status: 400,
+      });
+    }
+    const destinationOrg = parsed.data.destinationOrg || null;
+    const dryRun = parsed.data.dryRun;
+    if (destinationOrg && !OWNER_NAME_PATTERN.test(destinationOrg)) {
+      return jsonResponse({
+        data: {
+          success: false,
+          error: "The destination owner may only contain letters, digits, dots, dashes and underscores",
+        },
+        status: 400,
+      });
+    }
+
+    const [organization] = await db
+      .select()
+      .from(organizations)
+      .where(and(eq(organizations.id, orgId), eq(organizations.userId, userId)))
+      .limit(1);
+    if (!organization) {
+      return jsonResponse({ data: { success: false, error: "Organization not found" }, status: 404 });
+    }
+
+    const [config] = await db
+      .select()
+      .from(configs)
+      .where(and(eq(configs.userId, userId), eq(configs.isActive, true)))
+      .limit(1);
+    if (!config) {
+      return jsonResponse({ data: { success: false, error: "No active configuration found" }, status: 404 });
+    }
+    if (!config.giteaConfig?.url || !config.giteaConfig?.token || !config.giteaConfig?.defaultOwner) {
+      return jsonResponse({
+        data: {
+          success: false,
+          error: "Configure the destination URL, username and token before moving mirrors",
+        },
+        status: 400,
+      });
+    }
+
+    const result = await moveOrganizationMirrors({
+      userId,
+      config: config as unknown as Partial<Config>,
+      organization: { id: organization.id, name: organization.name },
+      destinationOrg,
+      dryRun,
+    });
+
+    if (!dryRun) {
+      await db
+        .update(organizations)
+        .set({ destinationOrg, updatedAt: new Date() })
+        .where(and(eq(organizations.id, orgId), eq(organizations.userId, userId)));
+    }
+
+    return jsonResponse({
+      data: {
+        success: true,
+        destinationOrg: dryRun ? (organization.destinationOrg ?? null) : destinationOrg,
+        ...result,
+      },
+    });
+  } catch (error) {
+    if (error instanceof MoveMirrorError) {
+      return jsonResponse({
+        data: { success: false, error: error.message, code: error.code },
+        status: error.status,
+      });
+    }
+    return createSecureErrorResponse(error, "Move organization mirrors", 500);
+  }
+};

--- a/src/pages/api/repositories/[id]/move-mirror.test.ts
+++ b/src/pages/api/repositories/[id]/move-mirror.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Route tests for POST /api/repositories/:id/move-mirror (issue #400): input
+ * checks, ownership, the owner the service is asked to move to, and what is
+ * written once the service answers.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+let repoRows: any[] = [];
+let configRows: any[] = [];
+const dbUpdateSetCalls: any[] = [];
+const mockRepositories = {};
+const mockConfigs = {};
+
+const mockDb = {
+  select: mock(() => ({
+    from: mock((table: any) => ({
+      where: mock(() => ({
+        limit: mock(() => Promise.resolve(table === mockConfigs ? configRows : repoRows)),
+      })),
+    })),
+  })),
+  update: mock(() => ({
+    set: mock((data: any) => {
+      dbUpdateSetCalls.push(data);
+      return { where: mock(() => Promise.resolve()) };
+    }),
+  })),
+};
+
+// The route pulls in the auth module, which imports every table, so the
+// mock has to name them all.
+mock.module("@/lib/db", () => ({
+  db: mockDb,
+  repositories: mockRepositories,
+  configs: mockConfigs,
+  organizations: {},
+  users: {},
+  mirrorJobs: {},
+  events: {},
+  accounts: {},
+  sessions: {},
+  verificationTokens: {},
+  verifications: {},
+  oauthClients: {},
+  oauthAccessTokens: {},
+  oauthRefreshTokens: {},
+  oauthConsents: {},
+  jwkss: {},
+  ssoProviders: {},
+  apikeys: {},
+  rateLimits: {},
+}));
+
+// Bun keeps module mocks across test files, and an earlier route test mocks
+// this module with another owner; mocking it here keeps the answer fixed
+// whatever the order.
+mock.module("@/lib/gitea", () => ({
+  getGiteaRepoOwnerAsync: mock(async () => "me"),
+  getGiteaRepoOwner: mock(() => "me"),
+  mirrorGithubRepoToGitea: mock(async () => {}),
+  mirrorGitHubOrgRepoToGiteaOrg: mock(async () => {}),
+  isRepoPresentInGitea: mock(async () => true),
+  syncGiteaRepo: mock(async () => ({ success: true })),
+}));
+
+const mockMoveMirror = mock(async () => ({
+  outcome: "moved",
+  from: "mirrors/hello",
+  to: "archive/hello",
+  message: "Moved octocat/hello from mirrors/hello to archive/hello.",
+}));
+mock.module("@/lib/destination-transfer-service", () => ({
+  moveMirror: mockMoveMirror,
+  moveOrganizationMirrors: mock(async () => ({})),
+  ensureDestinationOwner: mock(async () => {}),
+}));
+
+const { POST } = await import("./move-mirror");
+const { MoveMirrorError } = await import("@/lib/destination-transfer");
+
+const repoRow = {
+  id: "r1",
+  userId: "user-1",
+  name: "hello",
+  fullName: "octocat/hello",
+  owner: "octocat",
+  organization: null,
+  isStarred: false,
+  destinationOrg: null,
+  mirroredLocation: "mirrors/hello",
+  status: "mirrored",
+  cloneUrl: "https://github.com/octocat/hello.git",
+  url: "https://github.com/octocat/hello",
+  destinationProvider: "gitea",
+  destinationUrl: "https://gitea.example.com",
+};
+
+const configRow = {
+  id: "c1",
+  userId: "user-1",
+  isActive: true,
+  githubConfig: { token: "gh", owner: "octocat", mirrorStrategy: "preserve" },
+  giteaConfig: { url: "https://gitea.example.com", token: "t", defaultOwner: "me", provider: "gitea" },
+};
+
+function call(body: unknown, id = "r1") {
+  return POST({
+    params: { id },
+    request: new Request(`http://localhost/api/repositories/${id}/move-mirror`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    locals: { session: { userId: "user-1" } },
+  } as any);
+}
+
+beforeEach(() => {
+  repoRows = [repoRow];
+  configRows = [configRow];
+  dbUpdateSetCalls.length = 0;
+  mockMoveMirror.mockClear();
+});
+
+describe("POST /api/repositories/:id/move-mirror", () => {
+  test("rejects an owner name that could change the destination URL", async () => {
+    const response = await call({ destinationOrg: "arch/ive" });
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("letters");
+    expect(mockMoveMirror).not.toHaveBeenCalled();
+  });
+
+  test("answers 404 for a repository that is not the account's", async () => {
+    repoRows = [];
+    const response = await call({ destinationOrg: "archive" });
+    expect(response.status).toBe(404);
+    expect(mockMoveMirror).not.toHaveBeenCalled();
+  });
+
+  test("refuses before the destination is configured", async () => {
+    configRows = [{ ...configRow, giteaConfig: { url: "", token: "", defaultOwner: "" } }];
+    const response = await call({ destinationOrg: "archive" });
+    expect(response.status).toBe(400);
+    expect(mockMoveMirror).not.toHaveBeenCalled();
+  });
+
+  test("moves the mirror, then writes the override", async () => {
+    const response = await call({ destinationOrg: "archive" });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.transfer.outcome).toBe("moved");
+    expect(data.transfer.to).toBe("archive/hello");
+
+    expect(mockMoveMirror).toHaveBeenCalledTimes(1);
+    const args = (mockMoveMirror.mock.calls[0] as any[])[0];
+    expect(args.newOwner).toBe("archive");
+    expect(args.repository.id).toBe("r1");
+    expect(dbUpdateSetCalls).toEqual([expect.objectContaining({ destinationOrg: "archive" })]);
+  });
+
+  test("a null destination moves the mirror back to where the strategy puts it", async () => {
+    const response = await call({ destinationOrg: null });
+    expect(response.status).toBe(200);
+
+    const args = (mockMoveMirror.mock.calls[0] as any[])[0];
+    // The owner the strategy resolves for the row without its override.
+    expect(args.newOwner).toBe("me");
+    expect(args.repository.destinationOrg).toBeNull();
+    expect(dbUpdateSetCalls).toEqual([expect.objectContaining({ destinationOrg: null })]);
+  });
+
+  test("a refused move changes nothing and carries the reason", async () => {
+    mockMoveMirror.mockImplementationOnce(async () => {
+      throw new MoveMirrorError("archive/hello already exists", 409, "name-taken");
+    });
+    const response = await call({ destinationOrg: "archive" });
+    expect(response.status).toBe(409);
+    const data = await response.json();
+    expect(data.success).toBe(false);
+    expect(data.code).toBe("name-taken");
+    expect(data.error).toContain("already exists");
+    expect(dbUpdateSetCalls).toHaveLength(0);
+  });
+});

--- a/src/pages/api/repositories/[id]/move-mirror.ts
+++ b/src/pages/api/repositories/[id]/move-mirror.ts
@@ -1,0 +1,136 @@
+import type { APIRoute } from "astro";
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db, configs, repositories } from "@/lib/db";
+import type { Repository } from "@/lib/db/schema";
+import type { Config } from "@/types/config";
+import { requireAuthenticatedUserId } from "@/lib/auth-guards";
+import { jsonResponse, createSecureErrorResponse } from "@/lib/utils";
+import { getGiteaRepoOwnerAsync } from "@/lib/gitea";
+import { moveMirror } from "@/lib/destination-transfer-service";
+import { MoveMirrorError, OWNER_NAME_PATTERN } from "@/lib/destination-transfer";
+
+const bodySchema = z.object({
+  destinationOrg: z.string().trim().max(100).nullable().optional(),
+});
+
+/**
+ * Change a repository's destination and move its mirror there (issue #400).
+ *
+ * `destinationOrg` names the new owner; `null` removes the override and
+ * moves the mirror back to where the strategy puts it. The mirror is
+ * transferred on the destination (Gitea or Forgejo) before the row is
+ * updated, so a refused transfer changes nothing. PATCH /api/repositories/:id
+ * remains the way to change the label without touching the destination.
+ */
+export const POST: APIRoute = async ({ params, request, locals }) => {
+  try {
+    const authResult = await requireAuthenticatedUserId({ request, locals });
+    if ("response" in authResult) return authResult.response;
+    const userId = authResult.userId;
+
+    const repoId = params.id;
+    if (!repoId) {
+      return jsonResponse({ data: { success: false, error: "Repository ID is required" }, status: 400 });
+    }
+
+    const raw = await request.text();
+    let parsedBody: unknown = {};
+    if (raw.trim()) {
+      try {
+        parsedBody = JSON.parse(raw);
+      } catch {
+        return jsonResponse({ data: { success: false, error: "Body must be JSON" }, status: 400 });
+      }
+    }
+    const parsed = bodySchema.safeParse(parsedBody);
+    if (!parsed.success) {
+      return jsonResponse({
+        data: { success: false, error: "destinationOrg must be a string or null" },
+        status: 400,
+      });
+    }
+    const destinationOrg = parsed.data.destinationOrg || null;
+    if (destinationOrg && !OWNER_NAME_PATTERN.test(destinationOrg)) {
+      return jsonResponse({
+        data: {
+          success: false,
+          error: "The destination owner may only contain letters, digits, dots, dashes and underscores",
+        },
+        status: 400,
+      });
+    }
+
+    const [row] = await db
+      .select()
+      .from(repositories)
+      .where(and(eq(repositories.id, repoId), eq(repositories.userId, userId)))
+      .limit(1);
+    if (!row) {
+      return jsonResponse({ data: { success: false, error: "Repository not found" }, status: 404 });
+    }
+    const repository = row as Repository;
+
+    const [config] = await db
+      .select()
+      .from(configs)
+      .where(and(eq(configs.userId, userId), eq(configs.isActive, true)))
+      .limit(1);
+    if (!config) {
+      return jsonResponse({ data: { success: false, error: "No active configuration found" }, status: 404 });
+    }
+    if (!config.giteaConfig?.url || !config.giteaConfig?.token || !config.giteaConfig?.defaultOwner) {
+      return jsonResponse({
+        data: {
+          success: false,
+          error: "Configure the destination URL, username and token before moving mirrors",
+        },
+        status: 400,
+      });
+    }
+
+    // With the override removed, the mirror goes where the strategy (and an
+    // organization override, if any) would put it.
+    const newOwner =
+      destinationOrg ??
+      (await getGiteaRepoOwnerAsync({
+        config: config as unknown as Partial<Config>,
+        repository: { ...repository, destinationOrg: null },
+      }));
+
+    const transfer = await moveMirror({
+      userId,
+      config: config as unknown as Partial<Config>,
+      repository,
+      newOwner,
+    });
+
+    await db
+      .update(repositories)
+      .set({ destinationOrg, updatedAt: new Date() })
+      .where(and(eq(repositories.id, repoId), eq(repositories.userId, userId)));
+
+    const [updated] = await db
+      .select({ destinationOrg: repositories.destinationOrg, mirroredLocation: repositories.mirroredLocation })
+      .from(repositories)
+      .where(eq(repositories.id, repoId))
+      .limit(1);
+
+    return jsonResponse({
+      data: {
+        success: true,
+        destinationOrg: updated?.destinationOrg ?? destinationOrg,
+        mirroredLocation: updated?.mirroredLocation ?? repository.mirroredLocation ?? "",
+        transfer,
+      },
+    });
+  } catch (error) {
+    if (error instanceof MoveMirrorError) {
+      return jsonResponse({
+        data: { success: false, error: error.message, code: error.code },
+        status: error.status,
+      });
+    }
+    return createSecureErrorResponse(error, "Move mirror", 500);
+  }
+};


### PR DESCRIPTION
Closes #400.

## Problem

Changing a repository's or an organization's destination changed a label and nothing else. The mirror stayed where it was, sync failed once someone transferred it in Gitea, and Retry created a second copy at the old place.

## What changes

**Sync follows a moved mirror.** When neither the recorded nor the expected location holds the mirror, sync asks Gitea's repository search for a mirror of the same source before failing. The match is decided on `original_url`, never on the name. The mirror path does the same check before creating a copy, gated on the row having been mirrored before so a bulk import does not pay a search per repository.

**Reconcile reports moves.** A new "Moved on the destination" group with a "Record the new locations" checkbox. A second copy while the original still exists is listed under not managed instead of being treated as a move. Recording a location flips a failed row back to mirrored.

**Move from the app.** Editing a mirrored repository's destination now asks whether to move the mirror on Gitea or Forgejo too, ticked by default. Organizations get a checkbox in the destination popover and a confirmation that lists what will move and what is left alone. Transfers go through Gitea's transfer API: a target organization is created the way a mirror run creates one, a name held by another repository refuses the move, a mirror of the same source already under the target is recorded instead of duplicated, and a transfer that Gitea holds for acceptance (the token cannot create repositories under the new owner) is reported as pending. That mirror keeps syncing where it is and sync follows it once accepted. Nothing is deleted on either side.

**Editor copy.** A row whose label names one owner while its mirror sits under another shows an "at owner" badge with an explanation. The label-only path says what it does. The check button in the inline editor now works with the mouse; its mousedown used to blur the input, which cancelled the edit before the click landed.

New endpoints: `POST /api/repositories/{id}/move-mirror` and `POST /api/organizations/{id}/move-mirrors` (dry run by default), documented in docs/API.md. `PATCH` keeps changing the label only.

## Screenshots

![Repository move dialog](https://gist.githubusercontent.com/arunavo4/2e31255b94b1d38ffbf4261a848bf162/raw/180377be999ce6eb527eaed2d2a972b96bb32ce9/move-repo-dialog.png)

![Organization move confirmation](https://gist.githubusercontent.com/arunavo4/2e31255b94b1d38ffbf4261a848bf162/raw/180377be999ce6eb527eaed2d2a972b96bb32ce9/move-org-dialog.png)

## Verification

- `bun test`: 789 pass, 11 skip, 0 fail. 39 new tests cover the reconcile classification, the sync and mirror-path search fallback, the transfer primitive, the move service and the route.
- `bun run build` passes. The tsc error count is unchanged from main (168 pre-existing).
- Both dialogs were exercised in the browser against a seeded database with the move routes mocked.
- Not done: a live transfer against a real Gitea. The transfer API behaviour (201 pending, 202 done, `repo_transfer` on the body) is taken from Gitea's source and the owner in the response is checked as well, but this should be tried on a test instance before relying on it.
