### PR TITLE
fix(deps): update @astrojs/node to 11.1.5 so the standalone server starts on astro 7.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "gitea-mirror",
       "dependencies": {
         "@astrojs/mdx": "^7.0.3",
-        "@astrojs/node": "^11.0.2",
+        "@astrojs/node": "^11.1.5",
         "@astrojs/react": "^6.0.1",
         "@better-auth/api-key": "1.7.2",
         "@better-auth/oauth-provider": "1.7.2",
@@ -143,7 +143,7 @@
 
     "@astrojs/mdx": ["@astrojs/mdx@7.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-remark": "7.2.1", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "^0.3.1", "astro": "^7.0.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ=="],
 
-    "@astrojs/node": ["@astrojs/node@11.0.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-/ijULxT+A5Cm8wSwWZ2vgqfim1b05D6B8n/a9l6MMA4FCotIH73g7fL7y76XojKXpTe75FVvQH92OxsMqea9kQ=="],
+    "@astrojs/node": ["@astrojs/node@11.1.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.11.0", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.2.1" } }, "sha512-CgA+LmG4UWqHxg/Vdc5MdxjjJNZSjKYQQx4uEUwnbj+1ZD2CYumJI3OWg2twsVdj2FlYsB5yvmCC54Re+OK+UQ=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
@@ -1694,6 +1694,8 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
+
+    "@astrojs/node/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.11.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA=="],
 
     "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -113,9 +113,9 @@
     url = "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz";
     hash = "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==";
   };
-  "@astrojs/node@11.0.2" = fetchurl {
-    url = "https://registry.npmjs.org/@astrojs/node/-/node-11.0.2.tgz";
-    hash = "sha512-/ijULxT+A5Cm8wSwWZ2vgqfim1b05D6B8n/a9l6MMA4FCotIH73g7fL7y76XojKXpTe75FVvQH92OxsMqea9kQ==";
+  "@astrojs/node@11.1.5" = fetchurl {
+    url = "https://registry.npmjs.org/@astrojs/node/-/node-11.1.5.tgz";
+    hash = "sha512-CgA+LmG4UWqHxg/Vdc5MdxjjJNZSjKYQQx4uEUwnbj+1ZD2CYumJI3OWg2twsVdj2FlYsB5yvmCC54Re+OK+UQ==";
   };
   "@astrojs/prism@4.0.2" = fetchurl {
     url = "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz";

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.3",
-    "@astrojs/node": "^11.0.2",
+    "@astrojs/node": "^11.1.5",
     "@astrojs/react": "^6.0.1",
     "@better-auth/api-key": "1.7.2",
     "@better-auth/oauth-provider": "1.7.2",


### PR DESCRIPTION
Fixes #420.

## What was wrong

The 3.35.1 security bump (#414) raised astro from 7.1.0 to 7.3.2 but left `@astrojs/node` at 11.0.2. Astro 7.3 moved the startup logger from `app.pipeline.getLogger()` to `app.getLogger()`, and adapter 11.0.2 still reads `app.pipeline`, so starting the built `dist/server/entry.mjs` directly crashes:

```text
TypeError: undefined is not an object (evaluating 'app.pipeline.getLogger')
    at standalone (dist/server/entry.mjs:7141:57)
```

The Bun version in the report is a coincidence. The same crash reproduces on the 3.35.1 build under Bun 1.3.6 and Bun 1.4.2.

Who is affected:

- Docker is not. The entrypoint runs `scripts/runtime-server.ts`, which sets `ASTRO_NODE_AUTOSTART=disabled` and never calls the adapter's `standalone()`, so the crashing line never runs. That is why CI and the image did not notice.
- The Nix package is. `flake.nix` starts `bun dist/server/entry.mjs` directly.
- Bare metal installs that start `entry.mjs` (the reporter's systemd unit) are.

## Change

`@astrojs/node` 11.0.2 to 11.1.5, which calls `app.getLogger()` and declares `astro ^7.2.1` as its peer. The lockfile change is the adapter and its internal-helpers entry only. `bun.nix` regenerated so the Nix flake check passes.

## Verification

Built with the bump and started `dist/server/entry.mjs` directly under Bun 1.3.6 and Bun 1.4.2: both log "Server listening" and serve the login page. `scripts/runtime-server.ts` under Bun 1.4.2 still works. Full test suite passes.
