### PR TITLE
fix(security): mark the util-linux mount and nsenter CVEs as not affected

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -228,6 +228,12 @@ jobs:
           summary: true
           exit-code: false
           only-severities: critical,high
+          # OpenVEX statements in .vex/ mark CVEs the image cannot reach as
+          # not affected (see .vex/README.md). Scout only accepts statements
+          # from authors listed here; the default is *@docker.com.
+          vex-location: .vex
+          vex-author: developer@arunavoray.dev
+          only-vex-affected: true
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -246,6 +252,9 @@ jobs:
           summary: true
           exit-code: false
           only-severities: critical,high
+          vex-location: .vex
+          vex-author: developer@arunavoray.dev
+          only-vex-affected: true
           write-comment: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.vex/README.md
+++ b/.vex/README.md
@@ -1,0 +1,38 @@
+# Vulnerability exceptions for the Docker image
+
+This folder holds [OpenVEX](https://openvex.dev) statements for CVEs that
+Docker Scout reports against the image but that the image cannot reach. Each
+statement names the CVE, says why it does not apply, and points at the
+upstream and Debian status so the reason can be checked later.
+
+The statements are used in two places:
+
+- The Docker Scout steps in `.github/workflows/docker-build.yml` pass
+  `vex-location: .vex` together with `vex-author` and `only-vex-affected`, so
+  the scan that feeds the Security tab leaves these CVEs out. Scout ignores
+  statements from authors that are not listed; the default author filter only
+  accepts `*@docker.com`.
+- The `Dockerfile` copies `*.vex.json` into `/var/lib/db/` in the runner
+  stage, so `docker scout cves ghcr.io/raylabshq/gitea-mirror:latest` shows
+  the same result for anyone who scans the published image.
+
+To check locally:
+
+```bash
+docker scout cves --vex-location .vex --vex-author developer@arunavoray.dev \
+  --only-vex-affected ghcr.io/raylabshq/gitea-mirror:latest
+```
+
+## When to remove a statement
+
+Delete the statement once the Debian package it covers is fixed in the base
+image (the CVE disappears from the scan on its own), or once the reasoning no
+longer holds, for example if the image starts running a setuid helper or a
+different user model. Debian's status for a CVE is at
+`https://security-tracker.debian.org/tracker/<CVE>`.
+
+## Current statements
+
+| File | CVEs | Package | Why |
+| --- | --- | --- | --- |
+| `util-linux-mount-nsenter.vex.json` | CVE-2026-78408, CVE-2026-78409, CVE-2026-78410 | util-linux 2.41.5-0+deb13u1 (trixie, no fix planned) | nsenter and setuid mount(8) are never used; the runner stage strips setuid bits and the app runs unprivileged. |

--- a/.vex/util-linux-mount-nsenter.vex.json
+++ b/.vex/util-linux-mount-nsenter.vex.json
@@ -1,0 +1,58 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/RayLabsHQ/gitea-mirror/blob/main/.vex/util-linux-mount-nsenter.vex.json",
+  "author": "developer@arunavoray.dev",
+  "role": "Gitea Mirror maintainer",
+  "timestamp": "2026-09-04T01:30:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-78408",
+        "description": "util-linux nsenter --join-cgroup keeps a root-opened cgroup.procs descriptor across namespace and credential changes."
+      },
+      "timestamp": "2026-09-04T01:30:00Z",
+      "products": [
+        { "@id": "pkg:docker/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/ghcr.io/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/gitea-mirror" },
+        { "@id": "pkg:docker/library/gitea-mirror" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "nsenter is never run inside this image. The application runs as the unprivileged gitea-mirror user and only executes bun, git and git-lfs. The --join-cgroup path needs a privileged operator to run nsenter against a target, which happens on the host with the host's own nsenter, not with the copy in this container. Debian rates the issue minor and ships no fix for trixie (util-linux 2.41.5-0+deb13u1); the fix is only in unstable (2.42.3-1)."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-78409",
+        "description": "util-linux mount(8) X-mount.subdir follows intermediate symlinks on Linux 6.15 and later, letting an fstab-authorized user attach a host path."
+      },
+      "timestamp": "2026-09-04T01:30:00Z",
+      "products": [
+        { "@id": "pkg:docker/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/ghcr.io/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/gitea-mirror" },
+        { "@id": "pkg:docker/library/gitea-mirror" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flaw needs a setuid mount(8) and an fstab entry with X-mount.subdir that authorizes an unprivileged user. The image ships no user-mountable fstab entries, the runner stage strips the setuid and setgid bit from every binary, and the application runs as an unprivileged user that never calls mount. Debian rates the issue minor and ships no fix for trixie."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-78410",
+        "description": "util-linux mount(8) does not pin the source of a restricted bind mount before the privileged mount, so a user who can replace the source can redirect it."
+      },
+      "timestamp": "2026-09-04T01:30:00Z",
+      "products": [
+        { "@id": "pkg:docker/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/ghcr.io/raylabshq/gitea-mirror" },
+        { "@id": "pkg:docker/gitea-mirror" },
+        { "@id": "pkg:docker/library/gitea-mirror" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The flaw needs a setuid mount(8) and an fstab bind entry an unprivileged user is allowed to mount. The image ships no such entries, the runner stage strips the setuid and setgid bit from every binary, and the application runs as an unprivileged user that never calls mount. Debian rates the issue minor and ships no fix for trixie."
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-reco
   && rm -rf /var/lib/apt/lists/*
 ARG GO_VERSION=1.25.14
 ARG GIT_LFS_VERSION=3.7.1
+# Pinned rather than @latest: a cached layer kept an old @latest resolution
+# after golang.org/x/crypto 0.56.0 fixed CVE-2026-56855 and CVE-2026-78662.
+ARG GO_X_CRYPTO_VERSION=v0.56.0
+ARG GO_X_NET_VERSION=v0.58.0
 RUN ARCH="$(dpkg --print-architecture)" \
   && wget -qO /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
   && tar -C /usr/local -xzf /tmp/go.tar.gz \
@@ -43,8 +47,8 @@ ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
 ENV GOTOOLCHAIN=local
 RUN git clone --branch "v${GIT_LFS_VERSION}" --depth 1 https://github.com/git-lfs/git-lfs.git /tmp/git-lfs \
   && cd /tmp/git-lfs \
-  && go get golang.org/x/crypto@latest \
-  && go get golang.org/x/net@latest \
+  && go get "golang.org/x/crypto@${GO_X_CRYPTO_VERSION}" \
+  && go get "golang.org/x/net@${GO_X_NET_VERSION}" \
   && go mod tidy \
   && make \
   && install -m 755 /tmp/git-lfs/bin/git-lfs /usr/local/bin/git-lfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,11 @@ FROM debian:trixie-slim AS git-lfs-builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   wget ca-certificates git make \
   && rm -rf /var/lib/apt/lists/*
-ARG GO_VERSION=1.25.14
+ARG GO_VERSION=1.27.1
 ARG GIT_LFS_VERSION=3.7.1
 # Pinned rather than @latest: a cached layer kept an old @latest resolution
 # after golang.org/x/crypto 0.56.0 fixed CVE-2026-56855 and CVE-2026-78662.
+# x/crypto 0.56.0 needs Go 1.26 or newer, hence the toolchain above.
 ARG GO_X_CRYPTO_VERSION=v0.56.0
 ARG GO_X_NET_VERSION=v0.58.0
 RUN ARCH="$(dpkg --print-architecture)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   git wget sqlite3 openssl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
+# The app runs as an unprivileged user and never calls a setuid helper.
+# Dropping the bits closes the path CVE-2026-78409 and CVE-2026-78410 need
+# in mount(8); Debian ships no trixie fix for them. See .vex/README.md.
+RUN find / -xdev -type f -perm /6000 -exec chmod a-s '{}' +
+# OpenVEX statements for CVEs this image cannot reach, so that
+# `docker scout cves` on the published image reports them as not affected.
+COPY .vex/*.vex.json /var/lib/db/
 COPY --from=git-lfs-builder /usr/local/bin/git-lfs /usr/local/bin/git-lfs
 RUN git lfs install
 COPY --from=pruner /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary

Docker Scout reports three high severity CVEs on `main` against util-linux in the Debian trixie base image: CVE-2026-78408 (`nsenter --join-cgroup`), CVE-2026-78409 and CVE-2026-78410 (setuid `mount(8)` with fstab `X-mount` entries). Debian rates all three as minor, marks them `no-dsa` for trixie, and only ships the fix in unstable (util-linux 2.42.3-1), so `apt-get upgrade` cannot clear them and the alerts would stay open indefinitely.

None of the three can be reached from this image. The application runs as the unprivileged `gitea-mirror` user and only executes bun, git and git-lfs. `nsenter` is never run, and the two mount issues need a setuid `mount` binary plus an fstab entry that authorizes an unprivileged user, neither of which the image has.

This PR does two things:

- **Strips the setuid and setgid bit from every binary in the runner stage.** Nothing in the image needs one, and it removes the path the two mount CVEs rely on.
- **Adds an OpenVEX document under `.vex/`** that marks the three CVEs `not_affected` with `vulnerable_code_not_in_execute_path` and the reasoning above. The Docker Scout steps in the build workflow read it (`vex-location`, `vex-author`, `only-vex-affected`), so the scan that feeds the Security tab leaves these CVEs out, and the Dockerfile copies it into `/var/lib/db/` so `docker scout cves` on the published image reports the same. `.vex/README.md` explains when a statement should be removed.

Scout only accepts statements from listed authors (the default filter is `*@docker.com`), which is why the workflow names the author explicitly.

- **Pins golang.org/x/crypto to 0.56.0 and x/net to 0.58.0 in the git-lfs build.** The first scan on this PR showed CVE-2026-56855 and CVE-2026-78662 in the git-lfs binary: the stage used `go get @latest`, and since that line had not changed, BuildKit reused a layer resolved before 0.56.0 was published on 2 September. Pinning busts the cache now and makes the build reproducible; future bumps are explicit edits. x/crypto 0.56.0 requires Go 1.26 or newer, so the git-lfs build stage moves from Go 1.25.14 to 1.27.1, the current stable release.

## Verification

- The VEX file parses and the workflow YAML parses with the new inputs on both `cves` steps.
- The build and Scout steps run on this PR against the local scan image; the PR comment from Scout should no longer list the three CVEs. The alerts on `main` close on the first main build after merge.
- Not verified locally: no Docker on this machine, so the `find ... chmod a-s` step is exercised by the CI build.

## Notes

The image build already sets `provenance: false` and `sbom: false`, so Scout reads the filesystem VEX document instead of ignoring it in favour of attestations.
