### PR TITLE
fix(orgs): keep a destination override that matches the organization name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive fix report documentation
 
 ### Fixed
+- A per-organization Mirror Destination equal to the organization's own name is kept instead of being dropped (#416)
+  - The editor treated a typed value matching the organization name as "reset to default" and saved no override, which only holds under the preserve strategy; under single-org the default is the destination organization, so the repositories went there
+  - The organization card now shows the default for the configured strategy in the preview, the placeholder, the helper text and the reset button, and marks any stored destination as custom
+  - The repository destination column shows the organization's override as a repository's default, and pinning a repository to the value the strategy already produces is stored rather than discarded
+  - Reset to Default on an organization card clears the override instead of saving the current value again
 - Fixed metadata mirroring authentication errors (#68)
   - Changed field checking from `username` to `defaultOwner` in metadata functions
   - Added proper field validation for all metadata operations

--- a/src/components/organizations/MirrorDestinationEditor.tsx
+++ b/src/components/organizations/MirrorDestinationEditor.tsx
@@ -20,12 +20,19 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { resolveDestinationSaveValue } from "@/lib/utils/destination-editor";
 import type { OrganizationMoveResult } from "@/lib/destination-transfer";
 
 interface MirrorDestinationEditorProps {
   organizationId: string;
   organizationName: string;
   currentDestination?: string;
+  /**
+   * Where this organization's repositories land when it has no override: what
+   * the configured mirror strategy produces. Only the same-named organization
+   * under `preserve`; the destination organization under `single-org` (#416).
+   */
+  defaultDestination: string;
   onUpdate: (newDestination: string | null) => Promise<void>;
   /**
    * Plan (dryRun) or perform the move of the organization's mirrors on the
@@ -75,6 +82,7 @@ export function MirrorDestinationEditor({
   organizationId,
   organizationName,
   currentDestination,
+  defaultDestination,
   onUpdate,
   onMoveMirrors,
   destinationLabel = "Gitea",
@@ -91,15 +99,16 @@ export function MirrorDestinationEditor({
   const [applying, setApplying] = useState(false);
   const [confirmError, setConfirmError] = useState<string | null>(null);
 
-  const hasOverride = currentDestination && currentDestination !== organizationName;
-  const effectiveDestination = currentDestination || organizationName;
+  // Any stored destination is an override, including one that spells out what
+  // the strategy would have picked anyway. Clearing it is the only way back.
+  const hasOverride = Boolean(currentDestination);
+  const effectiveDestination = currentDestination || defaultDestination;
   const canMove = typeof onMoveMirrors === "function";
 
-  const handleSave = async () => {
-    const trimmedValue = editValue.trim();
-    const newDestination = trimmedValue === "" || trimmedValue === organizationName 
-      ? null 
-      : trimmedValue;
+  // The value is passed in rather than read from state so Reset can save the
+  // cleared field right away: setEditValue does not update this closure.
+  const handleSave = async (rawValue: string = editValue) => {
+    const newDestination = resolveDestinationSaveValue(rawValue);
 
     setIsLoading(true);
     try {
@@ -160,7 +169,7 @@ export function MirrorDestinationEditor({
 
   const handleReset = async () => {
     setEditValue("");
-    await handleSave();
+    await handleSave("");
   };
 
   const handleCancel = () => {
@@ -227,7 +236,7 @@ export function MirrorDestinationEditor({
                   <div className="flex items-center gap-1.5">
                     <Building2 className="h-4 w-4 text-primary" />
                     <span className="font-medium text-primary">
-                      {editValue.trim() || organizationName}
+                      {editValue.trim() || defaultDestination}
                     </span>
                   </div>
                 </div>
@@ -242,12 +251,12 @@ export function MirrorDestinationEditor({
                   id="destination"
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
-                  placeholder={organizationName}
+                  placeholder={defaultDestination}
                   className="h-8"
                   disabled={isLoading}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Leave empty to use the source organization name.
+                  Leave empty to use the default for your mirror strategy ({defaultDestination}).
                 </p>
               </div>
 
@@ -280,7 +289,7 @@ export function MirrorDestinationEditor({
                   className="w-full h-8 text-xs"
                 >
                   <RotateCcw className="h-3 w-3 mr-2" />
-                  Reset to Default ({organizationName})
+                  Reset to Default ({defaultDestination})
                 </Button>
               )}
             </div>
@@ -297,7 +306,7 @@ export function MirrorDestinationEditor({
               </Button>
               <Button
                 size="sm"
-                onClick={handleSave}
+                onClick={() => void handleSave()}
                 disabled={isLoading || (editValue.trim() === (currentDestination || ""))}
               >
                 {isLoading ? (

--- a/src/components/organizations/OrganizationsList.tsx
+++ b/src/components/organizations/OrganizationsList.tsx
@@ -272,6 +272,23 @@ export function OrganizationList({
   // GitHub and GitLab destinations are pushed to; only Gitea and Forgejo can transfer a repository.
   const destination = destinationInfo(giteaConfig);
 
+  // Where an organization's repositories land with no override, which is what
+  // the mirror strategy produces for organization repositories (see
+  // getGiteaRepoOwner in src/lib/gitea.ts). Only "preserve" and "mixed" make
+  // that the organization's own name, so the editor cannot assume it (#416).
+  // preserveOrgStructure is not consulted: the config API maps it from
+  // preserveVisibility, so mirrorStrategy is the only reliable signal here.
+  const defaultDestinationFor = (orgName: string): string => {
+    const strategy = giteaConfig?.mirrorStrategy || "preserve";
+    if (strategy === "single-org") {
+      return giteaConfig?.organization || giteaConfig?.username || orgName;
+    }
+    if (strategy === "flat-user") {
+      return giteaConfig?.username || orgName;
+    }
+    return orgName;
+  };
+
   const hasAnyFilter = Object.values(filter).some(
     (val) => val?.toString().trim() !== ""
   );
@@ -453,6 +470,7 @@ export function OrganizationList({
                   organizationId={org.id!}
                   organizationName={org.name!}
                   currentDestination={org.destinationOrg ?? undefined}
+                  defaultDestination={defaultDestinationFor(org.name!)}
                   onUpdate={(newDestination) => handleUpdateDestination(org.id!, newDestination)}
                   onMoveMirrors={
                     destination.isPushTarget
@@ -546,6 +564,7 @@ export function OrganizationList({
                   organizationId={org.id!}
                   organizationName={org.name!}
                   currentDestination={org.destinationOrg ?? undefined}
+                  defaultDestination={defaultDestinationFor(org.name!)}
                   onUpdate={(newDestination) => handleUpdateDestination(org.id!, newDestination)}
                   onMoveMirrors={
                     destination.isPushTarget

--- a/src/components/repositories/InlineDestinationEditor.tsx
+++ b/src/components/repositories/InlineDestinationEditor.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { destinationInfo } from "@/components/destination/DestinationIcon";
 import { cn } from "@/lib/utils";
+import { resolveDestinationSaveValue } from "@/lib/utils/destination-editor";
 import type { Repository } from "@/lib/db/schema";
 
 export interface DestinationUpdateOptions {
@@ -24,6 +25,12 @@ export interface DestinationUpdateOptions {
 interface InlineDestinationEditorProps {
   repository: Repository;
   giteaConfig: any;
+  /**
+   * Destination the repository's organization overrides to, when it sets one.
+   * It outranks the mirror strategy for the organization's repositories, so the
+   * row would otherwise name the strategy's owner instead (#416).
+   */
+  organizationDestination?: string | null;
   onUpdate: (
     repoId: string,
     newDestination: string | null,
@@ -40,6 +47,7 @@ const CANNOT_MOVE_STATUSES = new Set(["imported", "deleted", "deleting", "mirror
 export function InlineDestinationEditor({
   repository,
   giteaConfig,
+  organizationDestination,
   onUpdate,
   isUpdating = false,
   className,
@@ -67,6 +75,12 @@ export function InlineDestinationEditor({
       return "starred";
     }
     
+    // An organization's own override applies to its repositories whatever the
+    // strategy says, matching getGiteaRepoOwnerAsync's precedence (#416).
+    if (repository.organization && organizationDestination) {
+      return organizationDestination;
+    }
+
     // Check mirror strategy
     const strategy = giteaConfig?.mirrorStrategy || 'preserve';
     
@@ -93,7 +107,9 @@ export function InlineDestinationEditor({
 
   const defaultDestination = getDefaultDestination();
   const currentDestination = repository.destinationOrg || defaultDestination;
-  const hasOverride = repository.destinationOrg && repository.destinationOrg !== defaultDestination;
+  // A stored destination is a pin even when it spells out the default, so the
+  // badge follows the stored value rather than comparing against it (#416).
+  const hasOverride = Boolean(repository.destinationOrg);
   const isStarredRepo = repository.isStarred;
 
   const destination = destinationInfo(giteaConfig);
@@ -122,7 +138,7 @@ export function InlineDestinationEditor({
 
   const handleSave = async () => {
     const trimmedValue = editValue.trim();
-    const newDestination = trimmedValue === defaultDestination ? null : trimmedValue;
+    const newDestination = resolveDestinationSaveValue(editValue);
 
     if (trimmedValue === currentDestination) {
       setIsEditing(false);

--- a/src/components/repositories/Repository.tsx
+++ b/src/components/repositories/Repository.tsx
@@ -55,6 +55,12 @@ import { getRepositorySource, normalizeSourceUrl } from "@/lib/source-providers/
 
 export default function Repository() {
   const [repositories, setRepositories] = useState<Repository[]>([]);
+  // Organization name -> its destination override, from the list response.
+  // Kept beside the rows rather than on them: the action endpoints return the
+  // repositories row alone, and replacing a row would drop the field (#416).
+  const [organizationDestinations, setOrganizationDestinations] = useState<
+    Record<string, string>
+  >({});
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const { user } = useAuth();
   const { registerRefreshCallback, isLiveEnabled } = useLiveRefresh();
@@ -137,6 +143,7 @@ export default function Repository() {
 
       if (response.success) {
         setRepositories(response.repositories);
+        setOrganizationDestinations(response.organizationDestinations ?? {});
         return true;
       } else {
         // Only show error toast for manual refreshes to avoid spam during live updates
@@ -1580,6 +1587,7 @@ export default function Repository() {
       ) : (
         <RepositoryTable
           repositories={repositories}
+          organizationDestinations={organizationDestinations}
           isLoading={isInitialLoading || !connected}
           filter={filter}
           setFilter={setFilter}

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -68,6 +68,8 @@ export const REPOSITORY_SORT_OPTIONS = [
 
 interface RepositoryTableProps {
   repositories: Repository[];
+  /** Organization name -> its destination override (#416). */
+  organizationDestinations?: Record<string, string>;
   isLoading: boolean;
   filter: FilterParams;
   setFilter: (filter: FilterParams) => void;
@@ -110,6 +112,7 @@ function getTableSorting(sortOrder: string | undefined): SortingState {
 
 export default function RepositoryTable({
   repositories,
+  organizationDestinations,
   isLoading,
   filter,
   setFilter,
@@ -1066,6 +1069,11 @@ export default function RepositoryTable({
                         <InlineDestinationEditor
                           repository={repo}
                           giteaConfig={giteaConfig}
+                          organizationDestination={
+                            repo.organization
+                              ? organizationDestinations?.[repo.organization]
+                              : undefined
+                          }
                           onUpdate={handleUpdateDestination}
                           isUpdating={loadingRepoIds.has(repo.id ?? "")}
                         />

--- a/src/lib/gitea-org-mirror-destination.test.ts
+++ b/src/lib/gitea-org-mirror-destination.test.ts
@@ -424,6 +424,41 @@ describe.skipIf(!isChild)("mirrorGitHubOrgToGitea destination routing (#343)", (
     expect(orgCreateCalls.filter((n) => n === "hub").length).toBe(1);
   });
 
+  test("single-org strategy keeps an organization override that equals the organization name (#416)", async () => {
+    const config = makeConfig({
+      githubConfig: { mirrorStrategy: "single-org" },
+      giteaConfig: { organization: "mirrors" },
+    });
+    // The reporter's case: the override spells out the organization's own name,
+    // which single-org would never produce on its own.
+    const organization = makeOrg({ destinationOrg: "A" });
+    orgRepoRows = [makeRepo()];
+    orgConfigRows = [organization];
+
+    await mirrorGitHubOrgToGitea({ organization, octokit: fakeOctokit, config });
+
+    const migrates = migrateCalls();
+    expect(migrates.length).toBe(1);
+    expect(migrates[0].payload.uid).toBe(orgIdFor("A"));
+    expect(orgCreateCalls).not.toContain("mirrors");
+  });
+
+  test("a repository override beats an organization override under single-org (#416)", async () => {
+    const config = makeConfig({
+      githubConfig: { mirrorStrategy: "single-org" },
+      giteaConfig: { organization: "mirrors" },
+    });
+    const organization = makeOrg({ destinationOrg: "A" });
+    orgRepoRows = [makeRepo({ destinationOrg: "mirrors" })];
+    orgConfigRows = [organization];
+
+    await mirrorGitHubOrgToGitea({ organization, octokit: fakeOctokit, config });
+
+    const migrates = migrateCalls();
+    expect(migrates.length).toBe(1);
+    expect(migrates[0].payload.uid).toBe(orgIdFor("mirrors"));
+  });
+
   test("regression: flat-user strategy without overrides mirrors to the user account (repo_owner, no org)", async () => {
     const config = makeConfig({ githubConfig: { mirrorStrategy: "flat-user" } });
     const organization = makeOrg();

--- a/src/lib/gitea.test.ts
+++ b/src/lib/gitea.test.ts
@@ -594,6 +594,121 @@ describe("getGiteaRepoOwner - Organization Override Tests", () => {
     expect(result).toBe("custom-org");
   });
 
+  test("getGiteaRepoOwnerAsync: single-org strategy honors an organization override (#416)", async () => {
+    mockDbSelectResult = [
+      {
+        id: "org-id",
+        userId: "user-id",
+        configId: "config-id",
+        name: "GrapheneOS",
+        membershipRole: "member",
+        status: "imported",
+        destinationOrg: "GrapheneOS",
+        avatarUrl: "https://example.com/avatar.png",
+        isIncluded: true,
+        repositoryCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ];
+
+    const configWithSingleOrg: Partial<Config> = {
+      ...baseConfig,
+      userId: "user-id",
+      githubConfig: {
+        ...baseConfig.githubConfig!,
+        mirrorStrategy: "single-org"
+      },
+      giteaConfig: {
+        ...baseConfig.giteaConfig!,
+        organization: "mirrors"
+      }
+    };
+
+    const repo = { ...baseRepo, organization: "GrapheneOS", fullName: "GrapheneOS/platform_build" };
+
+    const result = await getGiteaRepoOwnerAsync({
+      config: configWithSingleOrg,
+      repository: repo
+    });
+
+    // The override names the organization's own name, which single-org would
+    // never produce: it must not be mistaken for "no override".
+    expect(result).toBe("GrapheneOS");
+  });
+
+  test("getGiteaRepoOwnerAsync: a repository override beats the organization override and single-org (#416)", async () => {
+    mockDbSelectResult = [
+      {
+        id: "org-id",
+        userId: "user-id",
+        configId: "config-id",
+        name: "GrapheneOS",
+        membershipRole: "member",
+        status: "imported",
+        destinationOrg: "GrapheneOS",
+        avatarUrl: "https://example.com/avatar.png",
+        isIncluded: true,
+        repositoryCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ];
+
+    const configWithSingleOrg: Partial<Config> = {
+      ...baseConfig,
+      userId: "user-id",
+      githubConfig: {
+        ...baseConfig.githubConfig!,
+        mirrorStrategy: "single-org"
+      },
+      giteaConfig: {
+        ...baseConfig.giteaConfig!,
+        organization: "mirrors"
+      }
+    };
+
+    const repo = {
+      ...baseRepo,
+      organization: "GrapheneOS",
+      fullName: "GrapheneOS/platform_build",
+      destinationOrg: "mirrors"
+    };
+
+    const result = await getGiteaRepoOwnerAsync({
+      config: configWithSingleOrg,
+      repository: repo
+    });
+
+    expect(result).toBe("mirrors");
+  });
+
+  test("getGiteaRepoOwnerAsync: single-org without an organization override uses the configured org (#416)", async () => {
+    mockDbSelectResult = [];
+
+    const configWithSingleOrg: Partial<Config> = {
+      ...baseConfig,
+      userId: "user-id",
+      githubConfig: {
+        ...baseConfig.githubConfig!,
+        mirrorStrategy: "single-org"
+      },
+      giteaConfig: {
+        ...baseConfig.giteaConfig!,
+        organization: "mirrors"
+      }
+    };
+
+    const repo = { ...baseRepo, organization: "GrapheneOS", fullName: "GrapheneOS/platform_build" };
+
+    const result = await getGiteaRepoOwnerAsync({
+      config: configWithSingleOrg,
+      repository: repo
+    });
+
+    expect(result).toBe("mirrors");
+  });
+
   test("getGiteaRepoOwnerAsync preserves starred owner when preserve-owner mode is enabled", async () => {
     const configWithUser: Partial<Config> = {
       ...baseConfig,

--- a/src/lib/utils/destination-editor.test.ts
+++ b/src/lib/utils/destination-editor.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "bun:test";
+import { resolveDestinationSaveValue } from "./destination-editor";
+
+describe("resolveDestinationSaveValue (#416)", () => {
+  test("an empty input clears the override", () => {
+    expect(resolveDestinationSaveValue("")).toBeNull();
+  });
+
+  test("whitespace only also clears the override", () => {
+    expect(resolveDestinationSaveValue("   ")).toBeNull();
+    expect(resolveDestinationSaveValue("\t\n ")).toBeNull();
+  });
+
+  test("the organization's own name is kept as an override", () => {
+    // Under single-org the default is the configured destination org, so
+    // "GrapheneOS" on the organization GrapheneOS is a real override.
+    expect(resolveDestinationSaveValue("GrapheneOS")).toBe("GrapheneOS");
+  });
+
+  test("the value the strategy would produce is kept as an override", () => {
+    // Pinning a repository to "mirrors" while single-org already sends
+    // everything there must survive a later strategy change.
+    expect(resolveDestinationSaveValue("mirrors")).toBe("mirrors");
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    expect(resolveDestinationSaveValue("  GrapheneOS  ")).toBe("GrapheneOS");
+    expect(resolveDestinationSaveValue("\tmirrors\n")).toBe("mirrors");
+  });
+});

--- a/src/lib/utils/destination-editor.ts
+++ b/src/lib/utils/destination-editor.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared save rule for the destination editors (organizations and repositories).
+ *
+ * A destination override is stored exactly as typed, and only an empty input
+ * clears it. The editors used to collapse a value that happened to equal the
+ * default (the organization's own name, or whatever the mirror strategy would
+ * produce) into `null`, which silently dropped legitimate overrides: under the
+ * `single-org` strategy the default is the configured destination organization,
+ * so typing the source organization's own name is a real override (issue #416).
+ *
+ * Keeping the typed value also makes the pin survive a later strategy change,
+ * which is the point of setting one by hand.
+ */
+export function resolveDestinationSaveValue(input: string): string | null {
+  const trimmed = input.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/src/pages/api/github/repositories.ts
+++ b/src/pages/api/github/repositories.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { db, repositories, configs } from "@/lib/db";
+import { db, repositories, configs, organizations } from "@/lib/db";
 import { and, eq, sql } from "drizzle-orm";
 import {
   repositoryVisibilityEnum,
@@ -51,9 +51,28 @@ export const GET: APIRoute = async ({ request, locals }) => {
       .where(and(...conditions))
       .orderBy(sql`${repositories.importedAt} DESC`, sql`name COLLATE NOCASE`);
 
+    // Organization-level destination overrides. A repository without its own
+    // destinationOrg follows its organization's, so the list ships the map and
+    // the destination column names that instead of the strategy default (#416).
+    const orgDestinationRows = await db
+      .select({
+        name: organizations.name,
+        destinationOrg: organizations.destinationOrg,
+      })
+      .from(organizations)
+      .where(eq(organizations.userId, userId));
+
+    const organizationDestinations: Record<string, string> = {};
+    for (const row of orgDestinationRows) {
+      if (row.destinationOrg) {
+        organizationDestinations[row.name] = row.destinationOrg;
+      }
+    }
+
     const response: RepositoryApiResponse = {
       success: true,
       message: "Repositories fetched successfully",
+      organizationDestinations,
       repositories: rawRepositories.map((repo) => ({
         ...repo,
         organization: repo.organization ?? undefined,

--- a/src/types/Repository.ts
+++ b/src/types/Repository.ts
@@ -31,6 +31,13 @@ export interface RepositoryApiSuccessResponse {
   success: true;
   message: string;
   repositories: Repository[];
+  /**
+   * Organization name -> the destination that organization overrides to, for
+   * the organizations that set one. A repository inherits it unless it has its
+   * own destinationOrg, the precedence getGiteaRepoOwnerAsync applies, so the
+   * list needs it to name a repository's real default (#416).
+   */
+  organizationDestinations?: Record<string, string>;
 }
 
 export interface RepositoryApiErrorResponse {


### PR DESCRIPTION
Fixes #416.

## What was wrong

The Mirror Destination editor on an organization card treated a typed value equal to the organization's own name as "reset to default" and saved no override. That rule is only right under the preserve strategy. Under single-org the default is the destination organization, so typing GrapheneOS for GrapheneOS stored nothing and every repository kept going to mirrors. The card then showed "GrapheneOS -> GrapheneOS" without a custom badge, so it looked saved.

Reproduced on main with a single-org fixture (destination organization "mirrors"): saving "RayLabsHQ" on the RayLabsHQ card sent `PATCH {"destinationOrg": null}`, and a second organization whose stored override equals its own name showed no custom badge.

The server side (`getGiteaRepoOwnerAsync`, the PATCH route, the move helper) was already correct and is untouched.

## Changes

- `src/lib/utils/destination-editor.ts`: one shared save rule for both editors. A destination is stored exactly as typed; only an empty field clears it.
- `MirrorDestinationEditor` takes a `defaultDestination` prop and uses it for the preview, placeholder, helper text and the Reset button. Any stored destination is marked custom. `OrganizationsList` computes the default from the configured strategy the same way `getGiteaRepoOwner` does (single-org: destination organization, flat-user: username, preserve and mixed: the organization name).
- Reset to Default now clears the override. It used to call save with the stale closure value and store the current destination again.
- Repositories page: the list response carries an `organizationDestinations` map (organization name to override), and the inline destination editor uses it as a repository's default before falling back to the strategy. Without it every repository of an organization with an override displayed "mirrors" as its destination, which is very likely why the per-repository field looked ignored too. The map is kept beside the rows because the action endpoints return bare repository rows and would drop a per-row field on every refresh.
- The repository editor also treats any stored destination as a pin, so pinning a repository to the value the strategy already produces is kept.

## Verification

- Full suite: 916 tests across 86 files, 0 failures. Build passes. No new type errors in touched files (the two in `src/pages/api/github/repositories.ts` exist on main).
- Browser, same fixture as the reproduction, on this branch: saving "RayLabsHQ" sends `PATCH {"destinationOrg": "RayLabsHQ"}` and the card shows the custom badge; the editor placeholder, helper and reset button all name "mirrors"; Reset to Default sends `{"destinationOrg": null}` and the card returns to "RayLabsHQ -> mirrors"; the Repositories page lists RayLabsHQ as the destination for that organization's repositories.

## Note for the reporter

If a reconcile ran while everything sat in mirrors, individual repositories may carry their own `destinationOrg = "mirrors"` pin, which outranks the organization override. Those show a custom badge on the Repositories page and need the field cleared once. The reply on the issue will say so.
