### PR TITLE
fix(discovery): track one row per upstream repository across sources on the same host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Every completed item is now recorded in the job's checkpoint instead of one in every N, so a real resume skips exactly what was done; progress events are still throttled
   - Concurrent items completing at the same time could overwrite each other's checkpoint; job progress writes are serialized per job
   - A resumed job records a fresh start time
+- The same upstream repository is no longer imported twice under two sources that point at the same host
+  - Discovery decided what was new by (source, full name), so an organization pinned to a public-only github.com source and a personal github.com token source each inserted their own row for one repository, and both rows mirrored to the same destination in the same scheduler batch
+  - Auto import, organization re-discovery and the two import endpoints now identify a repository by its host and full name whichever source lists it; the same name on a different host is still a separate repository
+  - A scheduler pass mirrors or syncs one row per upstream repository and logs the duplicate rows it skips, so existing duplicates never run side by side
 - A per-organization Mirror Destination equal to the organization's own name is kept instead of being dropped (#416)
   - The editor treated a typed value matching the organization name as "reset to default" and saved no override, which only holds under the preserve strategy; under single-org the default is the destination organization, so the repositories went there
   - The organization card now shows the default for the configured strategy in the preview, the placeholder, the helper text and the reset button, and marks any stored destination as custom

--- a/src/lib/repo-identity.test.ts
+++ b/src/lib/repo-identity.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  repositoryIdentityKey,
+  repositoryIdentityKeys,
+  selectNewRepositoriesByIdentity,
+  dedupeRepositoriesByIdentity,
+} from './repo-utils';
+
+describe('repositoryIdentityKey', () => {
+  test('is the host plus the full name, independent of the source row', () => {
+    const a = repositoryIdentityKey({ sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' });
+    const b = repositoryIdentityKey({ sourceProvider: 'github', sourceUrl: 'https://github.com/', normalizedFullName: 'ACME/Tools' });
+    expect(a).toBe(b);
+  });
+
+  test('treats missing provider and url as github.com, like legacy rows', () => {
+    expect(repositoryIdentityKey({ normalizedFullName: 'acme/tools' })).toBe(
+      repositoryIdentityKey({ sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' })
+    );
+  });
+
+  test('keeps the same name on two hosts apart', () => {
+    const ghe = repositoryIdentityKey({ sourceProvider: 'github', sourceUrl: 'https://ghe.example.com', normalizedFullName: 'acme/tools' });
+    const com = repositoryIdentityKey({ sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' });
+    expect(ghe).not.toBe(com);
+  });
+});
+
+describe('selectNewRepositoriesByIdentity', () => {
+  test('skips a repository already tracked on the same host under another source', () => {
+    const existing = repositoryIdentityKeys([
+      { sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' },
+    ]);
+    const { fresh, alreadyTracked } = selectNewRepositoriesByIdentity(
+      [
+        { sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools', sourceId: 'public-only' },
+        { sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/new', sourceId: 'public-only' },
+      ],
+      existing
+    );
+    expect(fresh.map((r) => r.normalizedFullName)).toEqual(['acme/new']);
+    expect(alreadyTracked.map((r) => r.normalizedFullName)).toEqual(['acme/tools']);
+  });
+
+  test('extends the existing set so a later source does not re-add the same repository', () => {
+    const existing = new Set<string>();
+    const first = selectNewRepositoriesByIdentity(
+      [{ sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' }],
+      existing
+    );
+    const second = selectNewRepositoriesByIdentity(
+      [{ sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' }],
+      existing
+    );
+    expect(first.fresh).toHaveLength(1);
+    expect(second.fresh).toHaveLength(0);
+    expect(second.alreadyTracked).toHaveLength(1);
+  });
+
+  test('still allows the same name from a different host', () => {
+    const existing = repositoryIdentityKeys([
+      { sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' },
+    ]);
+    const { fresh } = selectNewRepositoriesByIdentity(
+      [{ sourceProvider: 'gitlab', sourceUrl: 'https://gitlab.com', normalizedFullName: 'acme/tools' }],
+      existing
+    );
+    expect(fresh).toHaveLength(1);
+  });
+});
+
+describe('dedupeRepositoriesByIdentity', () => {
+  test('keeps one row per upstream repository in a batch', () => {
+    const { kept, dropped } = dedupeRepositoriesByIdentity([
+      { id: 'a', sourceId: 's1', sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' },
+      { id: 'b', sourceId: 's2', sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' },
+      { id: 'c', sourceId: 's1', sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/other' },
+    ]);
+    expect(kept.map((r) => r.id)).toEqual(['a', 'c']);
+    expect(dropped.map((r) => r.id)).toEqual(['b']);
+  });
+
+  test('prefers a row linked to a source over a legacy row without one', () => {
+    const { kept, dropped } = dedupeRepositoriesByIdentity([
+      { id: 'legacy', sourceId: null, normalizedFullName: 'acme/tools' },
+      { id: 'linked', sourceId: 's1', sourceProvider: 'github', sourceUrl: 'https://github.com', normalizedFullName: 'acme/tools' },
+    ]);
+    expect(kept.map((r) => r.id)).toEqual(['linked']);
+    expect(dropped.map((r) => r.id)).toEqual(['legacy']);
+  });
+
+  test('leaves a batch without duplicates alone', () => {
+    const rows = [
+      { id: 'a', sourceId: 's1', normalizedFullName: 'acme/a' },
+      { id: 'b', sourceId: 's1', normalizedFullName: 'acme/b' },
+    ];
+    const { kept, dropped } = dedupeRepositoriesByIdentity(rows);
+    expect(kept).toEqual(rows);
+    expect(dropped).toEqual([]);
+  });
+});

--- a/src/lib/repo-utils.ts
+++ b/src/lib/repo-utils.ts
@@ -93,3 +93,82 @@ export function repositoryDestinationColumns(
 ): Pick<RepoInsert, 'destinationProvider' | 'destinationUrl'> {
   return { destinationProvider: destination.provider, destinationUrl: destination.url };
 }
+
+/**
+ * Upstream identity of a repository row: which host it lives on and its full
+ * name there. The repositories table is unique on (userId, sourceId,
+ * normalizedFullName) so that the same owner/name can be tracked on two
+ * hosts, but two source rows can point at the same host (a personal token
+ * source and a public-only source, both github.com), and a legacy row with a
+ * NULL sourceId is distinct from a re-imported one. Discovery used the unique
+ * index alone to decide what was new, so one upstream repository could end up
+ * as two rows that both mirror to the same destination repository and get
+ * processed together in one batch (one of the overlaps behind #417).
+ */
+export interface RepositoryIdentityFields {
+  sourceProvider?: string | null;
+  sourceUrl?: string | null;
+  normalizedFullName: string;
+}
+
+export function repositoryIdentityKey(row: RepositoryIdentityFields): string {
+  const provider = (row.sourceProvider || 'github').trim().toLowerCase();
+  const url = (row.sourceUrl || 'https://github.com').trim().toLowerCase().replace(/\/+$/, '');
+  return `${provider}|${url}|${row.normalizedFullName.toLowerCase()}`;
+}
+
+/**
+ * Split discovered rows into the ones not yet tracked for this user on the
+ * same host under any source, and the ones that are. Also drops repeats
+ * within `candidates` themselves. `existing` is extended with every fresh
+ * row, so a caller looping over several sources can pass the same set.
+ */
+export function selectNewRepositoriesByIdentity<T extends RepositoryIdentityFields>(
+  candidates: T[],
+  existing: Set<string>
+): { fresh: T[]; alreadyTracked: T[] } {
+  const fresh: T[] = [];
+  const alreadyTracked: T[] = [];
+  for (const candidate of candidates) {
+    const key = repositoryIdentityKey(candidate);
+    if (existing.has(key)) {
+      alreadyTracked.push(candidate);
+    } else {
+      existing.add(key);
+      fresh.push(candidate);
+    }
+  }
+  return { fresh, alreadyTracked };
+}
+
+export function repositoryIdentityKeys(rows: Iterable<RepositoryIdentityFields>): Set<string> {
+  const keys = new Set<string>();
+  for (const row of rows) keys.add(repositoryIdentityKey(row));
+  return keys;
+}
+
+/**
+ * Keep one row per upstream identity in a processing batch, so two rows that
+ * resolve to the same destination repository are never mirrored or synced in
+ * the same pass. A row linked to a source wins over a legacy row without one;
+ * otherwise the first row in the batch is kept.
+ */
+export function dedupeRepositoriesByIdentity<
+  T extends RepositoryIdentityFields & { sourceId?: string | null },
+>(rows: T[]): { kept: T[]; dropped: T[] } {
+  const byKey = new Map<string, T>();
+  const dropped: T[] = [];
+  for (const row of rows) {
+    const key = repositoryIdentityKey(row);
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, row);
+    } else if (!current.sourceId && row.sourceId) {
+      dropped.push(current);
+      byKey.set(key, row);
+    } else {
+      dropped.push(row);
+    }
+  }
+  return { kept: Array.from(byKey.values()), dropped };
+}

--- a/src/lib/scheduler-service.test.ts
+++ b/src/lib/scheduler-service.test.ts
@@ -465,6 +465,34 @@ describe.skipIf(!isChild)("Scheduler public-only sources (WP4)", () => {
       .filter((row) => row.normalizedFullName?.startsWith("pinned-org/"))
       .map((row) => row.name);
     expect(orgRepoNamesAfterSecondRun).toEqual(["existing", "newly-published"]);
-    expect(repoInsertAttempts).toBeGreaterThan(attemptsAfterFirstRun);
+    // Nothing new on the second run, so discovery does not even attempt an
+    // insert: already-tracked repositories are filtered out by identity
+    // before the write, not dropped by the unique index afterwards.
+    expect(repoInsertAttempts).toBe(attemptsAfterFirstRun);
+  });
+
+  test("re-discovery does not add a second row for a repository the user already tracks under another source on the same host", async () => {
+    // Imported earlier through a personal token source on github.com, so it
+    // has a different sourceId than the pinned public-only source.
+    repoRows.push({
+      userId: "user-1",
+      sourceId: "source-personal",
+      name: "shared",
+      fullName: "pinned-org/shared",
+      normalizedFullName: "pinned-org/shared",
+      organization: "pinned-org",
+      sourceProvider: "github",
+      sourceUrl: "https://github.com",
+      status: "mirrored",
+    });
+    orgRepoListings.set("pinned-org", [makeGitRepo("shared"), makeGitRepo("fresh")]);
+
+    await schedulerLoop();
+
+    const sharedRows = repoRows.filter((row) => row.normalizedFullName === "pinned-org/shared");
+    expect(sharedRows).toHaveLength(1);
+    expect(sharedRows[0].sourceId).toBe("source-personal");
+    expect(repoRows.some((row) => row.normalizedFullName === "pinned-org/fresh")).toBe(true);
+    expect(consoleLines.some((line) => line.includes("already tracked") && line.includes("pinned-org"))).toBe(true);
   });
 });

--- a/src/lib/scheduler-service.ts
+++ b/src/lib/scheduler-service.ts
@@ -13,7 +13,14 @@ import { formatDuration } from '@/lib/utils/duration-parser';
 import type { Repository } from '@/lib/db/schema';
 import type { Octokit } from '@octokit/rest';
 import { repoStatusEnum, repositoryVisibilityEnum } from '@/types/Repository';
-import { mergeGitReposPreferStarred, normalizeGitRepoToInsert, calcBatchSizeForInsert } from '@/lib/repo-utils';
+import {
+  mergeGitReposPreferStarred,
+  normalizeGitRepoToInsert,
+  calcBatchSizeForInsert,
+  repositoryIdentityKeys,
+  selectNewRepositoriesByIdentity,
+  dedupeRepositoriesByIdentity,
+} from '@/lib/repo-utils';
 import { isMirrorableGitHubRepo } from '@/lib/repo-eligibility';
 import { loadOrganizationForkPolicies, orgForkSkipDecision, resolveOrganizationSkipForks } from '@/lib/utils/mirror-overrides';
 import { createMirrorJob } from '@/lib/helpers';
@@ -102,14 +109,19 @@ async function importRepositoriesFromSources(
   const orgForkOverrides = await loadOrganizationForkPolicies({ userId });
 
   const existingRepos = await db
-    .select({ normalizedFullName: repositories.normalizedFullName, sourceId: repositories.sourceId })
+    .select({
+      normalizedFullName: repositories.normalizedFullName,
+      sourceProvider: repositories.sourceProvider,
+      sourceUrl: repositories.sourceUrl,
+    })
     .from(repositories)
     .where(eq(repositories.userId, userId));
-  // Repositories are unique per source: the same full name under two sources
-  // counts as two repositories.
-  const existingRepoKeys = new Set(
-    existingRepos.map(r => `${r.sourceId ?? ''}|${r.normalizedFullName}`)
-  );
+  // A repository is identified by its host and full name, not by the source
+  // row that found it. Two sources can point at the same host (a personal
+  // token and a public-only source, both github.com), and a repository the
+  // user already tracks must not be inserted a second time under the other
+  // source: both rows would mirror to the same destination repository.
+  const existingRepoKeys = repositoryIdentityKeys(existingRepos);
 
   for (const source of sources) {
     try {
@@ -132,16 +144,20 @@ async function importRepositoriesFromSources(
       const allGithubRepos = mergeGitReposPreferStarred(basicAndForkedRepos, starredRepos);
       const mirrorableGithubRepos = allGithubRepos.filter(isMirrorableGitHubRepo);
 
-      const newRepos = mirrorableGithubRepos.filter(
-        r => !existingRepoKeys.has(`${source.id}|${r.fullName.toLowerCase()}`)
+      const candidates = mirrorableGithubRepos.map(repo =>
+        normalizeGitRepoToInsert(repo, { userId, configId: config.id, sourceId: source.id })
       );
+      const { fresh: reposToInsert, alreadyTracked } = selectNewRepositoriesByIdentity(
+        candidates,
+        existingRepoKeys
+      );
+      const newRepos = reposToInsert;
+      if (alreadyTracked.length > 0) {
+        console.log(`[Scheduler] ${alreadyTracked.length} repositories listed by source ${source.name} are already tracked for user ${userId} on the same host; not adding them again`);
+      }
 
       if (newRepos.length > 0) {
         console.log(`[Scheduler] Found ${newRepos.length} new repositories for user ${userId} on source ${source.name}`);
-
-        const reposToInsert = newRepos.map(repo =>
-          normalizeGitRepoToInsert(repo, { userId, configId: config.id, sourceId: source.id })
-        );
 
         // Batch insert to avoid SQLite parameter limit
         const sample = reposToInsert[0];
@@ -213,6 +229,19 @@ async function rediscoverOrganizationRepositories(
       )
     );
 
+  // Same identity rule as personal discovery: an organization pinned to a
+  // public-only source must not re-insert repositories the personal source
+  // already tracks on the same host (or the other way round).
+  const existingRepos = await db
+    .select({
+      normalizedFullName: repositories.normalizedFullName,
+      sourceProvider: repositories.sourceProvider,
+      sourceUrl: repositories.sourceUrl,
+    })
+    .from(repositories)
+    .where(eq(repositories.userId, userId));
+  const existingRepoKeys = repositoryIdentityKeys(existingRepos);
+
   for (const org of includedOrgs) {
     try {
       const source = findSourceForOrganization(org, sources);
@@ -228,14 +257,17 @@ async function rediscoverOrganizationRepositories(
         repo => repo.isDisabled !== true && !(skipOrgForks && repo.isForked)
       );
 
-      if (mirrorableRepos.length > 0) {
-        const repoRecords = mirrorableRepos.map(repo =>
+      const { fresh: repoRecords, alreadyTracked } = selectNewRepositoriesByIdentity(
+        mirrorableRepos.map(repo =>
           normalizeGitRepoToInsert(
             { ...repo, organization: repo.organization ?? org.name },
             { userId, configId: config.id, sourceId: source.id }
           )
-        );
+        ),
+        existingRepoKeys
+      );
 
+      if (repoRecords.length > 0) {
         // Batch insert to avoid SQLite parameter limit
         const sample = repoRecords[0];
         const columnCount = Object.keys(sample ?? {}).length || 1;
@@ -247,7 +279,10 @@ async function rediscoverOrganizationRepositories(
             .values(batch)
             .onConflictDoNothing({ target: [repositories.userId, repositories.sourceId, repositories.normalizedFullName] });
         }
-        console.log(`[Scheduler] Re-discovered ${mirrorableRepos.length} repositories for organization ${org.name} on source ${source.name} for user ${userId} during ${phase}`);
+        console.log(`[Scheduler] Re-discovered ${repoRecords.length} new repositories for organization ${org.name} on source ${source.name} for user ${userId} during ${phase}`);
+      }
+      if (alreadyTracked.length > 0) {
+        console.log(`[Scheduler] Organization ${org.name}: ${alreadyTracked.length} repositories are already tracked for user ${userId} on the same host, not adding them again under source ${source.name}`);
       }
 
       await db
@@ -331,6 +366,24 @@ function sourceUsernamesBySourceId(sources: SourceRecord[]): Map<string, string>
 /**
  * Run scheduled mirror sync for a single user configuration
  */
+/**
+ * Keep one row per upstream repository in a scheduler batch. Duplicate rows
+ * (the same repository imported under two sources on the same host) resolve
+ * to one destination repository, and processing both in one Promise.all ran
+ * every step twice against it. The dropped rows are logged so the duplicate
+ * can be cleaned up; discovery no longer creates new ones.
+ */
+function dropDuplicateRowsForPass<T extends { fullName: string; sourceId?: string | null; sourceProvider?: string | null; sourceUrl?: string | null; normalizedFullName: string }>(
+  rows: T[],
+  pass: string
+): T[] {
+  const { kept, dropped } = dedupeRepositoriesByIdentity(rows);
+  for (const row of dropped) {
+    console.warn(`[Scheduler] ${row.fullName} is tracked more than once (another row on the same host covers it); skipping the duplicate row in this ${pass} pass`);
+  }
+  return kept;
+}
+
 async function runScheduledSync(config: any): Promise<void> {
   const userId = config.userId;
   console.log(`[Scheduler] Running scheduled sync for user ${userId}`);
@@ -456,6 +509,11 @@ async function runScheduledSync(config: any): Promise<void> {
         if (reposNeedingMirror.length !== forkSkippedCount) {
           console.log(`[Scheduler] Skipped ${forkSkippedCount - reposNeedingMirror.length} forked repositories from auto-mirror (organization skip forks)`);
         }
+
+        // Two rows for one upstream repository (imported under two sources
+        // that point at the same host) resolve to one destination
+        // repository; mirror it once per pass, not twice at the same time.
+        reposNeedingMirror = dropDuplicateRowsForPass(reposNeedingMirror, 'auto-mirror');
 
         if (reposNeedingMirror.length > 0) {
           console.log(`[Scheduler] Found ${reposNeedingMirror.length} repositories that need initial mirroring`);
@@ -583,6 +641,8 @@ async function runScheduledSync(config: any): Promise<void> {
     } catch {
       // Non-critical logging, ignore errors
     }
+
+    reposToSync = dropDuplicateRowsForPass(reposToSync, 'sync');
 
     if (reposToSync.length === 0) {
       console.log(`[Scheduler] No repositories to sync for user ${userId}`);
@@ -808,6 +868,7 @@ async function performInitialAutoStart(): Promise<void> {
         if (skippedCount > 0) {
           console.log(`[Scheduler] Skipped ${skippedCount} repositories from initial auto-mirror (autoMirror=${autoMirrorOwned}, autoMirrorStarred=${autoMirrorStarred})`);
         }
+        reposNeedingMirror = dropDuplicateRowsForPass(reposNeedingMirror, 'initial auto-mirror');
 
         if (reposNeedingMirror.length > 0) {
           console.log(`[Scheduler] Found ${reposNeedingMirror.length} repositories that need mirroring`);

--- a/src/pages/api/sync/index.ts
+++ b/src/pages/api/sync/index.ts
@@ -9,6 +9,8 @@ import {
   mergeGitReposPreferStarred,
   normalizeGitRepoToInsert,
   calcBatchSizeForInsert,
+  repositoryIdentityKeys,
+  selectNewRepositoriesByIdentity,
 } from "@/lib/repo-utils";
 import { loadOrganizationForkPolicies } from "@/lib/utils/mirror-overrides";
 import { requireAuthenticatedUserId } from "@/lib/auth-guards";
@@ -165,7 +167,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
             tx
               .select({
                 normalizedFullName: repositories.normalizedFullName,
-                sourceId: repositories.sourceId,
+                sourceProvider: repositories.sourceProvider,
+                sourceUrl: repositories.sourceUrl,
               })
               .from(repositories)
               .where(eq(repositories.userId, userId)),
@@ -175,17 +178,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
               .where(eq(organizations.userId, userId)),
           ]);
 
-          // The same full name under two sources is two different repositories.
-          const existingRepoKeys = new Set(
-            existingRepos.map((r) => `${r.sourceId ?? ""}|${r.normalizedFullName}`)
-          );
+          // A repository is identified by its host and full name, whichever
+          // source row lists it. The same name on two hosts is two
+          // repositories; the same repository seen by two sources on one host
+          // (a personal token and a public-only source) is one, and must not
+          // become two rows that mirror to the same destination.
+          const existingRepoKeys = repositoryIdentityKeys(existingRepos);
           const existingOrgMap = new Map(existingOrgs.map((o) => [o.normalizedName, o.status]));
 
-          insertedRepos = newRepos.filter(
-            (r) =>
-              !existingRepoKeys.has(`${source.id}|${r.normalizedFullName}`) &&
-              (!r.organization || !ignoredOrgNames.has(r.organization.toLowerCase()))
-          );
+          insertedRepos = selectNewRepositoriesByIdentity(
+            newRepos.filter(
+              (r) => !r.organization || !ignoredOrgNames.has(r.organization.toLowerCase())
+            ),
+            existingRepoKeys
+          ).fresh;
           insertedOrgs = newOrgs.filter((o) => !existingOrgMap.has(o.normalizedName));
 
           // Update previously failed orgs that now succeeded. The pin must

--- a/src/pages/api/sync/organization.test.ts
+++ b/src/pages/api/sync/organization.test.ts
@@ -148,6 +148,17 @@ if (isChild) {
       select: () => ({
         from: (table: unknown) => ({
           where: (cond: unknown) => ({
+            // Awaited directly by the existing-repository lookup that keeps
+            // one row per upstream repository; the inserted rows stand in
+            // for the table.
+            then: (
+              onfulfilled: (rows: OrgRow[]) => unknown,
+              onrejected?: (reason: unknown) => unknown
+            ) =>
+              Promise.resolve(table === repositoriesTable ? [...insertedRepoRows] : []).then(
+                onfulfilled,
+                onrejected
+              ),
             limit: async (): Promise<OrgRow[]> => {
               const leaves = conditionLeafValues(cond);
               if (table === organizationsTable) {

--- a/src/pages/api/sync/organization.ts
+++ b/src/pages/api/sync/organization.ts
@@ -15,7 +15,12 @@ import {
   normalizeSourceUrl,
 } from "@/lib/source-providers/kinds";
 import type { SourceRecord } from "@/lib/sources";
-import { normalizeGitRepoToInsert, calcBatchSizeForInsert } from "@/lib/repo-utils";
+import {
+  normalizeGitRepoToInsert,
+  calcBatchSizeForInsert,
+  repositoryIdentityKeys,
+  selectNewRepositoriesByIdentity,
+} from "@/lib/repo-utils";
 import { resolveOrganizationSkipForks } from "@/lib/utils/mirror-overrides";
 import { requireAuthenticatedUserId } from "@/lib/auth-guards";
 
@@ -259,12 +264,31 @@ export const POST: APIRoute = async ({ request, locals }) => {
     );
 
     // Insert repositories. The normalizer stamps the source provider and URL.
-    const repoRecords = mirrorableRepos.map((repo) =>
-      normalizeGitRepoToInsert(
-        { ...repo, organization: repo.organization ?? orgData.name },
-        { userId, configId, sourceId: source.id }
-      )
+    // Repositories the user already tracks on this host under another source
+    // (the personal source, say) are not inserted a second time: two rows for
+    // one upstream repository would both mirror to the same destination.
+    const existingRepos = await db
+      .select({
+        normalizedFullName: repositories.normalizedFullName,
+        sourceProvider: repositories.sourceProvider,
+        sourceUrl: repositories.sourceUrl,
+      })
+      .from(repositories)
+      .where(eq(repositories.userId, userId));
+    const { fresh: repoRecords, alreadyTracked } = selectNewRepositoriesByIdentity(
+      mirrorableRepos.map((repo) =>
+        normalizeGitRepoToInsert(
+          { ...repo, organization: repo.organization ?? orgData.name },
+          { userId, configId, sourceId: source.id }
+        )
+      ),
+      repositoryIdentityKeys(existingRepos)
     );
+    if (alreadyTracked.length > 0) {
+      console.log(
+        `[Organization import] ${alreadyTracked.length} repositories of ${orgData.name} are already tracked for user ${userId} on this host; not adding them again under source ${source.name}`
+      );
+    }
 
     // Batch insert repositories to avoid SQLite parameter limit
     // Compute batch size based on column count


### PR DESCRIPTION
Found while investigating #417: the same upstream repository could exist twice in the repositories table for one user, under two different source rows, and both rows mirrored to the same destination repository in the same scheduler batch. Every non-idempotent step then ran twice against one destination.

## What was wrong

The table is unique on `(user_id, source_id, normalized_full_name)`, on purpose, so that `owner/name` can be tracked on two hosts (github.com and a GitHub Enterprise instance, say). But two source rows can point at the same host. The organization re-discovery from #409 inserts an organization's repositories under the organization's pinned source, and personal discovery inserts what the account can see under the personal source. When an organization is pinned to a public-only github.com source and the personal source is a github.com token, the same repository was inserted under both `source_id`s. Nothing collided, both rows resolved to the same destination, and `runScheduledSync` processed both with `Promise.all`. A legacy row with a NULL `source_id` next to a re-imported row has the same effect, since SQLite treats NULL as distinct in the index.

## Changes

- `src/lib/repo-utils.ts`: a repository's identity is its host and full name (`repositoryIdentityKey`: source provider, source URL and normalized full name, all of which every row already carries; rows without them count as github.com, which is what legacy rows are). `selectNewRepositoriesByIdentity` splits discovered rows into new and already tracked, extending the set so a loop over several sources sees its own inserts. `dedupeRepositoriesByIdentity` keeps one row per identity in a batch, preferring a row linked to a source over a legacy one.
- Discovery uses the identity instead of `(sourceId, name)` in all four places that insert discovered repositories: scheduler personal discovery, scheduler organization re-discovery, the bulk import endpoint and the add-organization endpoint. Already-tracked repositories are logged and skipped. The same name on a different host is still a separate repository.
- Processing: the scheduler dedupes the auto-mirror batch, the sync batch and the auto-start batch by identity before running them, logging each duplicate row it skips. Existing duplicates therefore never run side by side, and the log names them for cleanup. No rows are deleted.

## Tests

- `src/lib/repo-identity.test.ts` (new): identity key normalization and defaults, the same name on two hosts stays apart, already-tracked filtering across sources, in-batch dedupe with the source-linked preference.
- Scheduler: the re-discovery test now expects no insert attempt when nothing is new (already-tracked rows are filtered before the write, not dropped by the index after it), plus a new case where a repository tracked under the personal source is not re-inserted under the pinned public-only source.
- Organization route: the db mock learned the existing-repository lookup.
- Full suite passes; no type errors in the touched files.
